### PR TITLE
rename ImageProjectiveTransform to ImageProjectiveTransformV2

### DIFF
--- a/tensorflow_addons/custom_ops/image/cc/kernels/image_projective_transform_op.cc
+++ b/tensorflow_addons/custom_ops/image/cc/kernels/image_projective_transform_op.cc
@@ -50,12 +50,12 @@ using generator::INTERPOLATION_NEAREST;
 using generator::ProjectiveGenerator;
 
 template <typename Device, typename T>
-class ImageProjectiveTransform : public OpKernel {
+class ImageProjectiveTransformV2 : public OpKernel {
  private:
   Interpolation interpolation_;
 
  public:
-  explicit ImageProjectiveTransform(OpKernelConstruction* ctx) : OpKernel(ctx) {
+  explicit ImageProjectiveTransformV2(OpKernelConstruction* ctx) : OpKernel(ctx) {
     string interpolation_str;
     OP_REQUIRES_OK(ctx, ctx->GetAttr("interpolation", &interpolation_str));
     if (interpolation_str == "NEAREST") {
@@ -118,10 +118,10 @@ class ImageProjectiveTransform : public OpKernel {
 };
 
 #define REGISTER(TYPE)                                        \
-  REGISTER_KERNEL_BUILDER(Name("ImageProjectiveTransform")    \
+  REGISTER_KERNEL_BUILDER(Name("ImageProjectiveTransformV2")  \
                               .Device(DEVICE_CPU)             \
                               .TypeConstraint<TYPE>("dtype"), \
-                          ImageProjectiveTransform<CPUDevice, TYPE>)
+                          ImageProjectiveTransformV2<CPUDevice, TYPE>)
 
 TF_CALL_uint8(REGISTER);
 TF_CALL_int32(REGISTER);
@@ -157,11 +157,11 @@ TF_CALL_double(DECLARE_FUNCTOR);
 }  // end namespace functor
 
 #define REGISTER(TYPE)                                       \
-  REGISTER_KERNEL_BUILDER(Name("ImageProjectiveTransform")   \
+  REGISTER_KERNEL_BUILDER(Name("ImageProjectiveTransformV2") \
                               .Device(DEVICE_GPU)            \
                               .TypeConstraint<TYPE>("dtype") \
                               .HostMemory("output_shape"),   \
-                          ImageProjectiveTransform<GPUDevice, TYPE>)
+                          ImageProjectiveTransformV2<GPUDevice, TYPE>)
 
 TF_CALL_uint8(REGISTER);
 TF_CALL_int32(REGISTER);

--- a/tensorflow_addons/custom_ops/image/cc/ops/image_ops.cc
+++ b/tensorflow_addons/custom_ops/image/cc/ops/image_ops.cc
@@ -92,7 +92,7 @@ the `transforms` to the `images`. Satisfies the description above.
 }  // namespace
 
 // V2 op supports output_shape.
-REGISTER_OP("ImageProjectiveTransform")
+REGISTER_OP("ImageProjectiveTransformV2")
     .Input("images: dtype")
     .Input("transforms: float32")
     .Input("output_shape: int32")

--- a/tensorflow_addons/custom_ops/image/python/transform.py
+++ b/tensorflow_addons/custom_ops/image/python/transform.py
@@ -30,7 +30,7 @@ _IMAGE_DTYPES = set([
     tf.dtypes.float32, tf.dtypes.float64
 ])
 
-ops.RegisterShape("ImageProjectiveTransform")(common_shapes.call_cpp_shape_fn)
+ops.RegisterShape("ImageProjectiveTransformV2")(common_shapes.call_cpp_shape_fn)
 
 
 @tf.function
@@ -108,7 +108,7 @@ def transform(images,
         else:
             raise TypeError("Transforms should have rank 1 or 2.")
 
-        output = _image_ops_so.image_projective_transform(
+        output = _image_ops_so.image_projective_transform_v2(
             images,
             output_shape=output_shape,
             transforms=transforms,
@@ -260,7 +260,7 @@ def angles_to_projective_transforms(angles,
             axis=1)
 
 
-@ops.RegisterGradient("ImageProjectiveTransform")
+@ops.RegisterGradient("ImageProjectiveTransformV2")
 def _image_projective_transform_grad(op, grad):
     """Computes the gradient for ImageProjectiveTransform."""
     images = op.inputs[0]
@@ -284,7 +284,7 @@ def _image_projective_transform_grad(op, grad):
     transforms = flat_transforms_to_matrices(transforms=transforms)
     inverse = tf.linalg.inv(transforms)
     transforms = matrices_to_flat_transforms(inverse)
-    output = _image_ops_so.image_projective_transform(
+    output = _image_ops_so.image_projective_transform_v2(
         images=grad,
         transforms=transforms,
         output_shape=tf.shape(image_or_images)[1:3],


### PR DESCRIPTION
Rename addon op ImageProjectiveTransform to ImageProjectiveTransformV2.

This ensures the op names are consistent between addon and contrib (see #86).