### PR TITLE
Implemented bazel python version flags

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -94,6 +94,16 @@ bazel test -c opt -k \
 --test_output=errors \
 //tensorflow_addons/...
 ```
+This test will test Python2 by default.
+
+To test Python2 or Python3 specifically please run:
+```bash 
+# Python 3
+bazel test --python_top=//tools:python3.4.3 //...
+# Python 2
+bazel test --python_top=//tools:python2.7.6 //...
+```
+
 
 ## Code Reviews
 

--- a/configure.sh
+++ b/configure.sh
@@ -36,6 +36,7 @@ function write_action_env_to_bazelrc() {
 
 [[ -f .bazelrc ]] && rm .bazelrc
 pip install $QUIET_FLAG -r requirements.txt
+pip3 install $QUIET_FLAG -r requirements.txt
 
 TF_CFLAGS=( $(python -c 'import tensorflow as tf; print(" ".join(tf.sysconfig.get_compile_flags()))') )
 TF_LFLAGS=( $(python -c 'import tensorflow as tf; print(" ".join(tf.sysconfig.get_link_flags()))') )

--- a/tools/BUILD
+++ b/tools/BUILD
@@ -1,0 +1,13 @@
+py_runtime(
+	name = "python2.7.6",
+	files = [],
+	interpreter_path = "/usr/bin/python",
+	visibility = ["//visibility:public"]
+)
+
+py_runtime(
+	name = "python3.4.3",
+	files = [],
+	interpreter_path = "/usr/bin/python3",
+	visibility = ["//visibility:public"]
+)


### PR DESCRIPTION
I implemented python interpreter flags to make it easier to switch between Python2 and Python3 while developing. 
I added two Bazel Interpreter rules in a BUILD file in the tools directory which points to the specific interpreter in the docker container that we use for development. 
In order to run both test I had to update the ./configure.sh script aswell to download tensorflow with pip3 as well. 

In the end I added a little description to CONTRIBUTING.md
