### PR TITLE
CLN: Simplify Build Script

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,8 +88,6 @@ bazel-bin/build_pip_pkg artifacts
 pip install artifacts/tensorflow_addons-*.whl
 ```
 
-**Notice**: If you are using Mac OS X, you need install addition software by `brew install coreutils` (this requires the [Homebrew](https://brew.sh/)) or `port install coreutils` (this requires the [MacPorts](https://www.macports.org/))
-
 ## Contributing
 TF-Addons is a community led open source project. As such, the project
 depends on public contributions, bug-fixes, and documentation. Please

--- a/build_pip_pkg.sh
+++ b/build_pip_pkg.sh
@@ -21,6 +21,7 @@ PIP_FILE_PREFIX="bazel-bin/build_pip_pkg.runfiles/__main__/"
 function abspath() {
   cd $(dirname $1)
   echo $PWD/$(basename $1)
+  cd $OLDPWD
 }
 
 function main() {

--- a/build_pip_pkg.sh
+++ b/build_pip_pkg.sh
@@ -19,9 +19,9 @@ set -x
 PIP_FILE_PREFIX="bazel-bin/build_pip_pkg.runfiles/__main__/"
 
 function abspath() {
-  cd $(dirname $1)
-  echo $PWD/$(basename $1)
-  cd $OLDPWD
+  cd "$(dirname $1)"
+  echo "$PWD/$(basename $1)"
+  cd "$OLDPWD"
 }
 
 function main() {

--- a/build_pip_pkg.sh
+++ b/build_pip_pkg.sh
@@ -16,44 +16,26 @@
 set -e
 set -x
 
-PLATFORM="$(uname -s | tr 'A-Z' 'a-z')"
-
 PIP_FILE_PREFIX="bazel-bin/build_pip_pkg.runfiles/__main__/"
 
-if [[ ${PLATFORM} == "darwin" ]]; then
-    READLINK="greadlink"  # from pkg `coreutils` in brew/macports in Mac OS X
-else
-    READLINK="readlink"
-fi
-
+function abspath() {
+  cd $(dirname $1)
+  echo $PWD/$(basename $1)
+}
 
 function main() {
-  while [[ ! -z "${1}" ]]; do
-    if [[ ${1} == "make" ]]; then
-      echo "Using Makefile to build pip package."
-      PIP_FILE_PREFIX=""
-    else
-      DEST=${1}
-    fi
-    shift
-  done
-
+  DEST=${1}
   if [[ -z ${DEST} ]]; then
     echo "No destination dir provided"
     exit 1
   fi
 
-  # Create the directory, then do dirname on a non-existent file inside it to
-  # give us an absolute paths with tilde characters resolved to the destination
-  # directory.
   mkdir -p ${DEST}
-  DEST=$(${READLINK} -f "${DEST}")
+  DEST=$(abspath "${DEST}")
   echo "=== destination directory: ${DEST}"
 
   TMPDIR=$(mktemp -d -t tmp.XXXXXXXXXX)
-
   echo $(date) : "=== Using tmpdir: ${TMPDIR}"
-
   echo "=== Copy TensorFlow Addons files"
 
   cp ${PIP_FILE_PREFIX}setup.py "${TMPDIR}"

--- a/tensorflow_addons/version.py
+++ b/tensorflow_addons/version.py
@@ -19,7 +19,7 @@ from __future__ import print_function
 
 # We follow Semantic Versioning (https://semver.org/)
 _MAJOR_VERSION = '0'
-_MINOR_VERSION = '2'
+_MINOR_VERSION = '3'
 _PATCH_VERSION = '0'
 
 # When building releases, we can update this value on the release branch to


### PR DESCRIPTION
* Remove unnecessary check for cmake build. We only offer bazel build
* Remove os dependent call to readlink. All this was doing was gathering an absolute directory path