### PR TITLE
FIX: Correctly link the new soname for tf2

### DIFF
--- a/tf_dependency/BUILD.tpl
+++ b/tf_dependency/BUILD.tpl
@@ -8,13 +8,13 @@ cc_library(
 )
 
 # FIXME: Read shared library name from the installed python package.
-# See https://github.com/tensorflow/addons/pull/130 for why we're linking
-# to framework.so.1  in the meantime.
+# See https://github.com/tensorflow/tensorflow/issues/27430 for why we're
+# linking with hardcoded framework.so.2
 
 cc_library(
     name = "libtensorflow_framework",
-    srcs = [":libtensorflow_framework.so.1"],
-    #data = ["lib/libtensorflow_framework.so.1"],
+    srcs = [":libtensorflow_framework.so.2"],
+    #data = ["lib/libtensorflow_framework.so.2"],
     visibility = ["//visibility:public"],
 )
 

--- a/tf_dependency/tf_configure.bzl
+++ b/tf_dependency/tf_configure.bzl
@@ -183,14 +183,14 @@ def _tf_pip_impl(repository_ctx):
     )
 
     tf_shared_library_dir = repository_ctx.os.environ[_TF_SHARED_LIBRARY_DIR]
-    tf_shared_library_path = "%s/libtensorflow_framework.so.1" % tf_shared_library_dir
+    tf_shared_library_path = "%s/libtensorflow_framework.so.2" % tf_shared_library_dir
     tf_shared_library_rule = _symlink_genrule_for_dir(
         repository_ctx,
         None,
         "",
-        "libtensorflow_framework.so.1",
+        "libtensorflow_framework.so.2",
         [tf_shared_library_path],
-        ["libtensorflow_framework.so.1"],
+        ["libtensorflow_framework.so.2"],
     )
 
     _tpl(repository_ctx, "BUILD", {


### PR DESCRIPTION
Bit of a moving target here... but at least the soname is correct for tf2-preview now