### PR TITLE
ENH: Add documentation guidelines

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,8 @@ developments that cannot be integrated into core TensorFlow
 | addons.layers | Maxout | https://arxiv.org/abs/1302.4389             |
 | addons.layers | PoinareNormalize | https://arxiv.org/abs/1705.08039  |
 | addons.layers | WeightNormalization | https://arxiv.org/abs/1602.07868 |
-| addons.losses | TripletLoss | https://arxiv.org/abs/1503.03832       |
+| addons.losses | LiftedStructLoss | https://arxiv.org/abs/1511.06452       |
+| addons.losses | TripletSemiHardLoss | https://arxiv.org/abs/1503.03832       |
 | addons.optimizers | LazyAdamOptimizer | https://arxiv.org/abs/1412.6980 |
 | addons.text | SkipGrams | https://arxiv.org/abs/1301.3781 |
 

--- a/tensorflow_addons/custom_ops/README.md
+++ b/tensorflow_addons/custom_ops/README.md
@@ -20,3 +20,8 @@ must:
     expected.
  * When applicable, run all unittests with TensorFlow's
   `@run_all_in_graph_and_eager_modes` decorator.
+
+#### Documentation Requirements
+ * Update the table of contents in the project's central README
+ * Update the table of contents in this sub-project's README
+ 

--- a/tensorflow_addons/layers/README.md
+++ b/tensorflow_addons/layers/README.md
@@ -22,3 +22,7 @@ must:
   `@run_all_in_graph_and_eager_modes` decorator.
  * Run `keras.testing_utils.layer_test` on the layer.
 
+#### Documentation Requirements
+ * Update the table of contents in the project's central README
+ * Update the table of contents in this sub-project's README
+ 

--- a/tensorflow_addons/losses/README.md
+++ b/tensorflow_addons/losses/README.md
@@ -3,7 +3,8 @@
 ## Contents
 | Loss  | Reference                                              |
 |:----------------------- |:-------------------------------------|
-| TripletLoss | https://arxiv.org/abs/1503.03832 |
+| LiftedStructLoss | https://arxiv.org/abs/1511.06452       |
+| TripletSemiHardLoss | https://arxiv.org/abs/1503.03832       |
 
 
 ## Contribution Guidelines
@@ -19,3 +20,8 @@ must:
  some set of known inputs and outputs.
  * When applicable, run all tests with TensorFlow's
  `@run_all_in_graph_and_eager_modes` decorator.
+ 
+#### Documentation Requirements
+ * Update the table of contents in the project's central README
+ * Update the table of contents in this sub-project's README
+ 

--- a/tensorflow_addons/optimizers/README.md
+++ b/tensorflow_addons/optimizers/README.md
@@ -17,3 +17,8 @@ must:
 #### Testing Requirements
  * When applicable, run all tests with TensorFlow's
  `@run_all_in_graph_and_eager_modes` decorator
+  
+#### Documentation Requirements
+ * Update the table of contents in the project's central README
+ * Update the table of contents in this sub-project's README
+  


### PR DESCRIPTION
- Update the tables of content
- Add documentation guidelines per API

Just a note: It is understood that updating two tables of content is redundant. After #46 is completed we can remove the central TOC