### PR TITLE
Improve AttentionWrapper compatibility with TF 2.0

### DIFF
--- a/tensorflow_addons/seq2seq/attention_wrapper.py
+++ b/tensorflow_addons/seq2seq/attention_wrapper.py
@@ -31,7 +31,6 @@ from tensorflow.python.framework import tensor_shape
 from tensorflow.python.keras import initializers
 from tensorflow.python.keras import layers
 from tensorflow.python.keras.engine import base_layer_utils
-from tensorflow.python.layers import core as layers_core
 from tensorflow.python.ops import array_ops
 from tensorflow.python.ops import check_ops
 from tensorflow.python.ops import clip_ops
@@ -1706,7 +1705,7 @@ class AttentionWrapper(layers.AbstractRNNCell):
                     "one integer per attention_mechanism, saw: %d vs %d" %
                     (len(attention_layer_sizes), len(attention_mechanisms)))
             self._attention_layers = tuple(
-                layers_core.Dense(
+                layers.Dense(
                     attention_layer_size,
                     name="attention_layer",
                     use_bias=False,

--- a/tensorflow_addons/seq2seq/attention_wrapper.py
+++ b/tensorflow_addons/seq2seq/attention_wrapper.py
@@ -1666,7 +1666,7 @@ class AttentionWrapper(layers.AbstractRNNCell):
         rnn_cell_impl.assert_like_rnncell("cell", cell)
         if isinstance(attention_mechanism, (list, tuple)):
             self._is_multi = True
-            attention_mechanisms = attention_mechanism
+            attention_mechanisms = list(attention_mechanism)
             for attention_mechanism in attention_mechanisms:
                 if not isinstance(attention_mechanism, AttentionMechanism):
                     raise TypeError(
@@ -1680,7 +1680,7 @@ class AttentionWrapper(layers.AbstractRNNCell):
                     "attention_mechanism must be an AttentionMechanism or "
                     "list of multiple AttentionMechanism instances, saw type: "
                     "%s" % type(attention_mechanism).__name__)
-            attention_mechanisms = (attention_mechanism,)
+            attention_mechanisms = [attention_mechanism]
 
         if cell_input_fn is None:
             cell_input_fn = (lambda inputs, attention: array_ops.concat(
@@ -1704,7 +1704,7 @@ class AttentionWrapper(layers.AbstractRNNCell):
                     "If provided, attention_layer_size must contain exactly "
                     "one integer per attention_mechanism, saw: %d vs %d" %
                     (len(attention_layer_sizes), len(attention_mechanisms)))
-            self._attention_layers = tuple(
+            self._attention_layers = list(
                 layers.Dense(
                     attention_layer_size,
                     name="attention_layer",
@@ -1713,7 +1713,7 @@ class AttentionWrapper(layers.AbstractRNNCell):
                 attention_layer_size in enumerate(attention_layer_sizes))
             self._attention_layer_size = sum(attention_layer_sizes)
         elif attention_layer is not None:
-            self._attention_layers = tuple(
+            self._attention_layers = list(
                 attention_layer if isinstance(attention_layer, (
                     list, tuple)) else (attention_layer,))
             if len(self._attention_layers) != len(attention_mechanisms):

--- a/tensorflow_addons/seq2seq/attention_wrapper_test.py
+++ b/tensorflow_addons/seq2seq/attention_wrapper_test.py
@@ -372,8 +372,9 @@ class AttentionWrapperTest(test.TestCase, parameterized.TestCase):
                         (expected_time, batch_size, encoder_max_time),
                         tuple(state_alignment_history.get_shape().as_list()))
                 nest.assert_same_structure(
-                    cell.state_size, cell.zero_state(batch_size,
-                                                     dtypes.float32))
+                    cell.state_size,
+                    cell.get_initial_state(
+                        batch_size=batch_size, dtype=dtypes.float32))
                 # Remove the history from final_state for purposes of the
                 # remainder of the tests.
                 final_state = final_state._replace(alignment_history=())  # pylint: disable=protected-access
@@ -433,7 +434,8 @@ class AttentionWrapperTest(test.TestCase, parameterized.TestCase):
 
         final_outputs, final_state, _ = my_decoder(
             decoder_inputs,
-            initial_state=cell.zero_state(dtype=dtype, batch_size=self.batch),
+            initial_state=cell.get_initial_state(
+                batch_size=self.batch, dtype=dtype),
             sequence_length=self.decoder_sequence_length)
         self.assertIsInstance(final_outputs, basic_decoder.BasicDecoderOutput)
         self.assertEqual(final_outputs.rnn_output.dtype, dtype)
@@ -460,7 +462,8 @@ class AttentionWrapperTest(test.TestCase, parameterized.TestCase):
 
         final_outputs, final_state, _ = my_decoder(
             decoder_inputs,
-            initial_state=cell.zero_state(dtype=dtype, batch_size=self.batch),
+            initial_state=cell.get_initial_state(
+                batch_size=self.batch, dtype=dtype),
             sequence_length=self.decoder_sequence_length)
         self.assertIsInstance(final_outputs, basic_decoder.BasicDecoderOutput)
         self.assertEqual(final_outputs.rnn_output.dtype, dtype)

--- a/tensorflow_addons/seq2seq/attention_wrapper_test.py
+++ b/tensorflow_addons/seq2seq/attention_wrapper_test.py
@@ -319,9 +319,8 @@ class AttentionWrapperTest(test.TestCase, parameterized.TestCase):
                 attention_layer=attention_layer)
             if cell._attention_layers is not None:
                 for layer in cell._attention_layers:
-                    if getattr(layer, "kernel_initializer") is None:
-                        layer.kernel_initializer = initializers.glorot_uniform(
-                            seed=1337)
+                    layer.kernel_initializer = initializers.glorot_uniform(
+                        seed=1337)
 
             sampler = sampler_py.TrainingSampler()
             my_decoder = basic_decoder.BasicDecoder(cell=cell, sampler=sampler)

--- a/tensorflow_addons/seq2seq/beam_search_decoder.py
+++ b/tensorflow_addons/seq2seq/beam_search_decoder.py
@@ -450,7 +450,7 @@ class BeamSearchDecoderMixin(object):
                 "and batch size.  The reshaped tensor has shape: %s.  "
                 "We expected it to have shape "
                 "(batch_size, beam_width, depth) == %s.  Perhaps you "
-                "forgot to create a zero_state with "
+                "forgot to call get_initial_state with "
                 "batch_size=encoder_batch_size * beam_width?" %
                 (reshaped_t.shape, expected_reshaped_shape))
         reshaped_t.set_shape(expected_reshaped_shape)
@@ -622,9 +622,9 @@ class BeamSearchDecoder(BeamSearchDecoderMixin, decoder.BaseDecoder):
 
     - The encoder output has been tiled to `beam_width` via
       `tf.contrib.seq2seq.tile_batch` (NOT `tf.tile`).
-    - The `batch_size` argument passed to the `zero_state` method of this
-      wrapper is equal to `true_batch_size * beam_width`.
-    - The initial state created with `zero_state` above contains a
+    - The `batch_size` argument passed to the `get_initial_state` method of
+      this wrapper is equal to `true_batch_size * beam_width`.
+    - The initial state created with `get_initial_state` above contains a
       `cell_state` value containing properly tiled final state from the
       encoder.
 
@@ -642,8 +642,8 @@ class BeamSearchDecoder(BeamSearchDecoderMixin, decoder.BaseDecoder):
         memory=tiled_inputs,
         memory_sequence_length=tiled_sequence_length)
     attention_cell = AttentionWrapper(cell, attention_mechanism, ...)
-    decoder_initial_state = attention_cell.zero_state(
-        dtype, batch_size=true_batch_size * beam_width)
+    decoder_initial_state = attention_cell.get_initial_state(
+        batch_size=true_batch_size * beam_width, dtype=dtype)
     decoder_initial_state = decoder_initial_state.clone(
         cell_state=tiled_encoder_final_state)
     ```

--- a/tensorflow_addons/seq2seq/beam_search_decoder_test.py
+++ b/tensorflow_addons/seq2seq/beam_search_decoder_test.py
@@ -30,7 +30,6 @@ from tensorflow.python.framework import test_util
 from tensorflow.python.keras import layers
 from tensorflow.python.ops import array_ops
 from tensorflow.python.ops import nn_ops
-from tensorflow.python.ops import rnn_cell
 from tensorflow.python.ops import variables
 from tensorflow.python.platform import test
 
@@ -508,8 +507,9 @@ class BeamSearchDecoderTest(test.TestCase):
             batch_size_tensor = constant_op.constant(batch_size)
             embedding = np.random.randn(vocab_size,
                                         embedding_dim).astype(np.float32)
-            cell = rnn_cell.LSTMCell(cell_depth)
-            initial_state = cell.zero_state(batch_size, dtypes.float32)
+            cell = layers.LSTMCell(cell_depth)
+            initial_state = cell.get_initial_state(
+                batch_size=batch_size, dtype=dtypes.float32)
             coverage_penalty_weight = 0.0
             if has_attention:
                 coverage_penalty_weight = 0.2
@@ -532,9 +532,9 @@ class BeamSearchDecoderTest(test.TestCase):
                     attention_mechanism=attention_mechanism,
                     attention_layer_size=attention_depth,
                     alignment_history=with_alignment_history)
-            cell_state = cell.zero_state(
-                dtype=dtypes.float32,
-                batch_size=batch_size_tensor * beam_width)
+            cell_state = cell.get_initial_state(
+                batch_size=batch_size_tensor * beam_width,
+                dtype=dtypes.float32)
             if has_attention:
                 cell_state = cell_state.clone(cell_state=initial_state)
             bsd = beam_search_decoder.BeamSearchDecoder(


### PR DESCRIPTION
* Inherit from `tf.keras.layers.AbstractRNNCell`
* Replace `tf.compat.v1.layers.Dense` by `tf.keras.layers.Dense`
* Store sublayers in `list` instead of `tuple`

Closes #128 