### PR TITLE
conversion to use tf2 public API - installment 1

### DIFF
--- a/tensorflow_addons/seq2seq/attention_wrapper.py
+++ b/tensorflow_addons/seq2seq/attention_wrapper.py
@@ -278,7 +278,6 @@ class _BaseAttentionMechanism(AttentionMechanism, layers.Layer):
                 "memory_sequence_length and memory_mask cannot be "
                 "used at same time for attention.")
         with tf.name_scope(self.name or "BaseAttentionMechanismInit"):
-            #tf.nest.flatten(memory)):
             self.values = _prepare_memory(
                 memory,
                 memory_sequence_length=memory_sequence_length,
@@ -819,7 +818,7 @@ def safe_cumprod(x, *args, **kwargs):
     Returns:
       Cumulative product of x.
     """
-    with tf.name_scope("SafeCumprod"):  #, [x]):
+    with tf.name_scope("SafeCumprod"):
         x = tf.convert_to_tensor(x, name="x")
         tiny = np.finfo(x.dtype.as_numpy_dtype).tiny
         return tf.exp(
@@ -1483,7 +1482,7 @@ def hardmax(logits, name=None):
     Returns:
       A batched one-hot tensor.
     """
-    with tf.name_scope(name or "Hardmax"):  #, [logits]):
+    with tf.name_scope(name or "Hardmax"):
         logits = tf.convert_to_tensor(logits, name="logits")
         if tf.compat.dimension_value(logits.get_shape()[-1]) is not None:
             depth = tf.compat.dimension_value(logits.get_shape()[-1])

--- a/tensorflow_addons/seq2seq/attention_wrapper.py
+++ b/tensorflow_addons/seq2seq/attention_wrapper.py
@@ -1814,7 +1814,7 @@ class AttentionWrapper(layers.AbstractRNNCell):
         if inputs is not None:
             batch_size = tf.shape(inputs)[0]
             dtype = inputs.dtype
-        with tf.name_scope(type(self).__name__ + "ZeroState"):  #, values=[batch_size]):  # pylint: disable=bad-continuation
+        with tf.name_scope(type(self).__name__ + "ZeroState"):  # pylint: disable=bad-continuation
             if self._initial_cell_state is not None:
                 cell_state = self._initial_cell_state
             else:

--- a/tensorflow_addons/seq2seq/attention_wrapper_test.py
+++ b/tensorflow_addons/seq2seq/attention_wrapper_test.py
@@ -25,21 +25,18 @@ from absl.testing import parameterized
 import numpy as np
 import tensorflow as tf
 
+from tensorflow_addons.utils import test_utils
 from tensorflow_addons.seq2seq import attention_wrapper as wrapper
 from tensorflow_addons.seq2seq import basic_decoder
 from tensorflow_addons.seq2seq import sampler as sampler_py
 from tensorflow.python import keras
 from tensorflow.python.eager import context
-from tensorflow.python.framework import dtypes
-from tensorflow.python.framework import test_util
+
 from tensorflow.python.keras import initializers
-from tensorflow.python.ops import variables
-from tensorflow.python.platform import test
-from tensorflow.python.util import nest
 
 
-@test_util.run_all_in_graph_and_eager_modes
-class AttentionMechanismTest(test.TestCase, parameterized.TestCase):
+@test_utils.run_all_in_graph_and_eager_modes
+class AttentionMechanismTest(tf.test.TestCase, parameterized.TestCase):
     def setUp(self):
         super(AttentionMechanismTest, self).setUp()
         self.batch = 10
@@ -90,7 +87,7 @@ class AttentionMechanismTest(test.TestCase, parameterized.TestCase):
     def test_layer_output(self, attention_cls):
         attention = attention_cls(self.units, self.memory)
         score = attention([self.query, self.state])
-        self.evaluate(variables.variables_initializer(attention.variables))
+        self.evaluate(tf.compat.v1.variables_initializer(attention.variables))
 
         score_val = self.evaluate(score)
         self.assertLen(score_val, 2)
@@ -108,7 +105,7 @@ class AttentionMechanismTest(test.TestCase, parameterized.TestCase):
         weights_before_query = attention.get_weights()
         ref_score = attention([self.query, self.state])
 
-        self.evaluate(variables.global_variables_initializer())
+        self.evaluate(tf.compat.v1.global_variables_initializer())
         ref_score_val = self.evaluate(ref_score)
 
         all_weights = attention.get_weights()
@@ -171,7 +168,7 @@ class AttentionMechanismTest(test.TestCase, parameterized.TestCase):
         state = None
         attention = wrapper.LuongAttention(5, memory, memory_sequence_length)
         alignment, _ = attention([query, state])
-        self.evaluate(variables.global_variables_initializer())
+        self.evaluate(tf.compat.v1.global_variables_initializer())
         alignment = self.evaluate(alignment)
         self.assertEqual(np.sum(np.triu(alignment, k=1)), 0)
 
@@ -189,8 +186,8 @@ def get_result_summary(x):
     return x
 
 
-@test_util.run_all_in_graph_and_eager_modes
-class AttentionWrapperTest(test.TestCase, parameterized.TestCase):
+@test_utils.run_all_in_graph_and_eager_modes
+class AttentionWrapperTest(tf.test.TestCase, parameterized.TestCase):
     def assertAllCloseOrEqual(self, x, y, **kwargs):
         if isinstance(x, np.ndarray) or isinstance(x, float):
             return super(AttentionWrapperTest, self).assertAllClose(
@@ -339,7 +336,7 @@ class AttentionWrapperTest(test.TestCase, parameterized.TestCase):
             sampler = sampler_py.TrainingSampler()
             my_decoder = basic_decoder.BasicDecoder(cell=cell, sampler=sampler)
             initial_state = cell.get_initial_state(
-                dtype=dtypes.float32, batch_size=batch_size)
+                dtype=tf.float32, batch_size=batch_size)
             final_outputs, final_state, _ = my_decoder(
                 decoder_inputs,
                 initial_state=initial_state,
@@ -384,17 +381,17 @@ class AttentionWrapperTest(test.TestCase, parameterized.TestCase):
                     self.assertEqual(
                         (expected_time, batch_size, encoder_max_time),
                         tuple(state_alignment_history.get_shape().as_list()))
-                nest.assert_same_structure(
+                tf.nest.assert_same_structure(
                     cell.state_size,
                     cell.get_initial_state(
-                        batch_size=batch_size, dtype=dtypes.float32))
+                        batch_size=batch_size, dtype=tf.float32))
                 # Remove the history from final_state for purposes of the
                 # remainder of the tests.
                 final_state = final_state._replace(alignment_history=())  # pylint: disable=protected-access
             else:
                 state_alignment_history = ()
 
-            self.evaluate(variables.global_variables_initializer())
+            self.evaluate(tf.compat.v1.global_variables_initializer())
             eval_result = self.evaluate({
                 "final_outputs":
                 final_outputs,
@@ -404,24 +401,24 @@ class AttentionWrapperTest(test.TestCase, parameterized.TestCase):
                 state_alignment_history,
             })
 
-            final_output_info = nest.map_structure(
+            final_output_info = tf.nest.map_structure(
                 get_result_summary, eval_result["final_outputs"])
-            final_state_info = nest.map_structure(get_result_summary,
-                                                  eval_result["final_state"])
+            final_state_info = tf.nest.map_structure(
+                get_result_summary, eval_result["final_state"])
             print("final_output_info: ", final_output_info)
             print("final_state_info: ", final_state_info)
 
-            nest.map_structure(self.assertAllCloseOrEqual,
-                               expected_final_output, final_output_info)
-            nest.map_structure(self.assertAllCloseOrEqual,
-                               expected_final_state, final_state_info)
+            tf.nest.map_structure(self.assertAllCloseOrEqual,
+                                  expected_final_output, final_output_info)
+            tf.nest.map_structure(self.assertAllCloseOrEqual,
+                                  expected_final_state, final_state_info)
             # by default, the wrapper emits attention as output
             if alignment_history:
-                final_alignment_history_info = nest.map_structure(
+                final_alignment_history_info = tf.nest.map_structure(
                     get_result_summary, eval_result["state_alignment_history"])
                 print("final_alignment_history_info: ",
                       final_alignment_history_info)
-                nest.map_structure(
+                tf.nest.map_structure(
                     self.assertAllCloseOrEqual,
                     # outputs are batch major but the stacked TensorArray is
                     # time major
@@ -794,4 +791,4 @@ class AttentionWrapperTest(test.TestCase, parameterized.TestCase):
 
 
 if __name__ == "__main__":
-    test.main()
+    tf.test.main()

--- a/tensorflow_addons/seq2seq/basic_decoder.py
+++ b/tensorflow_addons/seq2seq/basic_decoder.py
@@ -25,6 +25,7 @@ import tensorflow as tf
 from tensorflow_addons.seq2seq import decoder
 from tensorflow_addons.seq2seq import sampler as sampler_py
 
+from tensorflow.python.keras import layers
 from tensorflow.python.ops import rnn_cell_impl
 
 
@@ -57,7 +58,7 @@ class BasicDecoder(decoder.BaseDecoder):
             raise TypeError(
                 "sampler must be a Sampler, received: %s" % (sampler,))
         if (output_layer is not None
-                and not isinstance(output_layer, tf.keras.layers.Layer)):
+                and not isinstance(output_layer, layers.Layer)):
             raise TypeError(
                 "output_layer must be a Layer, received: %s" % (output_layer,))
         self.cell = cell

--- a/tensorflow_addons/seq2seq/basic_decoder.py
+++ b/tensorflow_addons/seq2seq/basic_decoder.py
@@ -20,12 +20,12 @@ from __future__ import print_function
 
 import collections
 
+import tensorflow as tf
+
 from tensorflow_addons.seq2seq import decoder
 from tensorflow_addons.seq2seq import sampler as sampler_py
-from tensorflow.python.framework import tensor_shape
-from tensorflow.python.keras import layers
+
 from tensorflow.python.ops import rnn_cell_impl
-from tensorflow.python.util import nest
 
 
 class BasicDecoderOutput(
@@ -57,7 +57,7 @@ class BasicDecoder(decoder.BaseDecoder):
             raise TypeError(
                 "sampler must be a Sampler, received: %s" % (sampler,))
         if (output_layer is not None
-                and not isinstance(output_layer, layers.Layer)):
+                and not isinstance(output_layer, tf.keras.layers.Layer)):
             raise TypeError(
                 "output_layer must be a Layer, received: %s" % (output_layer,))
         self.cell = cell
@@ -69,7 +69,7 @@ class BasicDecoder(decoder.BaseDecoder):
         """Initialize the decoder."""
         # Assume the dtype of the cell is the output_size structure
         # containing the input_state's first component's dtype.
-        self._cell_dtype = nest.flatten(initial_state)[0].dtype
+        self._cell_dtype = tf.nest.flatten(initial_state)[0].dtype
         return self.sampler.initialize(inputs, **kwargs) + (initial_state,)
 
     @property
@@ -77,7 +77,7 @@ class BasicDecoder(decoder.BaseDecoder):
         return self.sampler.batch_size
 
     def _rnn_output_size(self):
-        size = tensor_shape.TensorShape(self.cell.output_size)
+        size = tf.TensorShape(self.cell.output_size)
         if self.output_layer is None:
             return size
         else:
@@ -87,12 +87,11 @@ class BasicDecoder(decoder.BaseDecoder):
             # compute_output_shape and read off all but the first (batch)
             # dimensions to get the output size of the rnn with the layer
             # applied to the top.
-            output_shape_with_unknown_batch = nest.map_structure(
-                lambda s: tensor_shape.TensorShape([None]).concatenate(s),
-                size)
+            output_shape_with_unknown_batch = tf.nest.map_structure(
+                lambda s: tf.TensorShape([None]).concatenate(s), size)
             layer_output_shape = self.output_layer.compute_output_shape(
                 output_shape_with_unknown_batch)
-            return nest.map_structure(lambda s: s[1:], layer_output_shape)
+            return tf.nest.map_structure(lambda s: s[1:], layer_output_shape)
 
     @property
     def output_size(self):
@@ -108,7 +107,7 @@ class BasicDecoder(decoder.BaseDecoder):
         # Return that structure and the sample_ids_dtype from the helper.
         dtype = self._cell_dtype
         return BasicDecoderOutput(
-            nest.map_structure(lambda _: dtype, self._rnn_output_size()),
+            tf.nest.map_structure(lambda _: dtype, self._rnn_output_size()),
             self.sampler.sample_ids_dtype)
 
     def step(self, time, inputs, state):

--- a/tensorflow_addons/seq2seq/basic_decoder_test.py
+++ b/tensorflow_addons/seq2seq/basic_decoder_test.py
@@ -20,19 +20,14 @@ from __future__ import print_function
 from absl.testing import parameterized
 import numpy as np
 
+import tensorflow as tf
+
 from tensorflow_addons.seq2seq import basic_decoder
 from tensorflow_addons.seq2seq import sampler as sampler_py
 
-from tensorflow.python.framework import constant_op
-from tensorflow.python.framework import dtypes
-from tensorflow.python.framework import tensor_shape
 from tensorflow.python.keras import keras_parameterized
 from tensorflow.python.layers import core as layers_core
-from tensorflow.python.ops import array_ops
-from tensorflow.python.ops import math_ops
 from tensorflow.python.ops import rnn_cell
-from tensorflow.python.ops import variables
-from tensorflow.python.platform import test
 
 
 @keras_parameterized.run_all_keras_modes
@@ -52,7 +47,7 @@ class BasicDecoderTest(keras_parameterized.TestCase):
         with self.cached_session(use_gpu=True):
             inputs = np.random.randn(batch_size, max_time,
                                      input_depth).astype(np.float32)
-            input_t = constant_op.constant(inputs)
+            input_t = tf.constant(inputs)
             cell = rnn_cell.LSTMCell(cell_depth)
             sampler = sampler_py.TrainingSampler(time_major=False)
             if use_output_layer:
@@ -63,7 +58,7 @@ class BasicDecoderTest(keras_parameterized.TestCase):
                 output_layer = None
                 expected_output_depth = cell_depth
             initial_state = cell.zero_state(
-                dtype=dtypes.float32, batch_size=batch_size)
+                dtype=tf.float32, batch_size=batch_size)
             my_decoder = basic_decoder.BasicDecoder(
                 cell=cell, sampler=sampler, output_layer=output_layer)
 
@@ -76,15 +71,15 @@ class BasicDecoderTest(keras_parameterized.TestCase):
             output_dtype = my_decoder.output_dtype
             self.assertEqual(
                 basic_decoder.BasicDecoderOutput(expected_output_depth,
-                                                 tensor_shape.TensorShape([])),
+                                                 tf.TensorShape([])),
                 output_size)
             self.assertEqual(
-                basic_decoder.BasicDecoderOutput(dtypes.float32, dtypes.int32),
+                basic_decoder.BasicDecoderOutput(tf.float32, tf.int32),
                 output_dtype)
 
             (step_outputs, step_state, step_next_inputs,
              step_finished) = my_decoder.step(
-                 constant_op.constant(0), first_inputs, first_state)
+                 tf.constant(0), first_inputs, first_state)
             batch_size_t = my_decoder.batch_size
 
             self.assertTrue(isinstance(first_state, rnn_cell.LSTMStateTuple))
@@ -107,7 +102,7 @@ class BasicDecoderTest(keras_parameterized.TestCase):
                 # The output layer was accessed
                 self.assertEqual(len(output_layer.variables), 1)
 
-            self.evaluate(variables.global_variables_initializer())
+            self.evaluate(tf.compat.v1.global_variables_initializer())
             eval_result = self.evaluate({
                 "batch_size": batch_size_t,
                 "first_finished": first_finished,
@@ -140,11 +135,11 @@ class BasicDecoderTest(keras_parameterized.TestCase):
         with self.cached_session(use_gpu=True):
             embeddings = np.random.randn(vocabulary_size,
                                          input_depth).astype(np.float32)
-            embeddings_t = constant_op.constant(embeddings)
+            embeddings_t = tf.constant(embeddings)
             cell = rnn_cell.LSTMCell(vocabulary_size)
             sampler = sampler_py.GreedyEmbeddingSampler()
             initial_state = cell.zero_state(
-                dtype=dtypes.float32, batch_size=batch_size)
+                dtype=tf.float32, batch_size=batch_size)
             my_decoder = basic_decoder.BasicDecoder(cell=cell, sampler=sampler)
             (first_finished, first_inputs,
              first_state) = my_decoder.initialize(
@@ -155,16 +150,15 @@ class BasicDecoderTest(keras_parameterized.TestCase):
             output_size = my_decoder.output_size
             output_dtype = my_decoder.output_dtype
             self.assertEqual(
-                basic_decoder.BasicDecoderOutput(cell_depth,
-                                                 tensor_shape.TensorShape([])),
-                output_size)
+                basic_decoder.BasicDecoderOutput(cell_depth, tf.TensorShape(
+                    [])), output_size)
             self.assertEqual(
-                basic_decoder.BasicDecoderOutput(dtypes.float32, dtypes.int32),
+                basic_decoder.BasicDecoderOutput(tf.float32, tf.int32),
                 output_dtype)
 
             (step_outputs, step_state, step_next_inputs,
              step_finished) = my_decoder.step(
-                 constant_op.constant(0), first_inputs, first_state)
+                 tf.constant(0), first_inputs, first_state)
             batch_size_t = my_decoder.batch_size
 
             self.assertTrue(isinstance(first_state, rnn_cell.LSTMStateTuple))
@@ -183,7 +177,7 @@ class BasicDecoderTest(keras_parameterized.TestCase):
             self.assertEqual((batch_size, cell_depth),
                              step_state[1].get_shape())
 
-            self.evaluate(variables.global_variables_initializer())
+            self.evaluate(tf.compat.v1.global_variables_initializer())
             eval_result = self.evaluate({
                 "batch_size": batch_size_t,
                 "first_finished": first_finished,
@@ -222,11 +216,11 @@ class BasicDecoderTest(keras_parameterized.TestCase):
         with self.cached_session(use_gpu=True):
             embeddings = np.random.randn(vocabulary_size,
                                          input_depth).astype(np.float32)
-            embeddings_t = constant_op.constant(embeddings)
+            embeddings_t = tf.constant(embeddings)
             cell = rnn_cell.LSTMCell(vocabulary_size)
             sampler = sampler_py.SampleEmbeddingSampler(seed=0)
             initial_state = cell.zero_state(
-                dtype=dtypes.float32, batch_size=batch_size)
+                dtype=tf.float32, batch_size=batch_size)
             my_decoder = basic_decoder.BasicDecoder(cell=cell, sampler=sampler)
             (first_finished, first_inputs,
              first_state) = my_decoder.initialize(
@@ -237,16 +231,15 @@ class BasicDecoderTest(keras_parameterized.TestCase):
             output_size = my_decoder.output_size
             output_dtype = my_decoder.output_dtype
             self.assertEqual(
-                basic_decoder.BasicDecoderOutput(cell_depth,
-                                                 tensor_shape.TensorShape([])),
-                output_size)
+                basic_decoder.BasicDecoderOutput(cell_depth, tf.TensorShape(
+                    [])), output_size)
             self.assertEqual(
-                basic_decoder.BasicDecoderOutput(dtypes.float32, dtypes.int32),
+                basic_decoder.BasicDecoderOutput(tf.float32, tf.int32),
                 output_dtype)
 
             (step_outputs, step_state, step_next_inputs,
              step_finished) = my_decoder.step(
-                 constant_op.constant(0), first_inputs, first_state)
+                 tf.constant(0), first_inputs, first_state)
             batch_size_t = my_decoder.batch_size
 
             self.assertTrue(isinstance(first_state, rnn_cell.LSTMStateTuple))
@@ -265,7 +258,7 @@ class BasicDecoderTest(keras_parameterized.TestCase):
             self.assertEqual((batch_size, cell_depth),
                              step_state[1].get_shape())
 
-            self.evaluate(variables.global_variables_initializer())
+            self.evaluate(tf.compat.v1.global_variables_initializer())
             eval_result = self.evaluate({
                 "batch_size": batch_size_t,
                 "first_finished": first_finished,
@@ -296,15 +289,15 @@ class BasicDecoderTest(keras_parameterized.TestCase):
         with self.cached_session(use_gpu=True):
             inputs = np.random.randn(batch_size, max_time,
                                      input_depth).astype(np.float32)
-            input_t = constant_op.constant(inputs)
+            input_t = tf.constant(inputs)
             embeddings = np.random.randn(vocabulary_size,
                                          input_depth).astype(np.float32)
-            half = constant_op.constant(0.5)
+            half = tf.constant(0.5)
             cell = rnn_cell.LSTMCell(vocabulary_size)
             sampler = sampler_py.ScheduledEmbeddingTrainingSampler(
                 sampling_probability=half, time_major=False)
             initial_state = cell.zero_state(
-                dtype=dtypes.float32, batch_size=batch_size)
+                dtype=tf.float32, batch_size=batch_size)
             my_decoder = basic_decoder.BasicDecoder(cell=cell, sampler=sampler)
             (first_finished, first_inputs,
              first_state) = my_decoder.initialize(
@@ -316,15 +309,15 @@ class BasicDecoderTest(keras_parameterized.TestCase):
             output_dtype = my_decoder.output_dtype
             self.assertEqual(
                 basic_decoder.BasicDecoderOutput(vocabulary_size,
-                                                 tensor_shape.TensorShape([])),
+                                                 tf.TensorShape([])),
                 output_size)
             self.assertEqual(
-                basic_decoder.BasicDecoderOutput(dtypes.float32, dtypes.int32),
+                basic_decoder.BasicDecoderOutput(tf.float32, tf.int32),
                 output_dtype)
 
             (step_outputs, step_state, step_next_inputs,
              step_finished) = my_decoder.step(
-                 constant_op.constant(0), first_inputs, first_state)
+                 tf.constant(0), first_inputs, first_state)
             batch_size_t = my_decoder.batch_size
 
             self.assertTrue(isinstance(first_state, rnn_cell.LSTMStateTuple))
@@ -345,7 +338,7 @@ class BasicDecoderTest(keras_parameterized.TestCase):
             self.assertEqual((batch_size, input_depth),
                              step_next_inputs.get_shape())
 
-            self.evaluate(variables.global_variables_initializer())
+            self.evaluate(tf.compat.v1.global_variables_initializer())
             eval_result = self.evaluate({
                 "batch_size": batch_size_t,
                 "first_finished": first_finished,
@@ -390,17 +383,16 @@ class BasicDecoderTest(keras_parameterized.TestCase):
         with self.cached_session(use_gpu=True):
             inputs = np.random.randn(batch_size, max_time,
                                      input_depth).astype(np.float32)
-            input_t = constant_op.constant(inputs)
+            input_t = tf.constant(inputs)
             cell = rnn_cell.LSTMCell(cell_depth)
-            sampling_probability = constant_op.constant(sampling_probability)
+            sampling_probability = tf.constant(sampling_probability)
 
             if use_next_inputs_fn:
 
                 def next_inputs_fn(outputs):
                     # Use deterministic function for test.
-                    samples = math_ops.argmax(outputs, axis=1)
-                    return array_ops.one_hot(
-                        samples, cell_depth, dtype=dtypes.float32)
+                    samples = tf.argmax(outputs, axis=1)
+                    return tf.one_hot(samples, cell_depth, dtype=tf.float32)
             else:
                 next_inputs_fn = None
 
@@ -409,7 +401,7 @@ class BasicDecoderTest(keras_parameterized.TestCase):
                 time_major=False,
                 next_inputs_fn=next_inputs_fn)
             initial_state = cell.zero_state(
-                dtype=dtypes.float32, batch_size=batch_size)
+                dtype=tf.float32, batch_size=batch_size)
 
             my_decoder = basic_decoder.BasicDecoder(cell=cell, sampler=sampler)
 
@@ -422,16 +414,15 @@ class BasicDecoderTest(keras_parameterized.TestCase):
             output_size = my_decoder.output_size
             output_dtype = my_decoder.output_dtype
             self.assertEqual(
-                basic_decoder.BasicDecoderOutput(cell_depth,
-                                                 tensor_shape.TensorShape([])),
-                output_size)
+                basic_decoder.BasicDecoderOutput(cell_depth, tf.TensorShape(
+                    [])), output_size)
             self.assertEqual(
-                basic_decoder.BasicDecoderOutput(dtypes.float32, dtypes.int32),
+                basic_decoder.BasicDecoderOutput(tf.float32, tf.int32),
                 output_dtype)
 
             (step_outputs, step_state, step_next_inputs,
              step_finished) = my_decoder.step(
-                 constant_op.constant(0), first_inputs, first_state)
+                 tf.constant(0), first_inputs, first_state)
 
             if use_next_inputs_fn:
                 output_after_next_inputs_fn = next_inputs_fn(
@@ -455,7 +446,7 @@ class BasicDecoderTest(keras_parameterized.TestCase):
             self.assertEqual((batch_size, cell_depth),
                              step_state[1].get_shape())
 
-            self.evaluate(variables.global_variables_initializer())
+            self.evaluate(tf.compat.v1.global_variables_initializer())
 
             fetches = {
                 "batch_size": batch_size_t,
@@ -543,26 +534,26 @@ class BasicDecoderTest(keras_parameterized.TestCase):
         start_token = 0
         end_token = 6
 
-        start_inputs = array_ops.one_hot(
+        start_inputs = tf.one_hot(
             np.ones(batch_size, dtype=np.int32) * start_token, vocabulary_size)
 
         # The sample function samples categorically from the logits.
         sample_fn = lambda x: sampler_py.categorical_sample(logits=x)
         # The next inputs are a one-hot encoding of the sampled labels.
-        next_inputs_fn = (lambda x: array_ops.one_hot(
-            x, vocabulary_size, dtype=dtypes.float32))
-        end_fn = lambda sample_ids: math_ops.equal(sample_ids, end_token)
+        next_inputs_fn = (
+            lambda x: tf.one_hot(x, vocabulary_size, dtype=tf.float32))
+        end_fn = lambda sample_ids: tf.equal(sample_ids, end_token)
 
         with self.cached_session(use_gpu=True):
             cell = rnn_cell.LSTMCell(vocabulary_size)
             sampler = sampler_py.InferenceSampler(
                 sample_fn,
                 sample_shape=(),
-                sample_dtype=dtypes.int32,
+                sample_dtype=tf.int32,
                 end_fn=end_fn,
                 next_inputs_fn=next_inputs_fn)
             initial_state = cell.zero_state(
-                dtype=dtypes.float32, batch_size=batch_size)
+                dtype=tf.float32, batch_size=batch_size)
             my_decoder = basic_decoder.BasicDecoder(cell=cell, sampler=sampler)
             (first_finished, first_inputs,
              first_state) = my_decoder.initialize(
@@ -571,16 +562,15 @@ class BasicDecoderTest(keras_parameterized.TestCase):
             output_size = my_decoder.output_size
             output_dtype = my_decoder.output_dtype
             self.assertEqual(
-                basic_decoder.BasicDecoderOutput(cell_depth,
-                                                 tensor_shape.TensorShape([])),
-                output_size)
+                basic_decoder.BasicDecoderOutput(cell_depth, tf.TensorShape(
+                    [])), output_size)
             self.assertEqual(
-                basic_decoder.BasicDecoderOutput(dtypes.float32, dtypes.int32),
+                basic_decoder.BasicDecoderOutput(tf.float32, tf.int32),
                 output_dtype)
 
             (step_outputs, step_state, step_next_inputs,
              step_finished) = my_decoder.step(
-                 constant_op.constant(0), first_inputs, first_state)
+                 tf.constant(0), first_inputs, first_state)
             batch_size_t = my_decoder.batch_size
 
             self.assertTrue(isinstance(first_state, rnn_cell.LSTMStateTuple))
@@ -599,7 +589,7 @@ class BasicDecoderTest(keras_parameterized.TestCase):
             self.assertEqual((batch_size, cell_depth),
                              step_state[1].get_shape())
 
-            self.evaluate(variables.global_variables_initializer())
+            self.evaluate(tf.compat.v1.global_variables_initializer())
             eval_result = self.evaluate({
                 "batch_size": batch_size_t,
                 "first_finished": first_finished,
@@ -628,14 +618,14 @@ class BasicDecoderTest(keras_parameterized.TestCase):
         start_token = 0
         end_token = 6
 
-        start_inputs = array_ops.one_hot(
+        start_inputs = tf.one_hot(
             np.ones(batch_size, dtype=np.int32) * start_token, vocabulary_size)
 
         # The sample function samples independent bernoullis from the logits.
         sample_fn = (
-            lambda x: sampler_py.bernoulli_sample(logits=x, dtype=dtypes.bool))
+            lambda x: sampler_py.bernoulli_sample(logits=x, dtype=tf.bool))
         # The next inputs are a one-hot encoding of the sampled labels.
-        next_inputs_fn = math_ops.to_float
+        next_inputs_fn = lambda x: tf.cast(x, tf.float32)
         end_fn = lambda sample_ids: sample_ids[:, end_token]
 
         with self.cached_session(use_gpu=True):
@@ -643,11 +633,11 @@ class BasicDecoderTest(keras_parameterized.TestCase):
             sampler = sampler_py.InferenceSampler(
                 sample_fn,
                 sample_shape=[cell_depth],
-                sample_dtype=dtypes.bool,
+                sample_dtype=tf.bool,
                 end_fn=end_fn,
                 next_inputs_fn=next_inputs_fn)
             initial_state = cell.zero_state(
-                dtype=dtypes.float32, batch_size=batch_size)
+                dtype=tf.float32, batch_size=batch_size)
             my_decoder = basic_decoder.BasicDecoder(cell=cell, sampler=sampler)
             (first_finished, first_inputs,
              first_state) = my_decoder.initialize(
@@ -658,12 +648,12 @@ class BasicDecoderTest(keras_parameterized.TestCase):
                 basic_decoder.BasicDecoderOutput(cell_depth, cell_depth),
                 output_size)
             self.assertEqual(
-                basic_decoder.BasicDecoderOutput(dtypes.float32, dtypes.bool),
+                basic_decoder.BasicDecoderOutput(tf.float32, tf.bool),
                 output_dtype)
 
             (step_outputs, step_state, step_next_inputs,
              step_finished) = my_decoder.step(
-                 constant_op.constant(0), first_inputs, first_state)
+                 tf.constant(0), first_inputs, first_state)
             batch_size_t = my_decoder.batch_size
 
             self.assertTrue(isinstance(first_state, rnn_cell.LSTMStateTuple))
@@ -683,7 +673,7 @@ class BasicDecoderTest(keras_parameterized.TestCase):
             self.assertEqual((batch_size, cell_depth),
                              step_state[1].get_shape())
 
-            self.evaluate(variables.global_variables_initializer())
+            self.evaluate(tf.compat.v1.global_variables_initializer())
             eval_result = self.evaluate({
                 "batch_size": batch_size_t,
                 "first_finished": first_finished,
@@ -706,4 +696,4 @@ class BasicDecoderTest(keras_parameterized.TestCase):
 
 
 if __name__ == "__main__":
-    test.main()
+    tf.test.main()

--- a/tensorflow_addons/seq2seq/beam_search_decoder.py
+++ b/tensorflow_addons/seq2seq/beam_search_decoder.py
@@ -114,7 +114,7 @@ def tile_batch(t, multiplier, name=None):
       the rank is < 1.
     """
     flat_t = tf.nest.flatten(t)
-    with tf.name_scope(name or "tile_batch"):  #, flat_t + [multiplier]):
+    with tf.name_scope(name or "tile_batch"):
         return tf.nest.map_structure(lambda t_: _tile_batch(t_, multiplier), t)
 
 
@@ -549,7 +549,6 @@ class BeamSearchDecoderMixin(object):
         coverage_penalty_weight = self._coverage_penalty_weight
 
         with tf.name_scope(name or "BeamSearchDecoderStep"):
-            #,(time, inputs, state)):
             cell_state = state.cell_state
             inputs = tf.nest.map_structure(
                 lambda inp: self._merge_batch_beams(inp, s=inp.shape[2:]),

--- a/tensorflow_addons/seq2seq/beam_search_decoder.py
+++ b/tensorflow_addons/seq2seq/beam_search_decoder.py
@@ -21,23 +21,17 @@ from __future__ import print_function
 import collections
 import numpy as np
 
+import tensorflow as tf
+
 from tensorflow_addons.seq2seq import attention_wrapper
 from tensorflow_addons.seq2seq import decoder
 from tensorflow.python.eager import context
-from tensorflow.python.framework import dtypes
-from tensorflow.python.framework import ops
 from tensorflow.python.framework import tensor_shape
 from tensorflow.python.framework import tensor_util
 from tensorflow.python.keras import layers
-from tensorflow.python.ops import array_ops
-from tensorflow.python.ops import control_flow_ops
 from tensorflow.python.ops import embedding_ops
-from tensorflow.python.ops import math_ops
-from tensorflow.python.ops import nn_ops
 from tensorflow.python.ops import rnn_cell_impl
-from tensorflow.python.ops import tensor_array_ops
 from tensorflow.python.platform import tf_logging
-from tensorflow.python.util import nest
 
 from tensorflow.python.framework import load_library
 from tensorflow_addons.utils.resource_loader import get_path_to_datafile
@@ -79,20 +73,19 @@ class FinalBeamSearchDecoderOutput(
 
 def _tile_batch(t, multiplier):
     """Core single-tensor implementation of tile_batch."""
-    t = ops.convert_to_tensor(t, name="t")
-    shape_t = array_ops.shape(t)
+    t = tf.convert_to_tensor(t, name="t")
+    shape_t = tf.shape(t)
     if t.shape.ndims is None or t.shape.ndims < 1:
         raise ValueError("t must have statically known rank")
     tiling = [1] * (t.shape.ndims + 1)
     tiling[1] = multiplier
     tiled_static_batch_size = (t.shape.dims[0].value * multiplier
                                if t.shape.dims[0].value is not None else None)
-    tiled = array_ops.tile(array_ops.expand_dims(t, 1), tiling)
-    tiled = array_ops.reshape(
-        tiled, array_ops.concat(([shape_t[0] * multiplier], shape_t[1:]), 0))
+    tiled = tf.tile(tf.expand_dims(t, 1), tiling)
+    tiled = tf.reshape(tiled,
+                       tf.concat(([shape_t[0] * multiplier], shape_t[1:]), 0))
     tiled.set_shape(
-        tensor_shape.TensorShape([tiled_static_batch_size]).concatenate(
-            t.shape[1:]))
+        tf.TensorShape([tiled_static_batch_size]).concatenate(t.shape[1:]))
     return tiled
 
 
@@ -120,9 +113,9 @@ def tile_batch(t, multiplier, name=None):
       ValueError: if tensor(s) `t` do not have a statically known rank or
       the rank is < 1.
     """
-    flat_t = nest.flatten(t)
-    with ops.name_scope(name, "tile_batch", flat_t + [multiplier]):
-        return nest.map_structure(lambda t_: _tile_batch(t_, multiplier), t)
+    flat_t = tf.nest.flatten(t)
+    with tf.name_scope(name or "tile_batch"):  #, flat_t + [multiplier]):
+        return tf.nest.map_structure(lambda t_: _tile_batch(t_, multiplier), t)
 
 
 def gather_tree_from_array(t, parent_ids, sequence_length):
@@ -140,19 +133,16 @@ def gather_tree_from_array(t, parent_ids, sequence_length):
       `t` and where beams are sorted in each `Tensor` according to
       `parent_ids`.
     """
-    max_time = parent_ids.shape.dims[0].value or array_ops.shape(parent_ids)[0]
-    batch_size = parent_ids.shape.dims[1].value or array_ops.shape(
-        parent_ids)[1]
-    beam_width = parent_ids.shape.dims[2].value or array_ops.shape(
-        parent_ids)[2]
+    max_time = parent_ids.shape.dims[0].value or tf.shape(parent_ids)[0]
+    batch_size = parent_ids.shape.dims[1].value or tf.shape(parent_ids)[1]
+    beam_width = parent_ids.shape.dims[2].value or tf.shape(parent_ids)[2]
 
     # Generate beam ids that will be reordered by gather_tree.
-    beam_ids = array_ops.expand_dims(
-        array_ops.expand_dims(math_ops.range(beam_width), 0), 0)
-    beam_ids = array_ops.tile(beam_ids, [max_time, batch_size, 1])
+    beam_ids = tf.expand_dims(tf.expand_dims(tf.range(beam_width), 0), 0)
+    beam_ids = tf.tile(beam_ids, [max_time, batch_size, 1])
 
-    max_sequence_lengths = math_ops.to_int32(
-        math_ops.reduce_max(sequence_length, axis=1))
+    max_sequence_lengths = tf.cast(
+        tf.reduce_max(sequence_length, axis=1), tf.int32)
     sorted_beam_ids = gather_tree(
         step_ids=beam_ids,
         parent_ids=parent_ids,
@@ -160,29 +150,27 @@ def gather_tree_from_array(t, parent_ids, sequence_length):
         end_token=beam_width + 1)
 
     # For out of range steps, simply copy the same beam.
-    in_bound_steps = array_ops.transpose(
-        array_ops.sequence_mask(sequence_length, maxlen=max_time),
-        perm=[2, 0, 1])
-    sorted_beam_ids = array_ops.where(
-        in_bound_steps, x=sorted_beam_ids, y=beam_ids)
+    in_bound_steps = tf.transpose(
+        tf.sequence_mask(sequence_length, maxlen=max_time), perm=[2, 0, 1])
+    sorted_beam_ids = tf.where(in_bound_steps, x=sorted_beam_ids, y=beam_ids)
 
     # Generate indices for gather_nd.
-    time_ind = array_ops.tile(
-        array_ops.reshape(math_ops.range(max_time), [-1, 1, 1]),
+    time_ind = tf.tile(
+        tf.reshape(tf.range(max_time), [-1, 1, 1]),
         [1, batch_size, beam_width])
-    batch_ind = array_ops.tile(
-        array_ops.reshape(math_ops.range(batch_size), [-1, 1, 1]),
+    batch_ind = tf.tile(
+        tf.reshape(tf.range(batch_size), [-1, 1, 1]),
         [1, max_time, beam_width])
-    batch_ind = array_ops.transpose(batch_ind, perm=[1, 0, 2])
-    indices = array_ops.stack([time_ind, batch_ind, sorted_beam_ids], -1)
+    batch_ind = tf.transpose(batch_ind, perm=[1, 0, 2])
+    indices = tf.stack([time_ind, batch_ind, sorted_beam_ids], -1)
 
     # Gather from a tensor with collapsed additional dimensions.
     gather_from = t
-    final_shape = array_ops.shape(gather_from)
-    gather_from = array_ops.reshape(gather_from,
-                                    [max_time, batch_size, beam_width, -1])
-    ordered = array_ops.gather_nd(gather_from, indices)
-    ordered = array_ops.reshape(ordered, final_shape)
+    final_shape = tf.shape(gather_from)
+    gather_from = tf.reshape(gather_from,
+                             [max_time, batch_size, beam_width, -1])
+    ordered = tf.gather_nd(gather_from, indices)
+    ordered = tf.reshape(ordered, final_shape)
 
     return ordered
 
@@ -196,7 +184,7 @@ def _check_ndims(t):
 def _check_static_batch_beam_maybe(shape, batch_size, beam_width):
     """Raises an exception if dimensions are known statically and can not be
     reshaped to [batch_size, beam_size, -1]."""
-    reshaped_shape = tensor_shape.TensorShape([batch_size, beam_width, None])
+    reshaped_shape = tf.TensorShape([batch_size, beam_width, None])
     if (batch_size is not None and shape.dims[0].value is not None
             and (shape[0] != batch_size * beam_width or
                  (shape.ndims >= 2 and shape.dims[1].value is not None and
@@ -226,16 +214,16 @@ def _check_batch_beam(t, batch_size, beam_width):
         "TensorArray reordering during the beam search." %
         (t if context.executing_eagerly() else t.name))
     rank = t.shape.ndims
-    shape = array_ops.shape(t)
+    shape = tf.shape(t)
     if rank == 2:
-        condition = math_ops.equal(shape[1], batch_size * beam_width)
+        condition = tf.equal(shape[1], batch_size * beam_width)
     else:
-        condition = math_ops.logical_or(
-            math_ops.equal(shape[1], batch_size * beam_width),
-            math_ops.logical_and(
-                math_ops.equal(shape[1], batch_size),
-                math_ops.equal(shape[2], beam_width)))
-    return control_flow_ops.Assert(condition, [error_message])
+        condition = tf.logical_or(
+            tf.equal(shape[1], batch_size * beam_width),
+            tf.logical_and(
+                tf.equal(shape[1], batch_size), tf.equal(shape[2],
+                                                         beam_width)))
+    return tf.Assert(condition, [error_message])
 
 
 class BeamSearchDecoderMixin(object):
@@ -312,12 +300,11 @@ class BeamSearchDecoderMixin(object):
             # compute_output_shape and read off all but the first (batch)
             # dimensions to get the output size of the rnn with the layer
             # applied to the top.
-            output_shape_with_unknown_batch = nest.map_structure(
-                lambda s: tensor_shape.TensorShape([None]).concatenate(s),
-                size)
+            output_shape_with_unknown_batch = tf.nest.map_structure(
+                lambda s: tf.TensorShape([None]).concatenate(s), size)
             layer_output_shape = self._output_layer.compute_output_shape(
                 output_shape_with_unknown_batch)
-            return nest.map_structure(lambda s: s[1:], layer_output_shape)
+            return tf.nest.map_structure(lambda s: s[1:], layer_output_shape)
 
     @property
     def tracks_own_finished(self):
@@ -337,9 +324,9 @@ class BeamSearchDecoderMixin(object):
     def output_size(self):
         # Return the cell output and the id
         return BeamSearchDecoderOutput(
-            scores=tensor_shape.TensorShape([self._beam_width]),
-            predicted_ids=tensor_shape.TensorShape([self._beam_width]),
-            parent_ids=tensor_shape.TensorShape([self._beam_width]))
+            scores=tf.TensorShape([self._beam_width]),
+            predicted_ids=tf.TensorShape([self._beam_width]),
+            parent_ids=tf.TensorShape([self._beam_width]))
 
     def finalize(self, outputs, final_state, sequence_lengths):
         """Finalize and return the predicted_ids.
@@ -360,8 +347,8 @@ class BeamSearchDecoderMixin(object):
         """
         del sequence_lengths
         # Get max_sequence_length across all beams for each batch.
-        max_sequence_lengths = math_ops.to_int32(
-            math_ops.reduce_max(final_state.lengths, axis=1))
+        max_sequence_lengths = tf.cast(
+            tf.reduce_max(final_state.lengths, axis=1), tf.int32)
         predicted_ids = gather_tree(
             outputs.predicted_ids,
             outputs.parent_ids,
@@ -369,7 +356,7 @@ class BeamSearchDecoderMixin(object):
             end_token=self._end_token)
         if self._reorder_tensor_arrays:
             final_state = final_state._replace(
-                cell_state=nest.map_structure(
+                cell_state=tf.nest.map_structure(
                     lambda t: self._maybe_sort_array_beams(
                         t, outputs.parent_ids, final_state.lengths),
                     final_state.cell_state))
@@ -390,20 +377,19 @@ class BeamSearchDecoderMixin(object):
         Returns:
           A reshaped version of t with dimension [batch_size * beam_width, s].
         """
-        if isinstance(s, ops.Tensor):
+        if isinstance(s, tf.Tensor):
             s = tensor_shape.as_shape(tensor_util.constant_value(s))
         else:
-            s = tensor_shape.TensorShape(s)
-        t_shape = array_ops.shape(t)
+            s = tf.TensorShape(s)
+        t_shape = tf.shape(t)
         static_batch_size = tensor_util.constant_value(self._batch_size)
         batch_size_beam_width = (None if static_batch_size is None else
                                  static_batch_size * self._beam_width)
-        reshaped_t = array_ops.reshape(
+        reshaped_t = tf.reshape(
             t,
-            array_ops.concat(
-                ([self._batch_size * self._beam_width], t_shape[2:]), 0))
+            tf.concat(([self._batch_size * self._beam_width], t_shape[2:]), 0))
         reshaped_t.set_shape(
-            (tensor_shape.TensorShape([batch_size_beam_width]).concatenate(s)))
+            (tf.TensorShape([batch_size_beam_width]).concatenate(s)))
         return reshaped_t
 
     def _split_batch_beams(self, t, s=None):
@@ -424,17 +410,16 @@ class BeamSearchDecoderMixin(object):
             `[batch_size, beam_width, s]` (assuming batch_size and beam_width
             are known statically).
         """
-        if isinstance(s, ops.Tensor):
-            s = tensor_shape.TensorShape(tensor_util.constant_value(s))
+        if isinstance(s, tf.Tensor):
+            s = tf.TensorShape(tensor_util.constant_value(s))
         else:
-            s = tensor_shape.TensorShape(s)
-        t_shape = array_ops.shape(t)
-        reshaped_t = array_ops.reshape(
-            t,
-            array_ops.concat(
-                ([self._batch_size, self._beam_width], t_shape[1:]), 0))
+            s = tf.TensorShape(s)
+        t_shape = tf.shape(t)
+        reshaped_t = tf.reshape(
+            t, tf.concat(([self._batch_size, self._beam_width], t_shape[1:]),
+                         0))
         static_batch_size = tensor_util.constant_value(self._batch_size)
-        expected_reshaped_shape = tensor_shape.TensorShape(
+        expected_reshaped_shape = tf.TensorShape(
             [static_batch_size, self._beam_width]).concatenate(s)
         if not reshaped_t.shape.is_compatible_with(expected_reshaped_shape):
             raise ValueError(
@@ -466,7 +451,7 @@ class BeamSearchDecoderMixin(object):
         Raises:
           ValueError: If the rank of `t` is not statically known.
         """
-        if isinstance(t, tensor_array_ops.TensorArray):
+        if isinstance(t, tf.TensorArray):
             return t
         _check_ndims(t)
         if t.shape.ndims >= 1:
@@ -491,7 +476,7 @@ class BeamSearchDecoderMixin(object):
         Raises:
           ValueError:  If the rank of `t` is not statically known.
         """
-        if isinstance(t, tensor_array_ops.TensorArray):
+        if isinstance(t, tf.TensorArray):
             return t
         _check_ndims(t)
         if t.shape.ndims >= 2:
@@ -515,7 +500,7 @@ class BeamSearchDecoderMixin(object):
           A `TensorArray` where beams are sorted in each `Tensor` or `t` itself
             if it is not a `TensorArray` or does not meet shape requirements.
         """
-        if not isinstance(t, tensor_array_ops.TensorArray):
+        if not isinstance(t, tf.TensorArray):
             return t
         # pylint: disable=protected-access
         # This is a bad hack due to the implementation detail of eager/graph TA.
@@ -527,7 +512,7 @@ class BeamSearchDecoderMixin(object):
         if (not t._infer_shape or not t._element_shape
                 or element_shape.ndims is None or element_shape.ndims < 1):
             shape = (element_shape if t._infer_shape and t._element_shape else
-                     tensor_shape.TensorShape(None))
+                     tf.TensorShape(None))
             tf_logging.warn(
                 "The TensorArray %s in the cell state is not amenable to "
                 "sorting based on the beam search result. For a "
@@ -541,7 +526,7 @@ class BeamSearchDecoderMixin(object):
                 self._beam_width):
             return t
         t = t.stack()
-        with ops.control_dependencies(
+        with tf.control_dependencies(
             [_check_batch_beam(t, self._batch_size, self._beam_width)]):
             return gather_tree_from_array(t, parent_ids, sequence_length)
 
@@ -563,21 +548,22 @@ class BeamSearchDecoderMixin(object):
         length_penalty_weight = self._length_penalty_weight
         coverage_penalty_weight = self._coverage_penalty_weight
 
-        with ops.name_scope(name, "BeamSearchDecoderStep",
-                            (time, inputs, state)):
+        with tf.name_scope(name or "BeamSearchDecoderStep"):
+            #,(time, inputs, state)):
             cell_state = state.cell_state
-            inputs = nest.map_structure(
+            inputs = tf.nest.map_structure(
                 lambda inp: self._merge_batch_beams(inp, s=inp.shape[2:]),
                 inputs)
-            cell_state = nest.map_structure(self._maybe_merge_batch_beams,
-                                            cell_state, self._cell.state_size)
+            cell_state = tf.nest.map_structure(self._maybe_merge_batch_beams,
+                                               cell_state,
+                                               self._cell.state_size)
             cell_outputs, next_cell_state = self._cell(inputs, cell_state)
-            cell_outputs = nest.map_structure(
+            cell_outputs = tf.nest.map_structure(
                 lambda out: self._split_batch_beams(out, out.shape[1:]),
                 cell_outputs)
-            next_cell_state = nest.map_structure(self._maybe_split_batch_beams,
-                                                 next_cell_state,
-                                                 self._cell.state_size)
+            next_cell_state = tf.nest.map_structure(
+                self._maybe_split_batch_beams, next_cell_state,
+                self._cell.state_size)
 
             if self._output_layer is not None:
                 cell_outputs = self._output_layer(cell_outputs)
@@ -595,9 +581,9 @@ class BeamSearchDecoderMixin(object):
 
             finished = beam_search_state.finished
             sample_ids = beam_search_output.predicted_ids
-            next_inputs = control_flow_ops.cond(
-                math_ops.reduce_all(finished), lambda: self._start_inputs,
-                lambda: self._embedding_fn(sample_ids))
+            next_inputs = tf.cond(
+                tf.reduce_all(finished), lambda: self._start_inputs, lambda:
+                self._embedding_fn(sample_ids))
 
         return (beam_search_output, beam_search_state, next_inputs, finished)
 
@@ -719,39 +705,38 @@ class BeamSearchDecoder(BeamSearchDecoderMixin, decoder.BaseDecoder):
             self._embedding_fn = (
                 lambda ids: embedding_ops.embedding_lookup(embedding, ids))
 
-        self._start_tokens = ops.convert_to_tensor(
-            start_tokens, dtype=dtypes.int32, name="start_tokens")
+        self._start_tokens = tf.convert_to_tensor(
+            start_tokens, dtype=tf.int32, name="start_tokens")
         if self._start_tokens.get_shape().ndims != 1:
             raise ValueError("start_tokens must be a vector")
-        self._end_token = ops.convert_to_tensor(
-            end_token, dtype=dtypes.int32, name="end_token")
+        self._end_token = tf.convert_to_tensor(
+            end_token, dtype=tf.int32, name="end_token")
         if self._end_token.get_shape().ndims != 0:
             raise ValueError("end_token must be a scalar")
 
-        self._batch_size = array_ops.size(start_tokens)
-        self._initial_cell_state = nest.map_structure(
+        self._batch_size = tf.size(start_tokens)
+        self._initial_cell_state = tf.nest.map_structure(
             self._maybe_split_batch_beams, initial_state,
             self._cell.state_size)
-        self._start_tokens = array_ops.tile(
-            array_ops.expand_dims(self._start_tokens, 1),
-            [1, self._beam_width])
+        self._start_tokens = tf.tile(
+            tf.expand_dims(self._start_tokens, 1), [1, self._beam_width])
         self._start_inputs = self._embedding_fn(self._start_tokens)
 
-        self._finished = array_ops.one_hot(
-            array_ops.zeros([self._batch_size], dtype=dtypes.int32),
+        self._finished = tf.one_hot(
+            tf.zeros([self._batch_size], dtype=tf.int32),
             depth=self._beam_width,
             on_value=False,
             off_value=True,
-            dtype=dtypes.bool)
+            dtype=tf.bool)
 
         finished, start_inputs = self._finished, self._start_inputs
 
-        dtype = nest.flatten(self._initial_cell_state)[0].dtype
-        log_probs = array_ops.one_hot(  # shape(batch_sz, beam_sz)
-            array_ops.zeros([self._batch_size], dtype=dtypes.int32),
+        dtype = tf.nest.flatten(self._initial_cell_state)[0].dtype
+        log_probs = tf.one_hot(  # shape(batch_sz, beam_sz)
+            tf.zeros([self._batch_size], dtype=tf.int32),
             depth=self._beam_width,
-            on_value=ops.convert_to_tensor(0.0, dtype=dtype),
-            off_value=ops.convert_to_tensor(-np.Inf, dtype=dtype),
+            on_value=tf.convert_to_tensor(0.0, dtype=dtype),
+            off_value=tf.convert_to_tensor(-np.Inf, dtype=dtype),
             dtype=dtype)
         init_attention_probs = get_attention_probs(
             self._initial_cell_state, self._coverage_penalty_weight)
@@ -762,8 +747,8 @@ class BeamSearchDecoder(BeamSearchDecoderMixin, decoder.BaseDecoder):
             cell_state=self._initial_cell_state,
             log_probs=log_probs,
             finished=finished,
-            lengths=array_ops.zeros([self._batch_size, self._beam_width],
-                                    dtype=dtypes.int64),
+            lengths=tf.zeros([self._batch_size, self._beam_width],
+                             dtype=tf.int64),
             accumulated_attention_probs=init_attention_probs)
 
         return (finished, start_inputs, initial_state)
@@ -773,12 +758,12 @@ class BeamSearchDecoder(BeamSearchDecoderMixin, decoder.BaseDecoder):
         # Assume the dtype of the cell is the output_size structure
         # containing the input_state's first component's dtype.
         # Return that structure and int32 (the id)
-        dtype = nest.flatten(self._initial_cell_state)[0].dtype
+        dtype = tf.nest.flatten(self._initial_cell_state)[0].dtype
         return BeamSearchDecoderOutput(
-            scores=nest.map_structure(lambda _: dtype,
-                                      self._rnn_output_size()),
-            predicted_ids=dtypes.int32,
-            parent_ids=dtypes.int32)
+            scores=tf.nest.map_structure(lambda _: dtype,
+                                         self._rnn_output_size()),
+            predicted_ids=tf.int32,
+            parent_ids=tf.int32)
 
     def call(self, embeddning, start_tokens, end_token, initial_state,
              **kwargs):
@@ -828,28 +813,27 @@ def _beam_search_step(time, logits, next_cell_state, beam_state, batch_size,
     # Calculate the current lengths of the predictions
     prediction_lengths = beam_state.lengths
     previously_finished = beam_state.finished
-    not_finished = math_ops.logical_not(previously_finished)
+    not_finished = tf.logical_not(previously_finished)
 
     # Calculate the total log probs for the new hypotheses
     # Final Shape: [batch_size, beam_width, vocab_size]
-    step_log_probs = nn_ops.log_softmax(logits)
+    step_log_probs = tf.nn.log_softmax(logits)
     step_log_probs = _mask_probs(step_log_probs, end_token,
                                  previously_finished)
-    total_probs = array_ops.expand_dims(beam_state.log_probs,
-                                        2) + step_log_probs
+    total_probs = tf.expand_dims(beam_state.log_probs, 2) + step_log_probs
 
     # Calculate the continuation lengths by adding to all continuing beams.
-    vocab_size = logits.shape.dims[-1].value or array_ops.shape(logits)[-1]
-    lengths_to_add = array_ops.one_hot(
-        indices=array_ops.fill([batch_size, beam_width], end_token),
+    vocab_size = logits.shape.dims[-1].value or tf.shape(logits)[-1]
+    lengths_to_add = tf.one_hot(
+        indices=tf.fill([batch_size, beam_width], end_token),
         depth=vocab_size,
         on_value=np.int64(0),
         off_value=np.int64(1),
-        dtype=dtypes.int64)
-    add_mask = math_ops.to_int64(not_finished)
-    lengths_to_add *= array_ops.expand_dims(add_mask, 2)
+        dtype=tf.int64)
+    add_mask = tf.cast(not_finished, tf.int64)
+    lengths_to_add *= tf.expand_dims(add_mask, 2)
     new_prediction_lengths = (
-        lengths_to_add + array_ops.expand_dims(prediction_lengths, 2))
+        lengths_to_add + tf.expand_dims(prediction_lengths, 2))
 
     # Calculate the accumulated attention probabilities if coverage penalty is
     # enabled.
@@ -857,8 +841,7 @@ def _beam_search_step(time, logits, next_cell_state, beam_state, batch_size,
     attention_probs = get_attention_probs(next_cell_state,
                                           coverage_penalty_weight)
     if attention_probs is not None:
-        attention_probs *= array_ops.expand_dims(
-            math_ops.to_float(not_finished), 2)
+        attention_probs *= tf.expand_dims(tf.cast(not_finished, tf.float32), 2)
         accumulated_attention_probs = (
             beam_state.accumulated_attention_probs + attention_probs)
 
@@ -871,14 +854,14 @@ def _beam_search_step(time, logits, next_cell_state, beam_state, batch_size,
         finished=previously_finished,
         accumulated_attention_probs=accumulated_attention_probs)
 
-    time = ops.convert_to_tensor(time, name="time")
+    time = tf.convert_to_tensor(time, name="time")
     # During the first time step we only consider the initial beam
-    scores_flat = array_ops.reshape(scores, [batch_size, -1])
+    scores_flat = tf.reshape(scores, [batch_size, -1])
 
     # Pick the next beams according to the specified successors function
-    next_beam_size = ops.convert_to_tensor(
-        beam_width, dtype=dtypes.int32, name="beam_width")
-    next_beam_scores, word_indices = nn_ops.top_k(
+    next_beam_size = tf.convert_to_tensor(
+        beam_width, dtype=tf.int32, name="beam_width")
+    next_beam_scores, word_indices = tf.math.top_k(
         scores_flat, k=next_beam_size)
 
     next_beam_scores.set_shape([static_batch_size, beam_width])
@@ -894,15 +877,15 @@ def _beam_search_step(time, logits, next_cell_state, beam_state, batch_size,
         gather_shape=[-1],
         name="next_beam_probs")
     # Note: just doing the following
-    #   math_ops.to_int32(word_indices % vocab_size,
+    #   tf.to_int32(word_indices % vocab_size,
     #       name="next_beam_word_ids")
     # would be a lot cleaner but for reasons unclear, that hides the results of
     # the op which prevents capturing it with tfdbg debug ops.
-    raw_next_word_ids = math_ops.mod(
+    raw_next_word_ids = tf.mod(
         word_indices, vocab_size, name="next_beam_word_ids")
-    next_word_ids = math_ops.to_int32(raw_next_word_ids)
-    next_beam_ids = math_ops.to_int32(
-        word_indices / vocab_size, name="next_beam_parent_ids")
+    next_word_ids = tf.cast(raw_next_word_ids, tf.int32)
+    next_beam_ids = tf.cast(
+        word_indices / vocab_size, tf.int32, name="next_beam_parent_ids")
 
     # Append new ids to current predictions
     previously_finished = _tensor_gather_helper(
@@ -911,9 +894,9 @@ def _beam_search_step(time, logits, next_cell_state, beam_state, batch_size,
         batch_size=batch_size,
         range_size=beam_width,
         gather_shape=[-1])
-    next_finished = math_ops.logical_or(
+    next_finished = tf.logical_or(
         previously_finished,
-        math_ops.equal(next_word_ids, end_token),
+        tf.equal(next_word_ids, end_token),
         name="next_beam_finished")
 
     # Calculate the length of the next predictions.
@@ -921,8 +904,7 @@ def _beam_search_step(time, logits, next_cell_state, beam_state, batch_size,
     # 2. Beams that are now finished (EOS predicted) have their length
     #    increased by 1.
     # 3. Beams that are not yet finished have their length increased by 1.
-    lengths_to_add = math_ops.to_int64(
-        math_ops.logical_not(previously_finished))
+    lengths_to_add = tf.cast(tf.logical_not(previously_finished), tf.int64)
     next_prediction_len = _tensor_gather_helper(
         gather_indices=next_beam_ids,
         gather_from=beam_state.lengths,
@@ -944,7 +926,7 @@ def _beam_search_step(time, logits, next_cell_state, beam_state, batch_size,
     # different gather_shape here because the cell_state tensors, i.e.
     # the tensors that would be gathered from, all have dimension
     # greater than two and we need to preserve those dimensions.
-    next_cell_state = nest.map_structure(
+    next_cell_state = tf.nest.map_structure(
         lambda gather_from: _maybe_tensor_gather_helper(
             gather_indices=next_beam_ids,
             gather_from=gather_from,
@@ -1010,10 +992,10 @@ def get_attention_probs(next_cell_state, coverage_penalty_weight):
         # Calculate the average attention probabilities from all attention
         # layers.
         attention_probs = [
-            array_ops.expand_dims(prob, -1) for prob in probs_per_attn_layer
+            tf.expand_dims(prob, -1) for prob in probs_per_attn_layer
         ]
-        attention_probs = array_ops.concat(attention_probs, -1)
-        attention_probs = math_ops.reduce_mean(attention_probs, -1)
+        attention_probs = tf.concat(attention_probs, -1)
+        attention_probs = tf.reduce_mean(attention_probs, -1)
 
     return attention_probs
 
@@ -1047,10 +1029,10 @@ def _get_scores(log_probs, sequence_lengths, length_penalty_weight,
     length_penalty_ = _length_penalty(
         sequence_lengths=sequence_lengths,
         penalty_factor=length_penalty_weight)
-    length_penalty_ = math_ops.cast(length_penalty_, dtype=log_probs.dtype)
+    length_penalty_ = tf.cast(length_penalty_, dtype=log_probs.dtype)
     scores = log_probs / length_penalty_
 
-    coverage_penalty_weight = ops.convert_to_tensor(
+    coverage_penalty_weight = tf.convert_to_tensor(
         coverage_penalty_weight, name="coverage_penalty_weight")
     if coverage_penalty_weight.shape.ndims != 0:
         raise ValueError("coverage_penalty_weight should be a scalar, "
@@ -1065,21 +1047,19 @@ def _get_scores(log_probs, sequence_lengths, length_penalty_weight,
             "is disabled.")
 
     # Add source sequence length mask before computing coverage penalty.
-    accumulated_attention_probs = array_ops.where(
-        math_ops.equal(accumulated_attention_probs, 0.0),
-        array_ops.ones_like(accumulated_attention_probs),
-        accumulated_attention_probs)
+    accumulated_attention_probs = tf.where(
+        tf.equal(accumulated_attention_probs, 0.0),
+        tf.ones_like(accumulated_attention_probs), accumulated_attention_probs)
 
     # coverage penalty =
     #     sum over `max_time` {log(min(accumulated_attention_probs, 1.0))}
-    coverage_penalty = math_ops.reduce_sum(
-        math_ops.log(math_ops.minimum(accumulated_attention_probs, 1.0)), 2)
+    coverage_penalty = tf.reduce_sum(
+        tf.math.log(tf.minimum(accumulated_attention_probs, 1.0)), 2)
     # Apply coverage penalty to finished predictions.
-    coverage_penalty *= math_ops.to_float(finished)
+    coverage_penalty *= tf.cast(finished, tf.float32)
     weighted_coverage_penalty = coverage_penalty * coverage_penalty_weight
     # Reshape from [batch_size, beam_width] to [batch_size, beam_width, 1]
-    weighted_coverage_penalty = array_ops.expand_dims(
-        weighted_coverage_penalty, 2)
+    weighted_coverage_penalty = tf.expand_dims(weighted_coverage_penalty, 2)
     return scores + weighted_coverage_penalty
 
 
@@ -1099,10 +1079,10 @@ def attention_probs_from_attn_state(attention_state):
     attention_probs = attention_state.alignments
     if isinstance(attention_probs, tuple):
         attention_probs = [
-            array_ops.expand_dims(prob, -1) for prob in attention_probs
+            tf.expand_dims(prob, -1) for prob in attention_probs
         ]
-        attention_probs = array_ops.concat(attention_probs, -1)
-        attention_probs = math_ops.reduce_mean(attention_probs, -1)
+        attention_probs = tf.concat(attention_probs, -1)
+        attention_probs = tf.reduce_mean(attention_probs, -1)
     return attention_probs
 
 
@@ -1124,14 +1104,14 @@ def _length_penalty(sequence_lengths, penalty_factor):
       the length penalty factor, a tensor with the same shape as
       `sequence_lengths`.
     """
-    penalty_factor = ops.convert_to_tensor(
+    penalty_factor = tf.convert_to_tensor(
         penalty_factor, name="penalty_factor")
     penalty_factor.set_shape(())  # penalty should be a scalar.
     static_penalty = tensor_util.constant_value(penalty_factor)
     if static_penalty is not None and static_penalty == 0:
         return 1.0
-    return math_ops.div(
-        (5. + math_ops.to_float(sequence_lengths))**penalty_factor,
+    return tf.math.divide(
+        (5. + tf.cast(sequence_lengths, tf.float32))**penalty_factor,
         (5. + 1.)**penalty_factor)
 
 
@@ -1153,22 +1133,21 @@ def _mask_probs(probs, eos_token, finished):
       unfinished beams stay unchanged and finished beams are replaced with a
       tensor with all probability on the EOS token.
     """
-    vocab_size = array_ops.shape(probs)[2]
+    vocab_size = tf.shape(probs)[2]
     # All finished examples are replaced with a vector that has all
     # probability on EOS
-    finished_row = array_ops.one_hot(
+    finished_row = tf.one_hot(
         eos_token,
         vocab_size,
         dtype=probs.dtype,
-        on_value=ops.convert_to_tensor(0., dtype=probs.dtype),
+        on_value=tf.convert_to_tensor(0., dtype=probs.dtype),
         off_value=probs.dtype.min)
-    finished_probs = array_ops.tile(
-        array_ops.reshape(finished_row, [1, 1, -1]),
-        array_ops.concat([array_ops.shape(finished), [1]], 0))
-    finished_mask = array_ops.tile(
-        array_ops.expand_dims(finished, 2), [1, 1, vocab_size])
+    finished_probs = tf.tile(
+        tf.reshape(finished_row, [1, 1, -1]),
+        tf.concat([tf.shape(finished), [1]], 0))
+    finished_mask = tf.tile(tf.expand_dims(finished, 2), [1, 1, vocab_size])
 
-    return array_ops.where(finished_mask, finished_probs, probs)
+    return tf.where(finished_mask, finished_probs, probs)
 
 
 def _maybe_tensor_gather_helper(gather_indices, gather_from, batch_size,
@@ -1199,7 +1178,7 @@ def _maybe_tensor_gather_helper(gather_indices, gather_from, batch_size,
         tf.shape(gather_from)[:1+len(gather_shape)] or the original tensor if
         its dimensions are too small.
     """
-    if isinstance(gather_from, tensor_array_ops.TensorArray):
+    if isinstance(gather_from, tf.TensorArray):
         return gather_from
     _check_ndims(gather_from)
     if gather_from.shape.ndims >= len(gather_shape):
@@ -1245,17 +1224,15 @@ def _tensor_gather_helper(gather_indices,
       output: Gathered tensor of shape
         tf.shape(gather_from)[:1+len(gather_shape)]
     """
-    with ops.name_scope(name, "tensor_gather_helper"):
-        range_ = array_ops.expand_dims(
-            math_ops.range(batch_size) * range_size, 1)
-        gather_indices = array_ops.reshape(gather_indices + range_, [-1])
-        output = array_ops.gather(
-            array_ops.reshape(gather_from, gather_shape), gather_indices)
-        final_shape = array_ops.shape(gather_from)[:1 + len(gather_shape)]
+    with tf.name_scope(name or "tensor_gather_helper"):
+        range_ = tf.expand_dims(tf.range(batch_size) * range_size, 1)
+        gather_indices = tf.reshape(gather_indices + range_, [-1])
+        output = tf.gather(
+            tf.reshape(gather_from, gather_shape), gather_indices)
+        final_shape = tf.shape(gather_from)[:1 + len(gather_shape)]
         static_batch_size = tensor_util.constant_value(batch_size)
-        final_static_shape = (tensor_shape.TensorShape(
-            [static_batch_size]).concatenate(
-                gather_from.shape[1:1 + len(gather_shape)]))
-        output = array_ops.reshape(output, final_shape, name="output")
+        final_static_shape = (tf.TensorShape([static_batch_size]).concatenate(
+            gather_from.shape[1:1 + len(gather_shape)]))
+        output = tf.reshape(output, final_shape, name="output")
         output.set_shape(final_static_shape)
         return output

--- a/tensorflow_addons/seq2seq/beam_search_decoder_test.py
+++ b/tensorflow_addons/seq2seq/beam_search_decoder_test.py
@@ -21,19 +21,14 @@ from __future__ import print_function
 
 import numpy as np
 
+import tensorflow as tf
+
 from tensorflow_addons.seq2seq import attention_wrapper
 from tensorflow_addons.seq2seq import beam_search_decoder
 from tensorflow.python.eager import context
-from tensorflow.python.framework import constant_op
-from tensorflow.python.framework import dtypes
 from tensorflow.python.framework import errors
-from tensorflow.python.framework import ops
 from tensorflow.python.framework import test_util
 from tensorflow.python.keras import layers
-from tensorflow.python.ops import array_ops
-from tensorflow.python.ops import nn_ops
-from tensorflow.python.ops import variables
-from tensorflow.python.platform import test
 
 from tensorflow.python.framework import load_library
 from tensorflow_addons.utils.resource_loader import get_path_to_datafile
@@ -43,7 +38,7 @@ _beam_search_ops_so = load_library.load_op_library(
 gather_tree = _beam_search_ops_so.gather_tree
 
 
-class TestGatherTree(test.TestCase):
+class TestGatherTree(tf.test.TestCase):
     """Tests the gather_tree function."""
 
     def test_gather_tree(self):
@@ -90,27 +85,25 @@ class TestGatherTree(test.TestCase):
                                     [11, 12, 0]]]).transpose([1, 0, 2])
         sequence_length = [[3, 3, 3], [4, 4, 3]]
 
-        array = ops.convert_to_tensor(array, dtype=dtypes.float32)
-        parent_ids = ops.convert_to_tensor(parent_ids, dtype=dtypes.int32)
-        expected_array = ops.convert_to_tensor(
-            expected_array, dtype=dtypes.float32)
+        array = tf.convert_to_tensor(array, dtype=tf.float32)
+        parent_ids = tf.convert_to_tensor(parent_ids, dtype=tf.int32)
+        expected_array = tf.convert_to_tensor(expected_array, dtype=tf.float32)
 
-        max_time = array_ops.shape(array)[0]
-        batch_size = array_ops.shape(array)[1]
-        beam_width = array_ops.shape(array)[2]
+        max_time = tf.shape(array)[0]
+        batch_size = tf.shape(array)[1]
+        beam_width = tf.shape(array)[2]
 
         def _tile_in_depth(tensor):
             # Generate higher rank tensors by concatenating tensor and
             # tensor + 1.
             for _ in range(depth_ndims):
-                tensor = array_ops.stack([tensor, tensor + 1], -1)
+                tensor = tf.stack([tensor, tensor + 1], -1)
             return tensor
 
         if merged_batch_beam:
-            array = array_ops.reshape(array,
-                                      [max_time, batch_size * beam_width])
-            expected_array = array_ops.reshape(
-                expected_array, [max_time, batch_size * beam_width])
+            array = tf.reshape(array, [max_time, batch_size * beam_width])
+            expected_array = tf.reshape(expected_array,
+                                        [max_time, batch_size * beam_width])
 
         if depth_ndims > 0:
             array = _tile_in_depth(array)
@@ -155,10 +148,9 @@ class TestGatherTree(test.TestCase):
                                                               2]]]), -1)
         sequence_length = [[4, 6, 4, 7, 6]]
 
-        array = ops.convert_to_tensor(array, dtype=dtypes.float32)
-        parent_ids = ops.convert_to_tensor(parent_ids, dtype=dtypes.int32)
-        expected_array = ops.convert_to_tensor(
-            expected_array, dtype=dtypes.float32)
+        array = tf.convert_to_tensor(array, dtype=tf.float32)
+        parent_ids = tf.convert_to_tensor(parent_ids, dtype=tf.int32)
+        expected_array = tf.convert_to_tensor(expected_array, dtype=tf.float32)
 
         sorted_array = beam_search_decoder.gather_tree_from_array(
             array, parent_ids, sequence_length)
@@ -169,18 +161,18 @@ class TestGatherTree(test.TestCase):
             self.assertAllEqual(expected_array, sorted_array)
 
 
-class TestArrayShapeChecks(test.TestCase):
+class TestArrayShapeChecks(tf.test.TestCase):
     def _test_array_shape_dynamic_checks(self,
                                          static_shape,
                                          dynamic_shape,
                                          batch_size,
                                          beam_width,
                                          is_valid=True):
-        t = array_ops.placeholder_with_default(
+        t = tf.compat.v1.placeholder_with_default(
             np.random.randn(*static_shape).astype(np.float32),
             shape=dynamic_shape)
 
-        batch_size = array_ops.constant(batch_size)
+        batch_size = tf.constant(batch_size)
 
         def _test_body():
             # pylint: disable=protected-access
@@ -225,11 +217,11 @@ class TestArrayShapeChecks(test.TestCase):
                                               is_valid=False)
 
 
-class TestEosMasking(test.TestCase):
+class TestEosMasking(tf.test.TestCase):
     """Tests EOS masking used in beam search."""
 
     def test_eos_masking(self):
-        probs = constant_op.constant([
+        probs = tf.constant([
             [[-.2, -.2, -.2, -.2, -.2], [-.3, -.3, -.3, 3, 0], [5, 6, 0, 0,
                                                                 0]],
             [[-.2, -.2, -.2, -.2, 0], [-.3, -.3, -.1, 3, 0], [5, 6, 3, 0, 0]],
@@ -258,7 +250,7 @@ class TestEosMasking(test.TestCase):
                 self.assertAllClose(masked[1][2][i], np.finfo('float32').min)
 
 
-class TestBeamStep(test.TestCase):
+class TestBeamStep(tf.test.TestCase):
     """Tests a single step of beam search."""
 
     def setUp(self):
@@ -271,17 +263,15 @@ class TestBeamStep(test.TestCase):
         self.coverage_penalty_weight = 0.0
 
     def test_step(self):
-        dummy_cell_state = array_ops.zeros([self.batch_size, self.beam_width])
+        dummy_cell_state = tf.zeros([self.batch_size, self.beam_width])
         beam_state = beam_search_decoder.BeamSearchDecoderState(
             cell_state=dummy_cell_state,
-            log_probs=nn_ops.log_softmax(
-                array_ops.ones([self.batch_size, self.beam_width])),
-            lengths=constant_op.constant(
-                2,
-                shape=[self.batch_size, self.beam_width],
-                dtype=dtypes.int64),
-            finished=array_ops.zeros([self.batch_size, self.beam_width],
-                                     dtype=dtypes.bool),
+            log_probs=tf.nn.log_softmax(
+                tf.ones([self.batch_size, self.beam_width])),
+            lengths=tf.constant(
+                2, shape=[self.batch_size, self.beam_width], dtype=tf.int64),
+            finished=tf.zeros([self.batch_size, self.beam_width],
+                              dtype=tf.bool),
             accumulated_attention_probs=())
 
         logits_ = np.full([self.batch_size, self.beam_width, self.vocab_size],
@@ -294,15 +284,15 @@ class TestBeamStep(test.TestCase):
         logits_[1, 1, 2] = 2.7
         logits_[1, 2, 2] = 10.0
         logits_[1, 2, 3] = 0.2
-        logits = ops.convert_to_tensor(logits_, dtype=dtypes.float32)
-        log_probs = nn_ops.log_softmax(logits)
+        logits = tf.convert_to_tensor(logits_, dtype=tf.float32)
+        log_probs = tf.nn.log_softmax(logits)
 
         outputs, next_beam_state = beam_search_decoder._beam_search_step(
             time=2,
             logits=logits,
             next_cell_state=dummy_cell_state,
             beam_state=beam_state,
-            batch_size=ops.convert_to_tensor(self.batch_size),
+            batch_size=tf.convert_to_tensor(self.batch_size),
             beam_width=self.beam_width,
             end_token=self.end_token,
             length_penalty_weight=self.length_penalty_weight,
@@ -330,16 +320,15 @@ class TestBeamStep(test.TestCase):
         self.assertAllEqual(next_state_.log_probs, expected_log_probs)
 
     def test_step_with_eos(self):
-        dummy_cell_state = array_ops.zeros([self.batch_size, self.beam_width])
+        dummy_cell_state = tf.zeros([self.batch_size, self.beam_width])
         beam_state = beam_search_decoder.BeamSearchDecoderState(
             cell_state=dummy_cell_state,
-            log_probs=nn_ops.log_softmax(
-                array_ops.ones([self.batch_size, self.beam_width])),
-            lengths=ops.convert_to_tensor([[2, 1, 2], [2, 2, 1]],
-                                          dtype=dtypes.int64),
-            finished=ops.convert_to_tensor(
-                [[False, True, False], [False, False, True]],
-                dtype=dtypes.bool),
+            log_probs=tf.nn.log_softmax(
+                tf.ones([self.batch_size, self.beam_width])),
+            lengths=tf.convert_to_tensor([[2, 1, 2], [2, 2, 1]],
+                                         dtype=tf.int64),
+            finished=tf.convert_to_tensor(
+                [[False, True, False], [False, False, True]], dtype=tf.bool),
             accumulated_attention_probs=())
 
         logits_ = np.full([self.batch_size, self.beam_width, self.vocab_size],
@@ -352,15 +341,15 @@ class TestBeamStep(test.TestCase):
         logits_[1, 1, 2] = 5.7  # why does this not work when it's 2.7?
         logits_[1, 2, 2] = 1.0
         logits_[1, 2, 3] = 0.2
-        logits = ops.convert_to_tensor(logits_, dtype=dtypes.float32)
-        log_probs = nn_ops.log_softmax(logits)
+        logits = tf.convert_to_tensor(logits_, dtype=tf.float32)
+        log_probs = tf.nn.log_softmax(logits)
 
         outputs, next_beam_state = beam_search_decoder._beam_search_step(
             time=2,
             logits=logits,
             next_cell_state=dummy_cell_state,
             beam_state=beam_state,
-            batch_size=ops.convert_to_tensor(self.batch_size),
+            batch_size=tf.convert_to_tensor(self.batch_size),
             beam_width=self.beam_width,
             end_token=self.end_token,
             length_penalty_weight=self.length_penalty_weight,
@@ -386,7 +375,7 @@ class TestBeamStep(test.TestCase):
         self.assertAllEqual(next_state_.log_probs, expected_log_probs)
 
 
-class TestLargeBeamStep(test.TestCase):
+class TestLargeBeamStep(tf.test.TestCase):
     """Tests large beam step.
 
     Tests a single step of beam search in such case that beam size is
@@ -405,36 +394,35 @@ class TestLargeBeamStep(test.TestCase):
     def test_step(self):
         def get_probs():
             """this simulates the initialize method in BeamSearchDecoder."""
-            log_prob_mask = array_ops.one_hot(
-                array_ops.zeros([self.batch_size], dtype=dtypes.int32),
+            log_prob_mask = tf.one_hot(
+                tf.zeros([self.batch_size], dtype=tf.int32),
                 depth=self.beam_width,
                 on_value=True,
                 off_value=False,
-                dtype=dtypes.bool)
+                dtype=tf.bool)
 
-            log_prob_zeros = array_ops.zeros(
-                [self.batch_size, self.beam_width], dtype=dtypes.float32)
-            log_prob_neg_inf = array_ops.ones(
-                [self.batch_size, self.beam_width],
-                dtype=dtypes.float32) * -np.Inf
+            log_prob_zeros = tf.zeros([self.batch_size, self.beam_width],
+                                      dtype=tf.float32)
+            log_prob_neg_inf = tf.ones([self.batch_size, self.beam_width],
+                                       dtype=tf.float32) * -np.Inf
 
-            log_probs = array_ops.where(log_prob_mask, log_prob_zeros,
-                                        log_prob_neg_inf)
+            log_probs = tf.where(log_prob_mask, log_prob_zeros,
+                                 log_prob_neg_inf)
             return log_probs
 
         log_probs = get_probs()
-        dummy_cell_state = array_ops.zeros([self.batch_size, self.beam_width])
+        dummy_cell_state = tf.zeros([self.batch_size, self.beam_width])
 
         # pylint: disable=invalid-name
-        _finished = array_ops.one_hot(
-            array_ops.zeros([self.batch_size], dtype=dtypes.int32),
+        _finished = tf.one_hot(
+            tf.zeros([self.batch_size], dtype=tf.int32),
             depth=self.beam_width,
             on_value=False,
             off_value=True,
-            dtype=dtypes.bool)
+            dtype=tf.bool)
         _lengths = np.zeros([self.batch_size, self.beam_width], dtype=np.int64)
         _lengths[:, 0] = 2
-        _lengths = constant_op.constant(_lengths, dtype=dtypes.int64)
+        _lengths = tf.constant(_lengths, dtype=tf.int64)
 
         beam_state = beam_search_decoder.BeamSearchDecoderState(
             cell_state=dummy_cell_state,
@@ -453,15 +441,15 @@ class TestLargeBeamStep(test.TestCase):
         logits_[1, 1, 2] = 2.7
         logits_[1, 2, 2] = 10.0
         logits_[1, 2, 3] = 0.2
-        logits = constant_op.constant(logits_, dtype=dtypes.float32)
-        log_probs = nn_ops.log_softmax(logits)
+        logits = tf.constant(logits_, dtype=tf.float32)
+        log_probs = tf.nn.log_softmax(logits)
 
         outputs, next_beam_state = beam_search_decoder._beam_search_step(
             time=2,
             logits=logits,
             next_cell_state=dummy_cell_state,
             beam_state=beam_state,
-            batch_size=ops.convert_to_tensor(self.batch_size),
+            batch_size=tf.convert_to_tensor(self.batch_size),
             beam_width=self.beam_width,
             end_token=self.end_token,
             length_penalty_weight=self.length_penalty_weight,
@@ -485,7 +473,7 @@ class TestLargeBeamStep(test.TestCase):
 
 
 @test_util.run_all_in_graph_and_eager_modes
-class BeamSearchDecoderTest(test.TestCase):
+class BeamSearchDecoderTest(tf.test.TestCase):
     def _testDynamicDecodeRNN(self,
                               time_major,
                               has_attention,
@@ -506,16 +494,16 @@ class BeamSearchDecoderTest(test.TestCase):
         beam_width = 3
 
         with self.cached_session():
-            batch_size_tensor = constant_op.constant(batch_size)
+            batch_size_tensor = tf.constant(batch_size)
             embedding = np.random.randn(vocab_size,
                                         embedding_dim).astype(np.float32)
             cell = layers.LSTMCell(cell_depth)
             initial_state = cell.get_initial_state(
-                batch_size=batch_size, dtype=dtypes.float32)
+                batch_size=batch_size, dtype=tf.float32)
             coverage_penalty_weight = 0.0
             if has_attention:
                 coverage_penalty_weight = 0.2
-                inputs = array_ops.placeholder_with_default(
+                inputs = tf.compat.v1.placeholder_with_default(
                     np.random.randn(batch_size, decoder_max_time,
                                     input_depth).astype(np.float32),
                     shape=(None, None, input_depth))
@@ -535,8 +523,7 @@ class BeamSearchDecoderTest(test.TestCase):
                     attention_layer_size=attention_depth,
                     alignment_history=with_alignment_history)
             cell_state = cell.get_initial_state(
-                batch_size=batch_size_tensor * beam_width,
-                dtype=dtypes.float32)
+                batch_size=batch_size_tensor * beam_width, dtype=tf.float32)
             if has_attention:
                 cell_state = cell_state.clone(cell_state=initial_state)
             bsd = beam_search_decoder.BeamSearchDecoder(
@@ -550,7 +537,7 @@ class BeamSearchDecoderTest(test.TestCase):
 
             final_outputs, final_state, final_sequence_lengths = bsd(
                 embedding,
-                start_tokens=array_ops.fill([batch_size_tensor], start_token),
+                start_tokens=tf.fill([batch_size_tensor], start_token),
                 end_token=end_token,
                 initial_state=cell_state)
 
@@ -575,7 +562,7 @@ class BeamSearchDecoderTest(test.TestCase):
                 _t((batch_size, expected_seq_length, beam_width)),
                 tuple(final_outputs.predicted_ids.get_shape().as_list()))
 
-            self.evaluate(variables.global_variables_initializer())
+            self.evaluate(tf.compat.v1.global_variables_initializer())
             eval_results = self.evaluate({
                 'final_outputs':
                 final_outputs,
@@ -608,4 +595,4 @@ class BeamSearchDecoderTest(test.TestCase):
 
 
 if __name__ == '__main__':
-    test.main()
+    tf.test.main()

--- a/tensorflow_addons/seq2seq/beam_search_ops_test.py
+++ b/tensorflow_addons/seq2seq/beam_search_ops_test.py
@@ -21,8 +21,9 @@ import itertools
 
 import numpy as np
 
+import tensorflow as tf
+
 from tensorflow.python.framework import ops
-from tensorflow.python.platform import test
 
 from tensorflow.python.framework import load_library
 from tensorflow_addons.utils.resource_loader import get_path_to_datafile
@@ -36,7 +37,7 @@ def _transpose_batch_time(x):
     return np.transpose(x, [1, 0, 2]).astype(np.int32)
 
 
-class GatherTreeTest(test.TestCase):
+class GatherTreeTest(tf.test.TestCase):
     def testGatherTreeOne(self):
         # (max_time = 4, batch_size = 1, beams = 3)
         end_token = 10
@@ -65,8 +66,8 @@ class GatherTreeTest(test.TestCase):
                                              [-1, -1, -1]]])
         max_sequence_lengths = [3]
         with ops.device("/cpu:0"):
-            with self.assertRaisesOpError(
-                    r"parent id -1 at \(batch, time, beam\) == \(0, 0, 1\)"):
+            msg = r"parent id -1 at \(batch, time, beam\) == \(0, 0, 1\)"
+            with self.assertRaisesOpError(msg):
                 beams = gather_tree(
                     step_ids=step_ids,
                     parent_ids=parent_ids,
@@ -77,7 +78,7 @@ class GatherTreeTest(test.TestCase):
     def testBadParentValuesOnGPU(self):
         # Only want to run this test on CUDA devices, as gather_tree is not
         # registered for SYCL devices.
-        if not test.is_gpu_available(cuda_only=True):
+        if not tf.test.is_gpu_available(cuda_only=True):
             return
         # (max_time = 4, batch_size = 1, beams = 3)
         # bad parent in beam 1 time 1; appears as a negative index at time 0
@@ -143,4 +144,4 @@ class GatherTreeTest(test.TestCase):
 
 
 if __name__ == "__main__":
-    test.main()
+    tf.test.main()

--- a/tensorflow_addons/seq2seq/decoder.py
+++ b/tensorflow_addons/seq2seq/decoder.py
@@ -26,7 +26,8 @@ import tensorflow as tf
 from tensorflow.python.eager import context
 from tensorflow.python.framework import ops
 from tensorflow.python.framework import tensor_util
-from tensorflow.keras import layers
+#from tensorflow.python.keras.layers import Layer
+from tensorflow.python.keras import layers
 from tensorflow.python.ops import control_flow_util
 from tensorflow.python.ops import rnn
 from tensorflow.python.ops import rnn_cell_impl

--- a/tensorflow_addons/seq2seq/decoder.py
+++ b/tensorflow_addons/seq2seq/decoder.py
@@ -21,22 +21,16 @@ from __future__ import print_function
 import abc
 import six
 
+import tensorflow as tf
+
 from tensorflow.python.eager import context
-from tensorflow.python.framework import constant_op
-from tensorflow.python.framework import dtypes
 from tensorflow.python.framework import ops
-from tensorflow.python.framework import tensor_shape
 from tensorflow.python.framework import tensor_util
-from tensorflow.python.keras import layers
-from tensorflow.python.ops import array_ops
-from tensorflow.python.ops import control_flow_ops
+from tensorflow.keras import layers
 from tensorflow.python.ops import control_flow_util
-from tensorflow.python.ops import math_ops
 from tensorflow.python.ops import rnn
 from tensorflow.python.ops import rnn_cell_impl
-from tensorflow.python.ops import tensor_array_ops
 from tensorflow.python.ops import variable_scope
-from tensorflow.python.util import nest
 
 _transpose_batch_time = rnn._transpose_batch_time  # pylint: disable=protected-access
 _zero_state_tensors = rnn_cell_impl._zero_state_tensors  # pylint: disable=protected-access
@@ -266,7 +260,7 @@ def _create_zero_outputs(size, dtype, batch_size):
     def _create(s, d):
         return _zero_state_tensors(s, batch_size, d)
 
-    return nest.map_structure(_create, size, dtype)
+    return tf.nest.map_structure(_create, size, dtype)
 
 
 def dynamic_decode(decoder,
@@ -329,10 +323,8 @@ def dynamic_decode(decoder,
                 varscope.set_caching_device(lambda op: op.device)
 
         if maximum_iterations is not None:
-            maximum_iterations = ops.convert_to_tensor(
-                maximum_iterations,
-                dtype=dtypes.int32,
-                name="maximum_iterations")
+            maximum_iterations = tf.convert_to_tensor(
+                maximum_iterations, dtype=tf.int32, name="maximum_iterations")
             if maximum_iterations.get_shape().ndims != 0:
                 raise ValueError("maximum_iterations must be a scalar")
 
@@ -353,37 +345,36 @@ def dynamic_decode(decoder,
             raise ValueError(
                 "maximum_iterations is required for XLA compilation.")
         if maximum_iterations is not None:
-            initial_finished = math_ops.logical_or(initial_finished,
-                                                   0 >= maximum_iterations)
-        initial_sequence_lengths = array_ops.zeros_like(
-            initial_finished, dtype=dtypes.int32)
-        initial_time = constant_op.constant(0, dtype=dtypes.int32)
+            initial_finished = tf.logical_or(initial_finished,
+                                             0 >= maximum_iterations)
+        initial_sequence_lengths = tf.zeros_like(
+            initial_finished, dtype=tf.int32)
+        initial_time = tf.constant(0, dtype=tf.int32)
 
         def _shape(batch_size, from_shape):
-            if (not isinstance(from_shape, tensor_shape.TensorShape)
+            if (not isinstance(from_shape, tf.TensorShape)
                     or from_shape.ndims == 0):
                 return None
             else:
                 batch_size = tensor_util.constant_value(
-                    ops.convert_to_tensor(batch_size, name="batch_size"))
-                return tensor_shape.TensorShape(
-                    [batch_size]).concatenate(from_shape)
+                    tf.convert_to_tensor(batch_size, name="batch_size"))
+                return tf.TensorShape([batch_size]).concatenate(from_shape)
 
         dynamic_size = maximum_iterations is None or not is_xla
 
         def _create_ta(s, d):
-            return tensor_array_ops.TensorArray(
+            return tf.TensorArray(
                 dtype=d,
                 size=0 if dynamic_size else maximum_iterations,
                 dynamic_size=dynamic_size,
                 element_shape=_shape(decoder.batch_size, s))
 
-        initial_outputs_ta = nest.map_structure(
+        initial_outputs_ta = tf.nest.map_structure(
             _create_ta, decoder.output_size, decoder.output_dtype)
 
         def condition(unused_time, unused_outputs_ta, unused_state,
                       unused_inputs, finished, unused_sequence_lengths):
-            return math_ops.logical_not(math_ops.reduce_all(finished))
+            return tf.logical_not(tf.reduce_all(finished))
 
         def body(time, outputs_ta, state, inputs, finished, sequence_lengths):
             """Internal while_loop body.
@@ -406,20 +397,20 @@ def dynamic_decode(decoder,
             if decoder.tracks_own_finished:
                 next_finished = decoder_finished
             else:
-                next_finished = math_ops.logical_or(decoder_finished, finished)
-            next_sequence_lengths = array_ops.where(
-                math_ops.logical_not(finished),
-                array_ops.fill(array_ops.shape(sequence_lengths), time + 1),
+                next_finished = tf.logical_or(decoder_finished, finished)
+            next_sequence_lengths = tf.where(
+                tf.logical_not(finished),
+                tf.fill(tf.shape(sequence_lengths), time + 1),
                 sequence_lengths)
 
-            nest.assert_same_structure(state, decoder_state)
-            nest.assert_same_structure(outputs_ta, next_outputs)
-            nest.assert_same_structure(inputs, next_inputs)
+            tf.nest.assert_same_structure(state, decoder_state)
+            tf.nest.assert_same_structure(outputs_ta, next_outputs)
+            tf.nest.assert_same_structure(inputs, next_inputs)
 
             # Zero out output values past finish
             if impute_finished:
-                emit = nest.map_structure(
-                    lambda out, zero: array_ops.where(finished, zero, out),
+                emit = tf.nest.map_structure(
+                    lambda out, zero: tf.where(finished, zero, out),
                     next_outputs, zero_outputs)
             else:
                 emit = next_outputs
@@ -427,26 +418,25 @@ def dynamic_decode(decoder,
             # Copy through states past finish
             def _maybe_copy_state(new, cur):
                 # TensorArrays and scalar states get passed through.
-                if isinstance(cur, tensor_array_ops.TensorArray):
+                if isinstance(cur, tf.TensorArray):
                     pass_through = True
                 else:
                     new.set_shape(cur.shape)
                     pass_through = (new.shape.ndims == 0)
-                return new if pass_through else array_ops.where(
-                    finished, cur, new)
+                return new if pass_through else tf.where(finished, cur, new)
 
             if impute_finished:
-                next_state = nest.map_structure(_maybe_copy_state,
-                                                decoder_state, state)
+                next_state = tf.nest.map_structure(_maybe_copy_state,
+                                                   decoder_state, state)
             else:
                 next_state = decoder_state
 
-            outputs_ta = nest.map_structure(
+            outputs_ta = tf.nest.map_structure(
                 lambda ta, out: ta.write(time, out), outputs_ta, emit)
             return (time + 1, outputs_ta, next_state, next_inputs,
                     next_finished, next_sequence_lengths)
 
-        res = control_flow_ops.while_loop(
+        res = tf.compat.v1.while_loop(
             condition,
             body,
             loop_vars=(
@@ -465,8 +455,8 @@ def dynamic_decode(decoder,
         final_state = res[2]
         final_sequence_lengths = res[5]
 
-        final_outputs = nest.map_structure(lambda ta: ta.stack(),
-                                           final_outputs_ta)
+        final_outputs = tf.nest.map_structure(lambda ta: ta.stack(),
+                                              final_outputs_ta)
 
         try:
             final_outputs, final_state = decoder.finalize(
@@ -475,7 +465,7 @@ def dynamic_decode(decoder,
             pass
 
         if not output_time_major:
-            final_outputs = nest.map_structure(_transpose_batch_time,
-                                               final_outputs)
+            final_outputs = tf.nest.map_structure(_transpose_batch_time,
+                                                  final_outputs)
 
     return final_outputs, final_state, final_sequence_lengths

--- a/tensorflow_addons/seq2seq/decoder_test.py
+++ b/tensorflow_addons/seq2seq/decoder_test.py
@@ -18,21 +18,18 @@ from __future__ import division
 from __future__ import print_function
 
 import numpy as np
+import tensorflow as tf
 
 from tensorflow_addons.seq2seq import basic_decoder
 from tensorflow_addons.seq2seq import sampler as sampler_py
 from tensorflow.python.eager import context
-from tensorflow.python.framework import constant_op
-from tensorflow.python.framework import dtypes
 from tensorflow.python.keras import keras_parameterized
 from tensorflow.python.ops import rnn
 from tensorflow.python.ops import rnn_cell
-from tensorflow.python.ops import variables
-from tensorflow.python.platform import test
 
 
 @keras_parameterized.run_all_keras_modes
-class DecodeRNNTest(keras_parameterized.TestCase, test.TestCase):
+class DecodeRNNTest(keras_parameterized.TestCase, tf.test.TestCase):
     """Tests for Decoder."""
 
     def _testDecodeRNN(self, time_major, maximum_iterations=None):
@@ -51,7 +48,7 @@ class DecodeRNNTest(keras_parameterized.TestCase, test.TestCase):
             else:
                 inputs = np.random.randn(batch_size, max_time,
                                          input_depth).astype(np.float32)
-            input_t = constant_op.constant(inputs)
+            input_t = tf.constant(inputs)
             cell = rnn_cell.LSTMCell(cell_depth)
             sampler = sampler_py.TrainingSampler(time_major=time_major)
             my_decoder = basic_decoder.BasicDecoder(
@@ -61,7 +58,7 @@ class DecodeRNNTest(keras_parameterized.TestCase, test.TestCase):
                 maximum_iterations=maximum_iterations)
 
             initial_state = cell.zero_state(
-                dtype=dtypes.float32, batch_size=batch_size)
+                dtype=tf.float32, batch_size=batch_size)
             (final_outputs, unused_final_state,
              final_sequence_length) = my_decoder(
                  input_t,
@@ -84,7 +81,7 @@ class DecodeRNNTest(keras_parameterized.TestCase, test.TestCase):
                     _t((batch_size, None)),
                     tuple(final_outputs.sample_id.get_shape().as_list()))
 
-            self.evaluate(variables.global_variables_initializer())
+            self.evaluate(tf.compat.v1.global_variables_initializer())
             final_outputs = self.evaluate(final_outputs)
             final_sequence_length = self.evaluate(final_sequence_length)
 
@@ -129,11 +126,11 @@ class DecodeRNNTest(keras_parameterized.TestCase, test.TestCase):
         with self.cached_session(use_gpu=True):
             inputs = np.random.randn(batch_size, max_time,
                                      input_depth).astype(np.float32)
-            inputs = constant_op.constant(inputs)
+            inputs = tf.constant(inputs)
 
             cell = rnn_cell.LSTMCell(cell_depth)
             zero_state = cell.zero_state(
-                dtype=dtypes.float32, batch_size=batch_size)
+                dtype=tf.float32, batch_size=batch_size)
             sampler = sampler_py.TrainingSampler()
             my_decoder = basic_decoder.BasicDecoder(
                 cell=cell,
@@ -152,7 +149,7 @@ class DecodeRNNTest(keras_parameterized.TestCase, test.TestCase):
                 if use_sequence_length else None,
                 initial_state=zero_state)
 
-            self.evaluate(variables.global_variables_initializer())
+            self.evaluate(tf.compat.v1.global_variables_initializer())
             eval_result = self.evaluate({
                 "final_decoder_outputs": final_decoder_outputs,
                 "final_decoder_state": final_decoder_state,
@@ -181,4 +178,4 @@ class DecodeRNNTest(keras_parameterized.TestCase, test.TestCase):
 
 
 if __name__ == "__main__":
-    test.main()
+    tf.test.main()

--- a/tensorflow_addons/seq2seq/loss.py
+++ b/tensorflow_addons/seq2seq/loss.py
@@ -103,8 +103,7 @@ def sequence_loss(logits,
         raise ValueError(
             "average_across_batch and sum_over_batch cannot be set "
             "to True at same time.")
-    with tf.name_scope(name
-                       or "sequence_loss"):  #, [logits, targets, weights]):
+    with tf.name_scope(name or "sequence_loss"):
         num_classes = tf.shape(input=logits)[2]
         logits_flat = tf.reshape(logits, [-1, num_classes])
         targets = tf.reshape(targets, [-1])

--- a/tensorflow_addons/seq2seq/loss_test.py
+++ b/tensorflow_addons/seq2seq/loss_test.py
@@ -19,36 +19,34 @@ from __future__ import print_function
 
 import numpy as np
 
-from tensorflow.python.framework import constant_op
-from tensorflow.python.framework import dtypes
-from tensorflow.python.framework import test_util
-from tensorflow.python.ops import array_ops
-from tensorflow.python.platform import test
+import tensorflow as tf
+
 from tensorflow_addons.seq2seq import loss
+from tensorflow_addons.utils import test_utils
 
 
-@test_util.run_all_in_graph_and_eager_modes
-class LossTest(test.TestCase):
+@test_utils.run_all_in_graph_and_eager_modes
+class LossTest(tf.test.TestCase):
     def setup(self):
         self.batch_size = 2
         self.sequence_length = 3
         self.number_of_classes = 5
         logits = [
-            constant_op.constant(
+            tf.constant(
                 i + 0.5, shape=[self.batch_size, self.number_of_classes])
             for i in range(self.sequence_length)
         ]
-        self.logits = array_ops.stack(logits, axis=1)
+        self.logits = tf.stack(logits, axis=1)
         targets = [
-            constant_op.constant(i, dtypes.int32, shape=[self.batch_size])
+            tf.constant(i, tf.int32, shape=[self.batch_size])
             for i in range(self.sequence_length)
         ]
-        self.targets = array_ops.stack(targets, axis=1)
+        self.targets = tf.stack(targets, axis=1)
         weights = [
-            constant_op.constant(1.0, shape=[self.batch_size])
+            tf.constant(1.0, shape=[self.batch_size])
             for _ in range(self.sequence_length)
         ]
-        self.weights = array_ops.stack(weights, axis=1)
+        self.weights = tf.stack(weights, axis=1)
         # expected_loss = sparse_softmax_cross_entropy_with_logits(targets,
         # logits) where targets = [0, 1, 2],
         # and logits = [[0.5] * 5, [1.5] * 5, [2.5] * 5]
@@ -195,12 +193,12 @@ class LossTest(test.TestCase):
     def testWeightedSumReduction(self):
         self.setup()
         weights = [
-            constant_op.constant(1.0, shape=[self.batch_size])
+            tf.constant(1.0, shape=[self.batch_size])
             for _ in range(self.sequence_length)
         ]
         # Make the last element in the sequence to have zero weights.
-        weights[-1] = constant_op.constant(0.0, shape=[self.batch_size])
-        self.weights = array_ops.stack(weights, axis=1)
+        weights[-1] = tf.constant(0.0, shape=[self.batch_size])
+        self.weights = tf.stack(weights, axis=1)
         with self.cached_session(use_gpu=True):
             seq_loss = loss.SequenceLoss(
                 average_across_timesteps=False,
@@ -255,10 +253,10 @@ class LossTest(test.TestCase):
     def testZeroWeights(self):
         self.setup()
         weights = [
-            constant_op.constant(0.0, shape=[self.batch_size])
+            tf.constant(0.0, shape=[self.batch_size])
             for _ in range(self.sequence_length)
         ]
-        weights = array_ops.stack(weights, axis=1)
+        weights = tf.stack(weights, axis=1)
         with self.test_session(use_gpu=True):
             average_loss_per_example = loss.sequence_loss(
                 self.logits,
@@ -301,4 +299,4 @@ class LossTest(test.TestCase):
 
 
 if __name__ == '__main__':
-    test.main()
+    tf.test.main()

--- a/tensorflow_addons/seq2seq/sampler.py
+++ b/tensorflow_addons/seq2seq/sampler.py
@@ -692,7 +692,7 @@ class InferenceSampler(Sampler):
 # categorical_sample) mimic TensorFlow Probability distribution semantics.
 def _call_sampler(sample_n_fn, sample_shape, name=None):
     """Reshapes vector of samples."""
-    with tf.name_scope(name or "call_sampler"):  #, values=[sample_shape]):
+    with tf.name_scope(name or "call_sampler"):
         sample_shape = tf.convert_to_tensor(
             sample_shape, dtype=tf.int32, name="sample_shape")
         # Ensure sample_shape is a vector (vs just a scalar).

--- a/tensorflow_addons/seq2seq/sampler.py
+++ b/tensorflow_addons/seq2seq/sampler.py
@@ -22,18 +22,9 @@ import abc
 
 import six
 
+import tensorflow as tf
+
 from tensorflow_addons.seq2seq import decoder
-from tensorflow.python.framework import dtypes
-from tensorflow.python.framework import ops
-from tensorflow.python.framework import tensor_shape
-from tensorflow.python.ops import array_ops
-from tensorflow.python.ops import control_flow_ops
-from tensorflow.python.ops import embedding_ops
-from tensorflow.python.ops import gen_array_ops
-from tensorflow.python.ops import math_ops
-from tensorflow.python.ops import random_ops
-from tensorflow.python.ops import tensor_array_ops
-from tensorflow.python.util import nest
 
 _transpose_batch_time = decoder._transpose_batch_time  # pylint: disable=protected-access
 
@@ -142,9 +133,8 @@ class CustomSampler(Sampler):
         self._sample_fn = sample_fn
         self._next_inputs_fn = next_inputs_fn
         self._batch_size = None
-        self._sample_ids_shape = tensor_shape.TensorShape(sample_ids_shape
-                                                          or [])
-        self._sample_ids_dtype = sample_ids_dtype or dtypes.int32
+        self._sample_ids_shape = tf.TensorShape(sample_ids_shape or [])
+        self._sample_ids_dtype = sample_ids_dtype or tf.int32
 
     @property
     def batch_size(self):
@@ -164,7 +154,7 @@ class CustomSampler(Sampler):
     def initialize(self, inputs, **kwargs):
         (finished, next_inputs) = self._initialize_fn(inputs, **kwargs)
         if self._batch_size is None:
-            self._batch_size = array_ops.size(finished)
+            self._batch_size = tf.size(finished)
         return (finished, next_inputs)
 
     def sample(self, time, outputs, state):
@@ -205,11 +195,11 @@ class TrainingSampler(Sampler):
 
     @property
     def sample_ids_shape(self):
-        return tensor_shape.TensorShape([])
+        return tf.TensorShape([])
 
     @property
     def sample_ids_dtype(self):
-        return dtypes.int32
+        return tf.int32
 
     def initialize(self, inputs, sequence_length=None):
         """Initialize the TrainSampler.
@@ -224,50 +214,49 @@ class TrainingSampler(Sampler):
             finished. The second item is the first slide of input data based on
             the timestep dimension (usually the second dim of the input).
         """
-        self.inputs = ops.convert_to_tensor(inputs, name="inputs")
+        self.inputs = tf.convert_to_tensor(inputs, name="inputs")
         if not self.time_major:
-            inputs = nest.map_structure(_transpose_batch_time, inputs)
+            inputs = tf.nest.map_structure(_transpose_batch_time, inputs)
 
-        self.input_tas = nest.map_structure(_unstack_ta, inputs)
+        self.input_tas = tf.nest.map_structure(_unstack_ta, inputs)
         if sequence_length is None:
             raise ValueError("sequence_length is required for TrainingSampler")
-        self.sequence_length = ops.convert_to_tensor(
+        self.sequence_length = tf.convert_to_tensor(
             sequence_length, name="sequence_length")
         if self.sequence_length.get_shape().ndims != 1:
             raise ValueError(
                 "Expected sequence_length to be vector, but received shape: %s"
                 % self._sequence_length.get_shape())
 
-        self.zero_inputs = nest.map_structure(
-            lambda inp: array_ops.zeros_like(inp[0, :]), inputs)
+        self.zero_inputs = tf.nest.map_structure(
+            lambda inp: tf.zeros_like(inp[0, :]), inputs)
 
-        self._batch_size = array_ops.size(self.sequence_length)
+        self._batch_size = tf.size(self.sequence_length)
 
-        finished = math_ops.equal(0, self.sequence_length)
-        all_finished = math_ops.reduce_all(finished)
-        next_inputs = control_flow_ops.cond(
-            all_finished, lambda: self.zero_inputs, lambda: nest.map_structure(
-                lambda inp: inp.read(0), self.input_tas))
+        finished = tf.equal(0, self.sequence_length)
+        all_finished = tf.reduce_all(finished)
+        next_inputs = tf.cond(
+            all_finished, lambda: self.zero_inputs, lambda: tf.nest.
+            map_structure(lambda inp: inp.read(0), self.input_tas))
         return (finished, next_inputs)
 
     def sample(self, time, outputs, state):
         del state
-        sample_ids = math_ops.cast(
-            math_ops.argmax(outputs, axis=-1), dtypes.int32)
+        sample_ids = tf.cast(tf.argmax(outputs, axis=-1), tf.int32)
         return sample_ids
 
     def next_inputs(self, time, outputs, state, sample_ids):
         del sample_ids
         next_time = time + 1
         finished = (next_time >= self.sequence_length)
-        all_finished = math_ops.reduce_all(finished)
+        all_finished = tf.reduce_all(finished)
 
         def read_from_ta(inp):
             return inp.read(next_time)
 
-        next_inputs = control_flow_ops.cond(
-            all_finished, lambda: self.zero_inputs, lambda: nest.map_structure(
-                read_from_ta, self.input_tas))
+        next_inputs = tf.cond(
+            all_finished, lambda: self.zero_inputs, lambda: tf.nest.
+            map_structure(read_from_ta, self.input_tas))
         return (finished, next_inputs, state)
 
 
@@ -305,7 +294,7 @@ class ScheduledEmbeddingTrainingSampler(TrainingSampler):
         else:
             raise ValueError("embedding_fn is expected to be callable, got %s"
                              % type(embedding_fn))
-        self.sampling_probability = ops.convert_to_tensor(
+        self.sampling_probability = tf.convert_to_tensor(
             sampling_probability, name="sampling_probability")
         if self.sampling_probability.get_shape().ndims not in (0, 1):
             raise ValueError(
@@ -323,7 +312,7 @@ class ScheduledEmbeddingTrainingSampler(TrainingSampler):
                     "embedding is required as a keyword argument for "
                     "ScheduledEmbeddingTrainingSampler")
             self.embedding_fn = (
-                lambda ids: embedding_ops.embedding_lookup(embedding, ids))
+                lambda ids: tf.nn.embedding_lookup(embedding, ids))
         return super(ScheduledEmbeddingTrainingSampler, self).initialize(
             inputs, sequence_length=sequence_length)
 
@@ -332,12 +321,12 @@ class ScheduledEmbeddingTrainingSampler(TrainingSampler):
         # Return -1s where we did not sample, and sample_ids elsewhere
         select_sample = bernoulli_sample(
             probs=self.sampling_probability,
-            dtype=dtypes.bool,
+            dtype=tf.bool,
             sample_shape=self.batch_size,
             seed=self.scheduling_seed)
-        return array_ops.where(
-            select_sample, categorical_sample(logits=outputs, seed=self.seed),
-            gen_array_ops.fill([self.batch_size], -1))
+        return tf.where(select_sample,
+                        categorical_sample(logits=outputs, seed=self.seed),
+                        tf.fill([self.batch_size], -1))
 
     def next_inputs(self, time, outputs, state, sample_ids):
         (finished, base_next_inputs,
@@ -346,27 +335,24 @@ class ScheduledEmbeddingTrainingSampler(TrainingSampler):
 
         def maybe_sample():
             """Perform scheduled sampling."""
-            where_sampling = math_ops.cast(
-                array_ops.where(sample_ids > -1), dtypes.int32)
-            where_not_sampling = math_ops.cast(
-                array_ops.where(sample_ids <= -1), dtypes.int32)
-            sample_ids_sampling = array_ops.gather_nd(sample_ids,
-                                                      where_sampling)
-            inputs_not_sampling = array_ops.gather_nd(base_next_inputs,
-                                                      where_not_sampling)
+            where_sampling = tf.cast(tf.where(sample_ids > -1), tf.int32)
+            where_not_sampling = tf.cast(tf.where(sample_ids <= -1), tf.int32)
+            sample_ids_sampling = tf.gather_nd(sample_ids, where_sampling)
+            inputs_not_sampling = tf.gather_nd(base_next_inputs,
+                                               where_not_sampling)
             sampled_next_inputs = self.embedding_fn(sample_ids_sampling)
-            base_shape = array_ops.shape(base_next_inputs)
-            return (array_ops.scatter_nd(
+            base_shape = tf.shape(base_next_inputs)
+            return (tf.scatter_nd(
                 indices=where_sampling,
                 updates=sampled_next_inputs,
-                shape=base_shape) + array_ops.scatter_nd(
+                shape=base_shape) + tf.scatter_nd(
                     indices=where_not_sampling,
                     updates=inputs_not_sampling,
                     shape=base_shape))
 
-        all_finished = math_ops.reduce_all(finished)
-        next_inputs = control_flow_ops.cond(
-            all_finished, lambda: base_next_inputs, maybe_sample)
+        all_finished = tf.reduce_all(finished)
+        next_inputs = tf.cond(all_finished, lambda: base_next_inputs,
+                              maybe_sample)
         return (finished, next_inputs, state)
 
 
@@ -398,7 +384,7 @@ class ScheduledOutputTrainingSampler(TrainingSampler):
         Raises:
           ValueError: if `sampling_probability` is not a scalar or vector.
         """
-        self.sampling_probability = ops.convert_to_tensor(
+        self.sampling_probability = tf.convert_to_tensor(
             sampling_probability, name="sampling_probability")
         if self.sampling_probability.get_shape().ndims not in (0, 1):
             raise ValueError(
@@ -415,16 +401,15 @@ class ScheduledOutputTrainingSampler(TrainingSampler):
         if auxiliary_inputs is None:
             maybe_concatenated_inputs = inputs
         else:
-            inputs = ops.convert_to_tensor(inputs)
-            auxiliary_inputs = ops.convert_to_tensor(auxiliary_inputs)
-            maybe_concatenated_inputs = nest.map_structure(
-                lambda x, y: array_ops.concat((x, y), -1), inputs,
-                auxiliary_inputs)
+            inputs = tf.convert_to_tensor(inputs)
+            auxiliary_inputs = tf.convert_to_tensor(auxiliary_inputs)
+            maybe_concatenated_inputs = tf.nest.map_structure(
+                lambda x, y: tf.concat((x, y), -1), inputs, auxiliary_inputs)
             if not self.time_major:
-                auxiliary_inputs = nest.map_structure(_transpose_batch_time,
-                                                      auxiliary_inputs)
+                auxiliary_inputs = tf.nest.map_structure(
+                    _transpose_batch_time, auxiliary_inputs)
         if auxiliary_inputs is not None:
-            self._auxiliary_input_tas = nest.map_structure(
+            self._auxiliary_input_tas = tf.nest.map_structure(
                 _unstack_ta, auxiliary_inputs)
         else:
             self._auxiliary_input_tas = None
@@ -443,7 +428,7 @@ class ScheduledOutputTrainingSampler(TrainingSampler):
         (finished, base_next_inputs,
          state) = (super(ScheduledOutputTrainingSampler, self).next_inputs(
              time=time, outputs=outputs, state=state, sample_ids=sample_ids))
-        sample_ids = math_ops.cast(sample_ids, dtypes.bool)
+        sample_ids = tf.cast(sample_ids, tf.bool)
 
         def maybe_sample():
             """Perform scheduled sampling."""
@@ -454,45 +439,41 @@ class ScheduledOutputTrainingSampler(TrainingSampler):
                     return outputs_
 
                 next_time = time + 1
-                auxiliary_inputs = nest.map_structure(
+                auxiliary_inputs = tf.nest.map_structure(
                     lambda ta: ta.read(next_time), self._auxiliary_input_tas)
                 if indices is not None:
-                    auxiliary_inputs = array_ops.gather_nd(
-                        auxiliary_inputs, indices)
-                return nest.map_structure(
-                    lambda x, y: array_ops.concat((x, y), -1), outputs_,
+                    auxiliary_inputs = tf.gather_nd(auxiliary_inputs, indices)
+                return tf.nest.map_structure(
+                    lambda x, y: tf.concat((x, y), -1), outputs_,
                     auxiliary_inputs)
 
             if self.next_inputs_fn is None:
-                return array_ops.where(
-                    sample_ids, maybe_concatenate_auxiliary_inputs(outputs),
-                    base_next_inputs)
+                return tf.where(sample_ids,
+                                maybe_concatenate_auxiliary_inputs(outputs),
+                                base_next_inputs)
 
-            where_sampling = math_ops.cast(
-                array_ops.where(sample_ids), dtypes.int32)
-            where_not_sampling = math_ops.cast(
-                array_ops.where(math_ops.logical_not(sample_ids)),
-                dtypes.int32)
-            outputs_sampling = array_ops.gather_nd(outputs, where_sampling)
-            inputs_not_sampling = array_ops.gather_nd(base_next_inputs,
-                                                      where_not_sampling)
+            where_sampling = tf.cast(tf.where(sample_ids), tf.int32)
+            where_not_sampling = tf.cast(
+                tf.where(tf.logical_not(sample_ids)), tf.int32)
+            outputs_sampling = tf.gather_nd(outputs, where_sampling)
+            inputs_not_sampling = tf.gather_nd(base_next_inputs,
+                                               where_not_sampling)
             sampled_next_inputs = maybe_concatenate_auxiliary_inputs(
                 self.next_inputs_fn(outputs_sampling), where_sampling)
 
-            base_shape = array_ops.shape(base_next_inputs)
-            return (array_ops.scatter_nd(
+            base_shape = tf.shape(base_next_inputs)
+            return (tf.scatter_nd(
                 indices=where_sampling,
                 updates=sampled_next_inputs,
-                shape=base_shape) + array_ops.scatter_nd(
+                shape=base_shape) + tf.scatter_nd(
                     indices=where_not_sampling,
                     updates=inputs_not_sampling,
                     shape=base_shape))
 
-        all_finished = math_ops.reduce_all(finished)
-        no_samples = math_ops.logical_not(math_ops.reduce_any(sample_ids))
-        next_inputs = control_flow_ops.cond(
-            math_ops.logical_or(all_finished,
-                                no_samples), lambda: base_next_inputs,
+        all_finished = tf.reduce_all(finished)
+        no_samples = tf.logical_not(tf.reduce_any(sample_ids))
+        next_inputs = tf.cond(
+            tf.logical_or(all_finished, no_samples), lambda: base_next_inputs,
             maybe_sample)
         return (finished, next_inputs, state)
 
@@ -511,7 +492,7 @@ class GreedyEmbeddingSampler(Sampler):
           embedding_fn: A optional callable that takes a vector tensor of `ids`
             (argmax ids), or the `params` argument for `embedding_lookup`. The
             returned tensor will be passed to the decoder input. Default to use
-            `embedding_ops.embedding_lookup`.
+            `tf.nn.embedding_lookup`.
         """
         if embedding_fn is None or callable(embedding_fn):
             self.embedding_fn = embedding_fn
@@ -530,11 +511,11 @@ class GreedyEmbeddingSampler(Sampler):
 
     @property
     def sample_ids_shape(self):
-        return tensor_shape.TensorShape([])
+        return tf.TensorShape([])
 
     @property
     def sample_ids_dtype(self):
-        return dtypes.int32
+        return tf.int32
 
     def initialize(self, embedding, start_tokens=None, end_token=None):
         """Initialize the GreedyEmbeddingSampler.
@@ -555,39 +536,38 @@ class GreedyEmbeddingSampler(Sampler):
         """
         if self.embedding_fn is None:
             self.embedding_fn = (
-                lambda ids: embedding_ops.embedding_lookup(embedding, ids))
+                lambda ids: tf.nn.embedding_lookup(embedding, ids))
 
-        self.start_tokens = ops.convert_to_tensor(
-            start_tokens, dtype=dtypes.int32, name="start_tokens")
-        self.end_token = ops.convert_to_tensor(
-            end_token, dtype=dtypes.int32, name="end_token")
+        self.start_tokens = tf.convert_to_tensor(
+            start_tokens, dtype=tf.int32, name="start_tokens")
+        self.end_token = tf.convert_to_tensor(
+            end_token, dtype=tf.int32, name="end_token")
         if self.start_tokens.get_shape().ndims != 1:
             raise ValueError("start_tokens must be a vector")
-        self._batch_size = array_ops.size(start_tokens)
+        self._batch_size = tf.size(start_tokens)
         if self.end_token.get_shape().ndims != 0:
             raise ValueError("end_token must be a scalar")
         self.start_inputs = self.embedding_fn(self.start_tokens)
 
-        finished = array_ops.tile([False], [self._batch_size])
+        finished = tf.tile([False], [self._batch_size])
         return (finished, self.start_inputs)
 
     def sample(self, time, outputs, state):
         """sample for GreedyEmbeddingHelper."""
         del time, state  # unused by sample_fn
         # Outputs are logits, use argmax to get the most probable id
-        if not isinstance(outputs, ops.Tensor):
+        if not isinstance(outputs, tf.Tensor):
             raise TypeError("Expected outputs to be a single Tensor, got: %s" %
                             type(outputs))
-        sample_ids = math_ops.argmax(
-            outputs, axis=-1, output_type=dtypes.int32)
+        sample_ids = tf.argmax(outputs, axis=-1, output_type=tf.int32)
         return sample_ids
 
     def next_inputs(self, time, outputs, state, sample_ids):
         """next_inputs_fn for GreedyEmbeddingHelper."""
         del time, outputs  # unused by next_inputs_fn
-        finished = math_ops.equal(sample_ids, self.end_token)
-        all_finished = math_ops.reduce_all(finished)
-        next_inputs = control_flow_ops.cond(
+        finished = tf.equal(sample_ids, self.end_token)
+        all_finished = tf.reduce_all(finished)
+        next_inputs = tf.cond(
             all_finished,
             # If we're finished, the next_inputs value doesn't matter
             lambda: self.start_inputs,
@@ -629,7 +609,7 @@ class SampleEmbeddingSampler(GreedyEmbeddingSampler):
         """sample for SampleEmbeddingHelper."""
         del time, state  # unused by sample_fn
         # Outputs are logits, we sample instead of argmax (greedy).
-        if not isinstance(outputs, ops.Tensor):
+        if not isinstance(outputs, tf.Tensor):
             raise TypeError("Expected outputs to be a single Tensor, got: %s" %
                             type(outputs))
         if self.softmax_temperature is None:
@@ -666,7 +646,7 @@ class InferenceSampler(Sampler):
             used as the next batch of inputs.
         """
         self.sample_fn = sample_fn
-        self.sample_shape = tensor_shape.TensorShape(sample_shape)
+        self.sample_shape = tf.TensorShape(sample_shape)
         self.sample_dtype = sample_dtype
         self.end_fn = end_fn
         self.next_inputs_fn = next_inputs_fn
@@ -688,10 +668,10 @@ class InferenceSampler(Sampler):
         return self.sample_dtype
 
     def initialize(self, start_inputs):
-        self.start_inputs = ops.convert_to_tensor(
+        self.start_inputs = tf.convert_to_tensor(
             start_inputs, name="start_inputs")
-        self._batch_size = array_ops.shape(start_inputs)[0]
-        finished = array_ops.tile([False], [self._batch_size])
+        self._batch_size = tf.shape(start_inputs)[0]
+        finished = tf.tile([False], [self._batch_size])
         return (finished, self.start_inputs)
 
     def sample(self, time, outputs, state):
@@ -712,71 +692,68 @@ class InferenceSampler(Sampler):
 # categorical_sample) mimic TensorFlow Probability distribution semantics.
 def _call_sampler(sample_n_fn, sample_shape, name=None):
     """Reshapes vector of samples."""
-    with ops.name_scope(name, "call_sampler", values=[sample_shape]):
-        sample_shape = ops.convert_to_tensor(
-            sample_shape, dtype=dtypes.int32, name="sample_shape")
+    with tf.name_scope(name or "call_sampler"):  #, values=[sample_shape]):
+        sample_shape = tf.convert_to_tensor(
+            sample_shape, dtype=tf.int32, name="sample_shape")
         # Ensure sample_shape is a vector (vs just a scalar).
-        pad = math_ops.cast(
-            math_ops.equal(array_ops.rank(sample_shape), 0), dtypes.int32)
-        sample_shape = array_ops.reshape(
+        pad = tf.cast(tf.equal(tf.rank(sample_shape), 0), tf.int32)
+        sample_shape = tf.reshape(
             sample_shape,
-            array_ops.pad(
-                array_ops.shape(sample_shape),
-                paddings=[[pad, 0]],
+            tf.pad(
+                tf.shape(sample_shape), paddings=[[pad, 0]],
                 constant_values=1))
-        samples = sample_n_fn(math_ops.reduce_prod(sample_shape))
-        batch_event_shape = array_ops.shape(samples)[1:]
-        final_shape = array_ops.concat([sample_shape, batch_event_shape], 0)
-        return array_ops.reshape(samples, final_shape)
+        samples = sample_n_fn(tf.reduce_prod(sample_shape))
+        batch_event_shape = tf.shape(samples)[1:]
+        final_shape = tf.concat([sample_shape, batch_event_shape], 0)
+        return tf.reshape(samples, final_shape)
 
 
 def bernoulli_sample(probs=None,
                      logits=None,
-                     dtype=dtypes.int32,
+                     dtype=tf.int32,
                      sample_shape=(),
                      seed=None):
     """Samples from Bernoulli distribution."""
     if probs is None:
-        probs = math_ops.sigmoid(logits, name="probs")
+        probs = tf.sigmoid(logits, name="probs")
     else:
-        probs = ops.convert_to_tensor(probs, name="probs")
-    batch_shape_tensor = array_ops.shape(probs)
+        probs = tf.convert_to_tensor(probs, name="probs")
+    batch_shape_tensor = tf.shape(probs)
 
     def _sample_n(n):
         """Sample vector of Bernoullis."""
-        new_shape = array_ops.concat([[n], batch_shape_tensor], 0)
-        uniform = random_ops.random_uniform(
+        new_shape = tf.concat([[n], batch_shape_tensor], 0)
+        uniform = tf.compat.v1.random_uniform(
             new_shape, seed=seed, dtype=probs.dtype)
-        return math_ops.cast(math_ops.less(uniform, probs), dtype)
+        return tf.cast(tf.less(uniform, probs), dtype)
 
     return _call_sampler(_sample_n, sample_shape)
 
 
-def categorical_sample(logits, dtype=dtypes.int32, sample_shape=(), seed=None):
+def categorical_sample(logits, dtype=tf.int32, sample_shape=(), seed=None):
     """Samples from categorical distribution."""
-    logits = ops.convert_to_tensor(logits, name="logits")
-    event_size = array_ops.shape(logits)[-1]
-    batch_shape_tensor = array_ops.shape(logits)[:-1]
+    logits = tf.convert_to_tensor(logits, name="logits")
+    event_size = tf.shape(logits)[-1]
+    batch_shape_tensor = tf.shape(logits)[:-1]
 
     def _sample_n(n):
         """Sample vector of categoricals."""
         if logits.shape.ndims == 2:
             logits_2d = logits
         else:
-            logits_2d = array_ops.reshape(logits, [-1, event_size])
-        sample_dtype = dtypes.int64 if logits.dtype.size > 4 else dtypes.int32
-        draws = random_ops.multinomial(
+            logits_2d = tf.reshape(logits, [-1, event_size])
+        sample_dtype = tf.int64 if logits.dtype.size > 4 else tf.int32
+        draws = tf.compat.v1.multinomial(
             logits_2d, n, seed=seed, output_dtype=sample_dtype)
-        draws = array_ops.reshape(
-            array_ops.transpose(draws),
-            array_ops.concat([[n], batch_shape_tensor], 0))
-        return math_ops.cast(draws, dtype)
+        draws = tf.reshape(
+            tf.transpose(draws), tf.concat([[n], batch_shape_tensor], 0))
+        return tf.cast(draws, dtype)
 
     return _call_sampler(_sample_n, sample_shape)
 
 
 def _unstack_ta(inp):
-    return tensor_array_ops.TensorArray(
+    return tf.TensorArray(
         dtype=inp.dtype,
-        size=array_ops.shape(inp)[0],
+        size=tf.shape(inp)[0],
         element_shape=inp.get_shape()[1:]).unstack(inp)


### PR DESCRIPTION
- as per #134, replaces calls with TF2 public API
- TODO: replace v1 / compat.v1 constructs with v2
- TODO: `my_decoder is not callable` produced by pylint for decoder_test.py:63,140
- dense_image_warp_tests are failing - fixing them was not part of this pull request