### PR TITLE
Add docs for how using PyPi mirror

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -63,6 +63,17 @@ Try those commands below:
 2. Run unit test: `make unit-test`
 3. All of the above: `make`
 
+### Tips
+Using default Python Package Index (PyPI, https://pypi.org/) maybe pretty slow due to the network connection.
+Developers can choose using a PyPI mirror, search engine can help you find nearest and fast PyPI mirror.
+
+Setting python using a PyPI mirror as default package source is easy. For pip version >=10.0.0 (if not, please using `pip install pip -U` to upgrade pip):
+```bash
+pip config set global.index-url https://pypi.tuna.tsinghua.edu.cn/simple
+```
+
+in this example, `https://pypi.tuna.tsinghua.edu.cn/simple` is a PyPI mirror for China.
+
 ## Coding style
 
 Addons provides `make code-format` command to format your changes

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -63,7 +63,10 @@ Try those commands below:
 2. Run unit test: `make unit-test`
 3. All of the above: `make`
 
-**Tip**: If having trouble with running this script due to network connection, users may find want to consult [this documentation](https://mirror.tuna.tsinghua.edu.cn/help/pypi/) to properly set their pypi repository.
+**Tip**: If having trouble with running this script due to network connection, 
+users may find want to consult 
+[this documentation](https://mirror.tuna.tsinghua.edu.cn/help/pypi/) (wrote in Chinese, user who is not in China may need replace mirror URL in the command)
+to properly set their pypi repository.
 
 ## Coding style
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -67,7 +67,7 @@ Try those commands below:
 Using default Python Package Index (PyPI, https://pypi.org/) maybe pretty slow due to the network connection.
 Developers can choose using a PyPI mirror, search engine can help you find nearest and fast PyPI mirror.
 
-Setting python using a PyPI mirror as default package source is easy. For pip version >=10.0.0 (if not, please using `pip install pip -U` to upgrade pip):
+Setting python using a PyPI mirror as default package source is easy. For pip version >=10.0.0 (if not satisfied, please using `pip install -U pip` to upgrade pip):
 ```bash
 pip config set global.index-url https://pypi.tuna.tsinghua.edu.cn/simple
 ```

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -63,16 +63,7 @@ Try those commands below:
 2. Run unit test: `make unit-test`
 3. All of the above: `make`
 
-### Tips
-Using default Python Package Index (PyPI, https://pypi.org/) maybe pretty slow due to the network connection.
-Developers can choose using a PyPI mirror, search engine can help you find nearest and fast PyPI mirror.
-
-Setting python using a PyPI mirror as default package source is easy. For pip version >=10.0.0 (if not satisfied, please using `pip install -U pip` to upgrade pip):
-```bash
-pip config set global.index-url https://pypi.tuna.tsinghua.edu.cn/simple
-```
-
-in this example, `https://pypi.tuna.tsinghua.edu.cn/simple` is a PyPI mirror for China.
+**Tip**: If having trouble with running this script due to network connection, users may find want to consult [this documentation](https://mirror.tuna.tsinghua.edu.cn/help/pypi/) to properly set their pypi repository.
 
 ## Coding style
 


### PR DESCRIPTION
Using default Python Package Index (PyPI, https://pypi.org/) maybe pretty slow due to the network connection. Developers can choose using a PyPI mirror. This PR will add docs for telling developers how to set python using a PyPI mirror as default package source.

Related to  #95 