### PR TITLE
Migrate dense_image_warp op

### DIFF
--- a/tensorflow_addons/custom_ops/BUILD
+++ b/tensorflow_addons/custom_ops/BUILD
@@ -7,7 +7,7 @@ py_library(
     srcs = ["__init__.py"],
     srcs_version = "PY2AND3",
     deps = [
-            "//tensorflow_addons/custom_ops/image:images_ops_py",
+            "//tensorflow_addons/custom_ops/image:image_py",
             "//tensorflow_addons/custom_ops/text:text_py",
         ]
 )

--- a/tensorflow_addons/custom_ops/image/BUILD
+++ b/tensorflow_addons/custom_ops/image/BUILD
@@ -20,16 +20,51 @@ cc_binary(
 
 
 py_library(
-    name = "images_ops_py",
+    name = "image_py",
     srcs = ([
         "__init__.py",
         "python/__init__.py",
+    ]),
+    deps = [
+        ":dense_image_warp_py",
+        ":images_ops_py",
+    ],
+    srcs_version = "PY2AND3",
+)
+
+
+py_library(
+    name = "dense_image_warp_py",
+    srcs = ([
+        "python/dense_image_warp.py",
+    ]),
+    srcs_version = "PY2AND3",
+)
+
+
+py_library(
+    name = "images_ops_py",
+    srcs = ([
         "python/transform.py",
     ]),
     data = [
         ":python/_image_ops.so"
     ],
     srcs_version = "PY2AND3",
+)
+
+
+py_test(
+    name = "dense_image_warp_test",
+    size = "small",
+    srcs = [
+        "python/dense_image_warp_test.py"
+    ],
+    main = "python/dense_image_warp_test.py",
+    deps = [
+        ":dense_image_warp_py",
+    ],
+    srcs_version = "PY2AND3"
 )
 
 

--- a/tensorflow_addons/custom_ops/image/__init__.py
+++ b/tensorflow_addons/custom_ops/image/__init__.py
@@ -17,5 +17,7 @@ from __future__ import absolute_import
 from __future__ import division
 from __future__ import print_function
 
+# Image warping
+from tensorflow_addons.custom_ops.image.python.dense_image_warp import dense_image_warp
 # Transforms
 from tensorflow_addons.custom_ops.image.python.transform import transform

--- a/tensorflow_addons/custom_ops/image/python/dense_image_warp.py
+++ b/tensorflow_addons/custom_ops/image/python/dense_image_warp.py
@@ -1,0 +1,224 @@
+# Copyright 2019 The TensorFlow Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ==============================================================================
+"""Image warping using per-pixel flow vectors."""
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+
+import numpy as np
+
+import tensorflow as tf
+from tensorflow.python.framework import constant_op
+from tensorflow.python.framework import dtypes
+from tensorflow.python.framework import ops
+from tensorflow.python.ops import array_ops
+from tensorflow.python.ops import check_ops
+from tensorflow.python.ops import math_ops
+
+
+def _interpolate_bilinear(grid,
+                          query_points,
+                          name="interpolate_bilinear",
+                          indexing="ij"):
+    """Similar to Matlab's interp2 function.
+
+    Finds values for query points on a grid using bilinear interpolation.
+
+    Args:
+      grid: a 4-D float `Tensor` of shape `[batch, height, width, channels]`.
+      query_points: a 3-D float `Tensor` of N points with shape `[batch, N, 2]`.
+      name: a name for the operation (optional).
+      indexing: whether the query points are specified as row and column (ij),
+        or Cartesian coordinates (xy).
+
+    Returns:
+      values: a 3-D `Tensor` with shape `[batch, N, channels]`
+
+    Raises:
+      ValueError: if the indexing mode is invalid, or if the shape of the inputs
+        invalid.
+    """
+    if indexing != "ij" and indexing != "xy":
+        raise ValueError("Indexing mode must be \'ij\' or \'xy\'")
+
+    with ops.name_scope(name):
+        grid = ops.convert_to_tensor(grid)
+        query_points = ops.convert_to_tensor(query_points)
+        shape = grid.get_shape().as_list()
+        if len(shape) != 4:
+            msg = "Grid must be 4 dimensional. Received size: "
+            raise ValueError(msg + str(grid.get_shape()))
+
+        batch_size, height, width, channels = (array_ops.shape(grid)[0],
+                                               array_ops.shape(grid)[1],
+                                               array_ops.shape(grid)[2],
+                                               array_ops.shape(grid)[3])
+
+        shape = [batch_size, height, width, channels]
+        query_type = query_points.dtype
+        grid_type = grid.dtype
+
+        with ops.control_dependencies([
+            check_ops.assert_equal(
+                len(query_points.get_shape()),
+                3,
+                message="Query points must be 3 dimensional."),
+            check_ops.assert_equal(
+                array_ops.shape(query_points)[2],
+                2,
+                message="Query points must be size 2 in dim 2.")
+        ]):
+            num_queries = array_ops.shape(query_points)[1]
+
+        with ops.control_dependencies([
+            check_ops.assert_greater_equal(
+                height, 2, message="Grid height must be at least 2."),
+            check_ops.assert_greater_equal(
+                width, 2, message="Grid width must be at least 2.")
+        ]):
+            alphas = []
+            floors = []
+            ceils = []
+            index_order = [0, 1] if indexing == "ij" else [1, 0]
+            unstacked_query_points = array_ops.unstack(query_points, axis=2)
+
+        for dim in index_order:
+            with ops.name_scope("dim-" + str(dim)):
+                queries = unstacked_query_points[dim]
+
+                size_in_indexing_dimension = shape[dim + 1]
+
+                # max_floor is size_in_indexing_dimension - 2 so that max_floor + 1
+                # is still a valid index into the grid.
+                max_floor = math_ops.cast(
+                    size_in_indexing_dimension - 2, query_type)
+                min_floor = constant_op.constant(0.0, dtype=query_type)
+                floor = math_ops.minimum(math_ops.maximum(
+                    min_floor, math_ops.floor(queries)), max_floor)
+                int_floor = math_ops.cast(floor, dtypes.int32)
+                floors.append(int_floor)
+                ceil = int_floor + 1
+                ceils.append(ceil)
+
+                # alpha has the same type as the grid, as we will directly use alpha
+                # when taking linear combinations of pixel values from the image.
+                alpha = math_ops.cast(queries - floor, grid_type)
+                min_alpha = constant_op.constant(0.0, dtype=grid_type)
+                max_alpha = constant_op.constant(1.0, dtype=grid_type)
+                alpha = math_ops.minimum(
+                    math_ops.maximum(min_alpha, alpha),
+                    max_alpha)
+
+                # Expand alpha to [b, n, 1] so we can use broadcasting
+                # (since the alpha values don't depend on the channel).
+                alpha = array_ops.expand_dims(alpha, 2)
+                alphas.append(alpha)
+
+        with ops.control_dependencies([
+            check_ops.assert_less_equal(
+                math_ops.cast(batch_size * height * width, dtype=dtypes.float32),
+                np.iinfo(np.int32).max / 8.0,
+                message="""The image size or batch size is sufficiently large
+                       that the linearized addresses used by array_ops.gather
+                       may exceed the int32 limit.""")
+        ]):
+            flattened_grid = array_ops.reshape(
+                grid, [batch_size * height * width, channels])
+            batch_offsets = array_ops.reshape(
+                math_ops.range(batch_size) * height * width, [batch_size, 1])
+
+        # This wraps array_ops.gather. We reshape the image data such that the
+        # batch, y, and x coordinates are pulled into the first dimension.
+        # Then we gather. Finally, we reshape the output back. It's possible this
+        # code would be made simpler by using array_ops.gather_nd.
+        def gather(y_coords, x_coords, name):
+            with ops.name_scope("gather-" + name):
+                linear_coordinates = batch_offsets + y_coords * width + x_coords
+                gathered_values = array_ops.gather(
+                    flattened_grid, linear_coordinates)
+                return array_ops.reshape(gathered_values,
+                                         [batch_size, num_queries, channels])
+
+        # grab the pixel values in the 4 corners around each query point
+        top_left = gather(floors[0], floors[1], "top_left")
+        top_right = gather(floors[0], ceils[1], "top_right")
+        bottom_left = gather(ceils[0], floors[1], "bottom_left")
+        bottom_right = gather(ceils[0], ceils[1], "bottom_right")
+
+        # now, do the actual interpolation
+        with ops.name_scope("interpolate"):
+            interp_top = alphas[1] * (top_right - top_left) + top_left
+            interp_bottom = alphas[1] * (
+                bottom_right - bottom_left) + bottom_left
+            interp = alphas[0] * (interp_bottom - interp_top) + interp_top
+
+        return interp
+
+
+@tf.function
+def dense_image_warp(image, flow, name="dense_image_warp"):
+    """Image warping using per-pixel flow vectors.
+
+    Apply a non-linear warp to the image, where the warp is specified by a dense
+    flow field of offset vectors that define the correspondences of pixel values
+    in the output image back to locations in the  source image. Specifically, the
+    pixel value at output[b, j, i, c] is
+    images[b, j - flow[b, j, i, 0], i - flow[b, j, i, 1], c].
+
+    The locations specified by this formula do not necessarily map to an int
+    index. Therefore, the pixel value is obtained by bilinear
+    interpolation of the 4 nearest pixels around
+    (b, j - flow[b, j, i, 0], i - flow[b, j, i, 1]). For locations outside
+    of the image, we use the nearest pixel values at the image boundary.
+
+
+    Args:
+      image: 4-D float `Tensor` with shape `[batch, height, width, channels]`.
+      flow: A 4-D float `Tensor` with shape `[batch, height, width, 2]`.
+      name: A name for the operation (optional).
+
+      Note that image and flow can be of type tf.half, tf.float32, or tf.float64,
+      and do not necessarily have to be the same type.
+
+    Returns:
+      A 4-D float `Tensor` with shape`[batch, height, width, channels]`
+        and same type as input image.
+
+    Raises:
+      ValueError: if height < 2 or width < 2 or the inputs have the wrong number
+                  of dimensions.
+    """
+    with ops.name_scope(name):
+        batch_size, height, width, channels = (array_ops.shape(image)[0],
+                                               array_ops.shape(image)[1],
+                                               array_ops.shape(image)[2],
+                                               array_ops.shape(image)[3])
+
+        # The flow is defined on the image grid. Turn the flow into a list of query
+        # points in the grid space.
+        grid_x, grid_y = array_ops.meshgrid(
+            math_ops.range(width), math_ops.range(height))
+        stacked_grid = math_ops.cast(
+            array_ops.stack([grid_y, grid_x], axis=2), flow.dtype)
+        batched_grid = array_ops.expand_dims(stacked_grid, axis=0)
+        query_points_on_grid = batched_grid - flow
+        query_points_flattened = array_ops.reshape(
+            query_points_on_grid, [batch_size, height * width, 2])
+        # Compute values at the query points, then reshape the result back to the
+        # image grid.
+        interpolated = _interpolate_bilinear(image, query_points_flattened)
+        interpolated = array_ops.reshape(interpolated,
+                                         [batch_size, height, width, channels])
+        return interpolated

--- a/tensorflow_addons/custom_ops/image/python/dense_image_warp_test.py
+++ b/tensorflow_addons/custom_ops/image/python/dense_image_warp_test.py
@@ -1,0 +1,270 @@
+# Copyright 2019 The TensorFlow Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ==============================================================================
+"""Tests for dense_image_warp."""
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+
+import math
+import numpy as np
+
+
+from tensorflow.python.framework import constant_op
+from tensorflow.python.framework import dtypes
+from tensorflow.python.framework import errors
+from tensorflow.python.framework import ops
+from tensorflow.python.framework import test_util as tf_test_util
+from tensorflow.python.ops import array_ops
+from tensorflow.python.ops import gradients
+from tensorflow.python.ops import math_ops
+from tensorflow.python.ops import random_ops
+from tensorflow.python.ops import variables
+from tensorflow.python.platform import test
+from tensorflow.python.training import adam
+from tensorflow_addons.custom_ops.image.python import dense_image_warp as dense_image_warp_ops
+
+
+class DenseImageWarpTest(test.TestCase):
+
+    def setUp(self):
+        np.random.seed(0)
+
+    @tf_test_util.run_all_in_graph_and_eager_modes
+    def test_interpolate_small_grid_ij(self):
+        with self.cached_session():
+            grid = constant_op.constant(
+                [[0., 1., 2.], [3., 4., 5.], [6., 7., 8.]], shape=[1, 3, 3, 1])
+            query_points = constant_op.constant(
+                [[0., 0.], [1., 0.], [2., 0.5], [1.5, 1.5]], shape=[1, 4, 2])
+            expected_results = np.reshape(
+                np.array([0., 3., 6.5, 6.]), [1, 4, 1])
+
+            interp = dense_image_warp_ops._interpolate_bilinear(
+                grid, query_points)
+
+            self.assertAllClose(expected_results, interp)
+
+    @tf_test_util.run_all_in_graph_and_eager_modes
+    def test_interpolate_small_grid_xy(self):
+        with self.cached_session():
+            grid = constant_op.constant(
+                [[0., 1., 2.], [3., 4., 5.], [6., 7., 8.]], shape=[1, 3, 3, 1])
+            query_points = constant_op.constant(
+                [[0., 0.], [0., 1.], [0.5, 2.0], [1.5, 1.5]], shape=[1, 4, 2])
+            expected_results = np.reshape(
+                np.array([0., 3., 6.5, 6.]), [1, 4, 1])
+
+            interp = dense_image_warp_ops._interpolate_bilinear(
+                grid, query_points, indexing="xy")
+
+            self.assertAllClose(expected_results, interp)
+
+    @tf_test_util.run_all_in_graph_and_eager_modes
+    def test_interpolate_small_grid_batched(self):
+        with self.cached_session():
+            grid = constant_op.constant(
+                [[[0., 1.], [3., 4.]], [[5., 6.], [7., 8.]]], shape=[2, 2, 2, 1])
+            query_points = constant_op.constant([[[0., 0.], [1., 0.], [0.5, 0.5]],
+                                                 [[0.5, 0.], [1., 0.], [1., 1.]]])
+            expected_results = np.reshape(
+                np.array([[0., 3., 2.], [6., 7., 8.]]), [2, 3, 1])
+
+            interp = dense_image_warp_ops._interpolate_bilinear(
+                grid, query_points)
+
+            self.assertAllClose(expected_results, interp)
+
+    def get_image_and_flow_placeholders(self, shape, image_type, flow_type):
+        batch_size, height, width, num_channels = shape
+        image_shape = [batch_size, height, width, num_channels]
+        flow_shape = [batch_size, height, width, 2]
+
+        tf_type = {
+            "float16": dtypes.half,
+            "float32": dtypes.float32,
+            "float64": dtypes.float64
+        }
+
+        image = array_ops.placeholder(
+            dtype=tf_type[image_type],
+            shape=image_shape)
+
+        flows = array_ops.placeholder(
+            dtype=tf_type[flow_type],
+            shape=flow_shape)
+        return image, flows
+
+    def get_random_image_and_flows(self, shape, image_type, flow_type):
+        batch_size, height, width, num_channels = shape
+        image_shape = [batch_size, height, width, num_channels]
+        image = np.random.normal(size=image_shape)
+        flow_shape = [batch_size, height, width, 2]
+        flows = np.random.normal(size=flow_shape) * 3
+        return image.astype(image_type), flows.astype(flow_type)
+
+    def assert_correct_interpolation_value(self,
+                                           image,
+                                           flows,
+                                           pred_interpolation,
+                                           batch_index,
+                                           y_index,
+                                           x_index,
+                                           low_precision=False):
+        """Assert that the tf interpolation matches hand-computed value."""
+
+        height = image.shape[1]
+        width = image.shape[2]
+        displacement = flows[batch_index, y_index, x_index, :]
+        float_y = y_index - displacement[0]
+        float_x = x_index - displacement[1]
+        floor_y = max(min(height - 2, math.floor(float_y)), 0)
+        floor_x = max(min(width - 2, math.floor(float_x)), 0)
+        ceil_y = floor_y + 1
+        ceil_x = floor_x + 1
+
+        alpha_y = min(max(0.0, float_y - floor_y), 1.0)
+        alpha_x = min(max(0.0, float_x - floor_x), 1.0)
+
+        floor_y = int(floor_y)
+        floor_x = int(floor_x)
+        ceil_y = int(ceil_y)
+        ceil_x = int(ceil_x)
+
+        top_left = image[batch_index, floor_y, floor_x, :]
+        top_right = image[batch_index, floor_y, ceil_x, :]
+        bottom_left = image[batch_index, ceil_y, floor_x, :]
+        bottom_right = image[batch_index, ceil_y, ceil_x, :]
+
+        interp_top = alpha_x * (top_right - top_left) + top_left
+        interp_bottom = alpha_x * (bottom_right - bottom_left) + bottom_left
+        interp = alpha_y * (interp_bottom - interp_top) + interp_top
+        atol = 1e-6
+        rtol = 1e-6
+        if low_precision:
+            atol = 1e-2
+            rtol = 1e-3
+        self.assertAllClose(
+            interp,
+            pred_interpolation[batch_index, y_index, x_index, :],
+            atol=atol,
+            rtol=rtol)
+
+    def check_zero_flow_correctness(self, shape, image_type, flow_type):
+        """Assert using zero flows doesn't change the input image."""
+
+        with self.cached_session():
+            rand_image, rand_flows = self.get_random_image_and_flows(
+                shape, image_type, flow_type)
+            rand_flows *= 0
+
+            interp = dense_image_warp_ops.dense_image_warp(
+                image=ops.convert_to_tensor(rand_image),
+                flow=ops.convert_to_tensor(rand_flows))
+
+            self.assertAllClose(rand_image, interp)
+
+    @tf_test_util.run_all_in_graph_and_eager_modes
+    def test_zero_flows(self):
+        """Apply check_zero_flow_correctness() for a few sizes and types."""
+
+        shapes_to_try = [[3, 4, 5, 6], [1, 2, 2, 1]]
+        for shape in shapes_to_try:
+            self.check_zero_flow_correctness(
+                shape, image_type="float32", flow_type="float32")
+
+    def check_interpolation_correctness(self,
+                                        shape,
+                                        image_type,
+                                        flow_type,
+                                        num_probes=5):
+        """Interpolate, and then assert correctness for a few query locations."""
+        with self.cached_session():
+            low_precision = image_type == "float16" or flow_type == "float16"
+            rand_image, rand_flows = self.get_random_image_and_flows(
+                shape, image_type, flow_type)
+
+            interp = dense_image_warp_ops.dense_image_warp(
+                image=ops.convert_to_tensor(rand_image),
+                flow=ops.convert_to_tensor(rand_flows))
+
+            for _ in range(num_probes):
+                batch_index = np.random.randint(0, shape[0])
+                y_index = np.random.randint(0, shape[1])
+                x_index = np.random.randint(0, shape[2])
+
+                self.assert_correct_interpolation_value(
+                    rand_image,
+                    rand_flows,
+                    interp,
+                    batch_index,
+                    y_index,
+                    x_index,
+                    low_precision=low_precision)
+
+    @tf_test_util.run_all_in_graph_and_eager_modes
+    def test_interpolation(self):
+        """Apply check_interpolation_correctness() for a few sizes and types."""
+
+        shapes_to_try = [[3, 4, 5, 6], [1, 5, 5, 3], [1, 2, 2, 1]]
+        for im_type in ["float32", "float64", "float16"]:
+            for flow_type in ["float32", "float64", "float16"]:
+                for shape in shapes_to_try:
+                    self.check_interpolation_correctness(
+                        shape, im_type, flow_type)
+
+    # TODO: switch to TF2 later.
+    @tf_test_util.run_deprecated_v1
+    def test_gradients_exist(self):
+        """Check that backprop can run.
+
+        The correctness of the gradients is assumed, since the forward propagation
+        is tested to be correct and we only use built-in tf ops.
+        However, we perform a simple test to make sure that backprop can actually
+        run. We treat the flows as a tf.Variable and optimize them to minimize
+        the difference between the interpolated image and the input image.
+        """
+
+        batch_size, height, width, num_channels = [4, 5, 6, 7]
+        image_shape = [batch_size, height, width, num_channels]
+        image = random_ops.random_normal(image_shape)
+        flow_shape = [batch_size, height, width, 2]
+        init_flows = np.float32(np.random.normal(size=flow_shape) * 0.25)
+        flows = variables.Variable(init_flows)
+
+        interp = dense_image_warp_ops.dense_image_warp(image, flows)
+        loss = math_ops.reduce_mean(math_ops.square(interp - image))
+
+        optimizer = adam.AdamOptimizer(1.0)
+        grad = gradients.gradients(loss, [flows])
+        opt_func = optimizer.apply_gradients(zip(grad, [flows]))
+        init_op = variables.global_variables_initializer()
+
+        with self.cached_session() as sess:
+            sess.run(init_op)
+            for _ in range(10):
+                sess.run(opt_func)
+
+    @tf_test_util.run_all_in_graph_and_eager_modes
+    def test_size_exception(self):
+        """Make sure it throws an exception for images that are too small."""
+
+        shape = [1, 2, 1, 1]
+        msg = "Should have raised an exception for invalid image size"
+        with self.assertRaises(errors.InvalidArgumentError, msg=msg):
+            self.check_interpolation_correctness(shape, "float32", "float32")
+
+
+if __name__ == "__main__":
+    test.main()


### PR DESCRIPTION
Address #25. CI test passed on my local machine. Note that the test of `_interpolate_bilinear` in `dense_image_warp` will fail if I use the decorator `tf.function` on it (that's why I haven't added it yet). I'm still trying to figure out why.