### PR TITLE
[bugfix] unit test on mac

### DIFF
--- a/tools/ci_testing/addons_cpu.sh
+++ b/tools/ci_testing/addons_cpu.sh
@@ -24,7 +24,14 @@ fi
 
 set -x
 
-N_JOBS=$(grep -c ^processor /proc/cpuinfo)
+PLATFORM="$(uname -s | tr 'A-Z' 'a-z')"
+
+if [[ ${PLATFORM} == "darwin" ]]; then
+    N_JOBS=$(sysctl -n hw.ncpu)
+else
+    N_JOBS=$(grep -c ^processor /proc/cpuinfo)
+fi
+
 
 echo ""
 echo "Bazel will use ${N_JOBS} concurrent job(s)."


### PR DESCRIPTION
addons_cpu.sh cannot work correctly on Mac OS X system due to cannot get CPU core number correctly. this PR fix it.

Also, related with #77 , I build and unit test tensorflow-addons on Mac based on [commit a3fd8ef](https://github.com/tensorflow/addons/commit/a3fd8efd977accec0a68c96c7a49358369f641a1) (not the master branch which is CI test failed when I write this PR): building is OK and unit test passed. 

As a reminder for other developers on Mac, due to the issue bazelbuild/bazel#7241 with bazel, developers should not using virtualenv to test addons on Mac for now.