### PR TITLE
FIX: testutil decorator

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,7 +51,10 @@ for end-to-end examples of various addons.
 
 ## Installation
 #### Stable Builds
-`tensorflow-addons` will soon be available in PyPi.
+To install the latest version, run the following:
+```
+pip install tensorflow-addons
+```
 
 #### Installing from Source
 You can also install from source. This requires the [Bazel](

--- a/tensorflow_addons/layers/python/sparsemax_test.py
+++ b/tensorflow_addons/layers/python/sparsemax_test.py
@@ -60,7 +60,7 @@ class SparsemaxTest(tf.test.TestCase):
         z = random.uniform(low=-3, high=3, size=(test_obs, 10)).astype(dtype)
 
         test_utils.layer_test(
-            layer_cls=Sparsemax,
+            Sparsemax,
             input_data=z,
             expected_output=_np_sparsemax(z).astype(dtype))
 


### PR DESCRIPTION
Our first catch from nightly CI... but this is kind of an ugly one. 

**Summary:** 
New decorator introcduced in https://github.com/tensorflow/tensorflow/commit/c27909ea80e8823dbf4f7176ab69991a630356a1#diff-f541c00fcae53468339272b7c92a67a4 is causing this test to fail because the decorator is never provided an argument as [seen here](https://source.cloud.google.com/results/invocations/c481cc72-92ab-46d9-90b4-7e9ae40e2626/targets/tensorflow_addons%2Fubuntu%2Fgpu%2Fpy2%2Fcontinuous/log)

I believe this is a bug, but since we're using a private test API, I wasn't sure if its worth an issue (maybe just a bug fix PR?) 
