### PR TITLE
Add Mac OS X supporting for install from source

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,7 +88,7 @@ bazel-bin/build_pip_pkg artifacts
 pip install artifacts/tensorflow_addons-*.whl
 ```
 
-**Notice**: If you are using Mac OS X, you need install addition software by `brew install coreutils` (this requires the [brew](https://brew.sh/)) 
+**Notice**: If you are using Mac OS X, you need install addition software by `brew install coreutils` (this requires the [brew](https://brew.sh/)) or `port install coreutils` (this requires the [MacPorts](https://www.macports.org/))
 
 ## Contributing
 TF-Addons is a community led open source project. As such, the project

--- a/README.md
+++ b/README.md
@@ -88,7 +88,7 @@ bazel-bin/build_pip_pkg artifacts
 pip install artifacts/tensorflow_addons-*.whl
 ```
 
-**Notice**: If you are using Mac OS X, you need install addition software by `brew install coreutils` (this requires the [brew](https://brew.sh/)) or `port install coreutils` (this requires the [MacPorts](https://www.macports.org/))
+**Notice**: If you are using Mac OS X, you need install addition software by `brew install coreutils` (this requires the [Homebrew](https://brew.sh/)) or `port install coreutils` (this requires the [MacPorts](https://www.macports.org/))
 
 ## Contributing
 TF-Addons is a community led open source project. As such, the project

--- a/README.md
+++ b/README.md
@@ -88,6 +88,8 @@ bazel-bin/build_pip_pkg artifacts
 pip install artifacts/tensorflow_addons-*.whl
 ```
 
+**Notice**: If you are using Mac OS X, you need install addition software by `brew install coreutils` (this requires the [brew](https://brew.sh/)) 
+
 ## Contributing
 TF-Addons is a community led open source project. As such, the project
 depends on public contributions, bug-fixes, and documentation. Please

--- a/build_pip_pkg.sh
+++ b/build_pip_pkg.sh
@@ -20,6 +20,13 @@ PLATFORM="$(uname -s | tr 'A-Z' 'a-z')"
 
 PIP_FILE_PREFIX="bazel-bin/build_pip_pkg.runfiles/__main__/"
 
+if [[ ${PLATFORM} == "darwin" ]]; then
+    READLINK="greadlink"  # provided by package `coreutils` in brew in Mac OS X
+else
+    READLINK="readlink"
+fi
+
+
 function main() {
   while [[ ! -z "${1}" ]]; do
     if [[ ${1} == "make" ]]; then
@@ -40,7 +47,7 @@ function main() {
   # give us an absolute paths with tilde characters resolved to the destination
   # directory.
   mkdir -p ${DEST}
-  DEST=$(readlink -f "${DEST}")
+  DEST=$(${READLINK} -f "${DEST}")
   echo "=== destination directory: ${DEST}"
 
   TMPDIR=$(mktemp -d -t tmp.XXXXXXXXXX)

--- a/build_pip_pkg.sh
+++ b/build_pip_pkg.sh
@@ -21,7 +21,7 @@ PLATFORM="$(uname -s | tr 'A-Z' 'a-z')"
 PIP_FILE_PREFIX="bazel-bin/build_pip_pkg.runfiles/__main__/"
 
 if [[ ${PLATFORM} == "darwin" ]]; then
-    READLINK="greadlink"  # provided by package `coreutils` in brew in Mac OS X
+    READLINK="greadlink"  # from pkg `coreutils` in brew/macports in Mac OS X
 else
     READLINK="readlink"
 fi


### PR DESCRIPTION
Mac's builtin readlink don't support -f option. Which need install GNU's readlink: greadlink by brew. Doc and script are both modified for this.