### PR TITLE
Utilize current TF2 nightly

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,1 @@
-tf-nightly-2.0-preview==2.0.0.dev20190405
+tf-nightly-2.0-preview


### PR DESCRIPTION
Starting the PR to unpin tf-nightly and resume testing against latest build. It looks as though the protobuf error we had will be fixed in tomorrows nightly.