### PR TITLE
Add LayerNormLSTMCell to RNN cell

### DIFF
--- a/tensorflow_addons/layers/wrappers.py
+++ b/tensorflow_addons/layers/wrappers.py
@@ -56,49 +56,10 @@ class WeightNormalization(tf.keras.layers.Wrapper):
     """
 
     def __init__(self, layer, data_init=True, **kwargs):
-        if not isinstance(layer, tf.keras.layers.Layer):
-            raise ValueError(
-                'Please initialize `WeightNormalization` layer with a '
-                '`Layer` instance. You passed: {input}'.format(input=layer))
-
-        self.initialized = True
-        if data_init:
-            self.initialized = False
-
         super(WeightNormalization, self).__init__(layer, **kwargs)
+        self.data_init = data_init
+        self._initialized = False
         self._track_trackable(layer, name='layer')
-
-    def _compute_weights(self):
-        """Generate weights by combining the direction of weight vector with
-        its norm."""
-        with tf.name_scope('compute_weights'):
-            self.layer.kernel = tf.nn.l2_normalize(
-                self.layer.v, axis=self.kernel_norm_axes) * self.layer.g
-
-    def _init_norm(self, weights):
-        """Set the norm of the weight vector."""
-        with tf.name_scope('init_norm'):
-            flat = tf.reshape(weights, [-1, self.layer_depth])
-            return tf.reshape(
-                tf.linalg.norm(flat, axis=0), (self.layer_depth,))
-
-    def _data_dep_init(self, inputs):
-        """Data dependent initialization."""
-
-        with tf.name_scope('data_dep_init'):
-            # Generate data dependent init values
-            activation = self.layer.activation
-            self.layer.activation = None
-            x_init = self.layer.call(inputs)
-            data_norm_axes = list(range(x_init.shape.rank - 1))
-            m_init, v_init = tf.nn.moments(x_init, data_norm_axes)
-            scale_init = 1. / tf.math.sqrt(v_init + 1e-10)
-
-        # Assign data dependent init values
-        self.layer.g = self.layer.g * scale_init
-        self.layer.bias = (-m_init * scale_init)
-        self.layer.activation = activation
-        self.initialized = True
 
     def build(self, input_shape):
         """Build `Layer`"""
@@ -107,7 +68,6 @@ class WeightNormalization(tf.keras.layers.Wrapper):
 
         if not self.layer.built:
             self.layer.build(input_shape)
-            self.layer.built = False
 
             if not hasattr(self.layer, 'kernel'):
                 raise ValueError('`WeightNormalization` must wrap a layer that'
@@ -118,34 +78,77 @@ class WeightNormalization(tf.keras.layers.Wrapper):
             self.kernel_norm_axes = list(
                 range(self.layer.kernel.shape.rank - 1))
 
-            self.layer.v = self.layer.kernel
-            self.layer.g = self.layer.add_variable(
+            self.v = self.layer.kernel
+            self.g = self.add_variable(
                 name="g",
                 shape=(self.layer_depth,),
                 initializer=tf.keras.initializers.get('ones'),
                 dtype=self.layer.kernel.dtype,
-                trainable=True,
-                aggregation=tf.VariableAggregation.MEAN)
-
-            # TODO: Check if this needs control deps in TF2 graph mode
-            self.layer.g.assign(self._init_norm(self.layer.v))
-            self._compute_weights()
-
-            self.layer.built = True
+                trainable=True)
 
         super(WeightNormalization, self).build()
-        self.built = True
 
-    @tf.function
     def call(self, inputs):
         """Call `Layer`"""
-        if not self.initialized:
-            self._data_dep_init(inputs)
+        if not self._initialized:
+            self._initialize_weights(inputs)
 
         self._compute_weights()  # Recompute weights for each forward pass
-        output = self.layer.call(inputs)
+        output = self.layer(inputs)
         return output
 
     def compute_output_shape(self, input_shape):
         return tf.TensorShape(
             self.layer.compute_output_shape(input_shape).as_list())
+
+    def _compute_weights(self):
+        """Generate normalized weights.
+
+        This method will update the value of self.layer.kernel with the
+        normalized value, so that the layer is ready for call().
+        """
+        with tf.name_scope('compute_weights'):
+            self.layer.kernel = tf.nn.l2_normalize(
+                self.v, axis=self.kernel_norm_axes) * self.g
+
+    def _initialize_weights(self, inputs):
+        """Initialize weight g.
+
+        The initial value of g could either from the initial value in v,
+        or by the input value if self.data_init is True.
+        """
+        if self.data_init:
+            self._data_dep_init(inputs)
+        else:
+            self._init_norm()
+        self._initialized = True
+
+    def _init_norm(self):
+        """Set the weight g with the norm of the weight vector."""
+        with tf.name_scope('init_norm'):
+            flat = tf.reshape(self.v, [-1, self.layer_depth])
+            self.g.assign(
+                tf.reshape(tf.linalg.norm(flat, axis=0), (self.layer_depth,)))
+
+    def _data_dep_init(self, inputs):
+        """Data dependent initialization."""
+
+        with tf.name_scope('data_dep_init'):
+            # Generate data dependent init values
+            existing_activation = self.layer.activation
+            self.layer.activation = None
+            x_init = self.layer(inputs)
+            data_norm_axes = list(range(x_init.shape.rank - 1))
+            m_init, v_init = tf.nn.moments(x_init, data_norm_axes)
+            scale_init = 1. / tf.math.sqrt(v_init + 1e-10)
+
+        # Assign data dependent init values
+        self.g.assign(self.g * scale_init)
+        if hasattr(self.layer, 'bias'):
+            self.layer.bias.assign(-m_init * scale_init)
+        self.layer.activation = existing_activation
+
+    def get_config(self):
+        config = {'data_init': self.data_init}
+        base_config = super(WeightNormalization, self).get_config()
+        return dict(list(base_config.items()) + list(config.items()))

--- a/tensorflow_addons/layers/wrappers_test.py
+++ b/tensorflow_addons/layers/wrappers_test.py
@@ -31,7 +31,6 @@ class WeightNormalizationTest(tf.test.TestCase):
         model.add(
             wrappers.WeightNormalization(
                 tf.keras.layers.Dense(2), input_shape=(3, 4)))
-
         model.compile(
             optimizer=tf.keras.optimizers.RMSprop(learning_rate=0.001),
             loss='mse')
@@ -40,7 +39,7 @@ class WeightNormalizationTest(tf.test.TestCase):
             np.random.random((10, 3, 2)),
             epochs=3,
             batch_size=10)
-        self.assertTrue(hasattr(model.layers[0].layer, 'g'))
+        self.assertTrue(hasattr(model.layers[0], 'g'))
 
     def test_weightnorm_dense_train_notinit(self):
         model = tf.keras.models.Sequential()
@@ -56,7 +55,7 @@ class WeightNormalizationTest(tf.test.TestCase):
             np.random.random((10, 3, 2)),
             epochs=3,
             batch_size=10)
-        self.assertTrue(hasattr(model.layers[0].layer, 'g'))
+        self.assertTrue(hasattr(model.layers[0], 'g'))
 
     def test_weightnorm_conv2d(self):
         model = tf.keras.models.Sequential()
@@ -74,18 +73,18 @@ class WeightNormalizationTest(tf.test.TestCase):
             epochs=3,
             batch_size=10)
 
-        self.assertTrue(hasattr(model.layers[0].layer, 'g'))
+        self.assertTrue(hasattr(model.layers[0], 'g'))
 
     def test_weightnorm_tflayers(self):
         images = tf.random.uniform((2, 4, 4, 3))
         wn_wrapper = wrappers.WeightNormalization(
             tf.keras.layers.Conv2D(32, [2, 2]), input_shape=(4, 4, 3))
         wn_wrapper.apply(images)
-        self.assertTrue(hasattr(wn_wrapper.layer, 'g'))
+        self.assertTrue(hasattr(wn_wrapper, 'g'))
 
     def test_weightnorm_nonlayer(self):
         images = tf.random.uniform((2, 4, 43))
-        with self.assertRaises(ValueError):
+        with self.assertRaises(AssertionError):
             wrappers.WeightNormalization(images)
 
     def test_weightnorm_nokernel(self):
@@ -95,7 +94,7 @@ class WeightNormalizationTest(tf.test.TestCase):
 
     def test_weightnorm_keras(self):
         input_data = np.random.random((10, 3, 4)).astype(np.float32)
-        outputs = test_utils.layer_test(
+        test_utils.layer_test(
             wrappers.WeightNormalization,
             kwargs={
                 'layer': tf.keras.layers.Dense(2),

--- a/tensorflow_addons/rnn/cell.py
+++ b/tensorflow_addons/rnn/cell.py
@@ -208,3 +208,180 @@ class NASCell(keras.layers.AbstractRNNCell):
         }
         base_config = super(NASCell, self).get_config()
         return dict(list(base_config.items()) + list(config.items()))
+
+
+class LayerNormLSTMCell(keras.layers.LSTMCell):
+    """LSTM cell with layer normalization and recurrent dropout.
+
+    This class adds layer normalization and recurrent dropout to a LSTM unit.
+    Layer normalization implementation is based on:
+
+      https://arxiv.org/abs/1607.06450.
+
+    "Layer Normalization" Jimmy Lei Ba, Jamie Ryan Kiros, Geoffrey E. Hinton
+
+    and is applied before the internal nonlinearities.
+    Recurrent dropout is base on:
+
+      https://arxiv.org/abs/1603.05118
+
+    "Recurrent Dropout without Memory Loss"
+    Stanislau Semeniuta, Aliaksei Severyn, Erhardt Barth.
+    """
+
+    def __init__(self,
+                 units,
+                 activation='tanh',
+                 recurrent_activation='sigmoid',
+                 use_bias=True,
+                 kernel_initializer='glorot_uniform',
+                 recurrent_initializer='orthogonal',
+                 bias_initializer='zeros',
+                 unit_forget_bias=True,
+                 kernel_regularizer=None,
+                 recurrent_regularizer=None,
+                 bias_regularizer=None,
+                 kernel_constraint=None,
+                 recurrent_constraint=None,
+                 bias_constraint=None,
+                 dropout=0.,
+                 recurrent_dropout=0.,
+                 layer_norm=True,
+                 norm_gamma_initializer='ones',
+                 norm_beta_initializer='zeros',
+                 **kwargs):
+        """Initializes the LSTM cell.
+
+        Args:
+          units: Positive integer, dimensionality of the output space.
+          activation: Activation function to use. Default: hyperbolic tangent
+            (`tanh`). If you pass `None`, no activation is applied (ie. "linear"
+            activation: `a(x) = x`).
+          recurrent_activation: Activation function to use for the recurrent
+            step. Default: sigmoid (`sigmoid`). If you pass `None`, no
+            activation is applied (ie. "linear" activation: `a(x) = x`).
+          use_bias: Boolean, whether the layer uses a bias vector.
+          kernel_initializer: Initializer for the `kernel` weights matrix, used
+            for the linear transformation of the inputs.
+          recurrent_initializer: Initializer for the `recurrent_kernel` weights
+            matrix, used for the linear transformation of the recurrent state.
+          bias_initializer: Initializer for the bias vector.
+          unit_forget_bias: Boolean. If True, add 1 to the bias of the forget
+            gate at initialization. Setting it to true will also force
+            `bias_initializer="zeros"`. This is recommended in [Jozefowicz et
+              al.](http://www.jmlr.org/proceedings/papers/v37/jozefowicz15.pdf)
+          kernel_regularizer: Regularizer function applied to the `kernel`
+            weights matrix.
+          recurrent_regularizer: Regularizer function applied to
+            the `recurrent_kernel` weights matrix.
+          bias_regularizer: Regularizer function applied to the bias vector.
+          kernel_constraint: Constraint function applied to the `kernel` weights
+            matrix.
+          recurrent_constraint: Constraint function applied to the
+            `recurrent_kernel` weights matrix.
+          bias_constraint: Constraint function applied to the bias vector.
+          dropout: Float between 0 and 1. Fraction of the units to drop for the
+            linear transformation of the inputs.
+          recurrent_dropout: Float between 0 and 1. Fraction of the units to
+            drop for the linear transformation of the recurrent state.
+          layer_norm: If `True`, layer normalization will be applied.
+          norm_gamma_initializer: Initializer for the layer normalization gain
+            initial value. If `layer_norm` has been set to `False`, this
+            argument will be ignored.
+          norm_beta_initializer: Initializer for the layer normalization shift
+            initial value. If `layer_norm` has been set to `False`, this
+            argument will be ignored.
+          **kwargs: Dict, the other keyword arguments for layer creation.
+        """
+        super(LayerNormLSTMCell, self).__init__(
+            units,
+            activation=activation,
+            recurrent_activation=recurrent_activation,
+            use_bias=use_bias,
+            kernel_initializer=kernel_initializer,
+            recurrent_initializer=recurrent_initializer,
+            bias_initializer=bias_initializer,
+            unit_forget_bias=unit_forget_bias,
+            kernel_regularizer=kernel_regularizer,
+            recurrent_regularizer=recurrent_regularizer,
+            bias_regularizer=bias_regularizer,
+            kernel_constraint=kernel_constraint,
+            recurrent_constraint=recurrent_constraint,
+            bias_constraint=bias_constraint,
+            dropout=dropout,
+            recurrent_dropout=recurrent_dropout,
+            **kwargs)
+        self.layer_norm = layer_norm
+        self.norm_gamma_initializer = keras.initializer.get(
+            norm_gamma_initializer)
+        self.norm_beta_initializer = keras.initializer.get(
+            norm_beta_initializer)
+        if self.layer_norm:
+            self.input_norm = keras.layers.LayerNormalization(
+                beta_initializer=self.norm_beta_initializer,
+                gamma_initializer=self.norm_gamma_initializer)
+            self.carry_norm = keras.layers.LayerNormalization(
+                beta_initializer=self.norm_beta_initializer,
+                gamma_initializer=self.norm_gamma_initializer)
+            self.forget_norm = keras.layers.LayerNormalization(
+                beta_initializer=self.norm_beta_initializer,
+                gamma_initializer=self.norm_gamma_initializer)
+            self.output_norm = keras.layers.LayerNormalization(
+                beta_initializer=self.norm_beta_initializer,
+                gamma_initializer=self.norm_gamma_initializer)
+            self.state_norm = keras.layers.LayerNormalization(
+                beta_initializer=self.norm_beta_initializer,
+                gamma_initializer=self.norm_gamma_initializer)
+
+    def build(self, input_shape):
+        super(LayerNormLSTMCell, self).build(input_shape)
+        if self.layer_norm:
+            norm_input_shape = input_shape[0] + self.units
+            self.input_norm.build(norm_input_shape)
+            self.carry_norm.build(norm_input_shape)
+            self.forget_norm.build(norm_input_shape)
+            self.output_norm.build(norm_input_shape)
+            self.state_norm.build(norm_input_shape)
+
+    def call(self, inputs, states, training=None):
+        if not self.layer_norm:
+            return super(LayerNormLSTMCell, self).call(
+                inputs, states, training=training)
+        # For the layer norm implementation
+        h_tm1 = states[0]  # previous memory state
+        c_tm1 = states[1]  # previous carry state
+
+        # Linear calculation
+        dp_mask = self.get_dropout_mask_for_cell(inputs, training, count=4)
+        rec_dp_mask = self.get_recurrent_dropout_mask_for_cell(
+            h_tm1, training, count=4)
+        if 0. < self.dropout < 1.:
+            inputs *= dp_mask[0]
+        z = keras.backend.dot(inputs, self.kernel)
+        if 0. < self.recurrent_dropout < 1.:
+            h_tm1 *= rec_dp_mask[0]
+        z += keras.backend.dot(h_tm1, self.recurrent_kernel)
+        if self.use_bias:
+            z = keras.backend.bias_add(z, self.bias)
+
+        # Apply the layer normalization for each of the gate if needed.
+        i, f, c, o = tf.split(z, num_or_size_splits=4, axis=1)
+        i = self.input_norm(i)
+        f = self.forget_norm(f)
+        c = self.carry_norm(c)
+        o = self.output_norm(o)
+        c, o = self._compute_carry_and_output_fused([i, f, c, o], c_tm1)
+        c = self.state_norm(c)
+        h = o * self.activation(c)
+        return h, [h, c]
+
+    def get_config(self):
+        config = {
+            'layer_norm': self.layer_norm,
+            'norm_gamma_initializer': keras.initializer.serialize(
+                self.norm_gamma_initializer),
+            'norm_beta_initializer': keras.initializer.serialize(
+                self.norm_beta_initializer)
+        }
+        base_config = super(LayerNormLSTMCell, self).get_config()
+        return dict(list(base_config.items()) + list(config.items()))

--- a/tensorflow_addons/rnn/cell.py
+++ b/tensorflow_addons/rnn/cell.py
@@ -210,6 +210,7 @@ class NASCell(keras.layers.AbstractRNNCell):
         return dict(list(base_config.items()) + list(config.items()))
 
 
+@keras_utils.register_keras_custom_object
 class LayerNormLSTMCell(keras.layers.LSTMCell):
     """LSTM cell with layer normalization and recurrent dropout.
 
@@ -256,8 +257,8 @@ class LayerNormLSTMCell(keras.layers.LSTMCell):
         Args:
           units: Positive integer, dimensionality of the output space.
           activation: Activation function to use. Default: hyperbolic tangent
-            (`tanh`). If you pass `None`, no activation is applied (ie. "linear"
-            activation: `a(x) = x`).
+            (`tanh`). If you pass `None`, no activation is applied (ie.
+            "linear" activation: `a(x) = x`).
           recurrent_activation: Activation function to use for the recurrent
             step. Default: sigmoid (`sigmoid`). If you pass `None`, no
             activation is applied (ie. "linear" activation: `a(x) = x`).
@@ -276,8 +277,8 @@ class LayerNormLSTMCell(keras.layers.LSTMCell):
           recurrent_regularizer: Regularizer function applied to
             the `recurrent_kernel` weights matrix.
           bias_regularizer: Regularizer function applied to the bias vector.
-          kernel_constraint: Constraint function applied to the `kernel` weights
-            matrix.
+          kernel_constraint: Constraint function applied to the `kernel`
+            weights matrix.
           recurrent_constraint: Constraint function applied to the
             `recurrent_kernel` weights matrix.
           bias_constraint: Constraint function applied to the bias vector.
@@ -369,12 +370,14 @@ class LayerNormLSTMCell(keras.layers.LSTMCell):
 
     def get_config(self):
         config = {
-            'layer_norm': self.layer_norm,
-            'norm_gamma_initializer': keras.initializers.serialize(
-                self.norm_gamma_initializer),
-            'norm_beta_initializer': keras.initializers.serialize(
-                self.norm_beta_initializer),
-            'norm_epsilon': self.norm_epsilon,
+            'layer_norm':
+            self.layer_norm,
+            'norm_gamma_initializer':
+            keras.initializers.serialize(self.norm_gamma_initializer),
+            'norm_beta_initializer':
+            keras.initializers.serialize(self.norm_beta_initializer),
+            'norm_epsilon':
+            self.norm_epsilon,
         }
         base_config = super(LayerNormLSTMCell, self).get_config()
         return dict(list(base_config.items()) + list(config.items()))

--- a/tensorflow_addons/rnn/cell_test.py
+++ b/tensorflow_addons/rnn/cell_test.py
@@ -200,11 +200,11 @@ class LayerNormBasicLSTMCellTest(tf.test.TestCase):
         self.evaluate([tf.compat.v1.global_variables_initializer()])
         output_v, output_states_v = self.evaluate([output, output_states])
 
-        expected_output = np.array([[-0.38079708, 0.38079708]])
-        expected_state0_c = np.array([[-1.0, 1.0]])
-        expected_state0_h = np.array([[-0.38079708, 0.38079708]])
-        expected_state1_c = np.array([[-1.0, 1.0]])
-        expected_state1_h = np.array([[-0.38079708, 0.38079708]])
+        expected_output = np.array([[-0.47406167, 0.47406143]])
+        expected_state0_c = np.array([[-1., 1.]])
+        expected_state0_h = np.array([[-0.47406167, 0.47406143]])
+        expected_state1_c = np.array([[-1., 1.]])
+        expected_state1_h = np.array([[-0.47406167, 0.47406143]])
 
         actual_state0_h = output_states_v[0][0]
         actual_state0_c = output_states_v[0][1]
@@ -231,7 +231,7 @@ class LayerNormBasicLSTMCellTest(tf.test.TestCase):
         output, output_states = cell(x, state)
         self.evaluate([tf.compat.v1.global_variables_initializer()])
         output_v, output_states_v = self.evaluate([output, output_states])
-        expected_h = np.array([[-0.38079708, 0.38079708]])
+        expected_h = np.array([[-0.47406167, 0.47406143]])
         expected_c = np.array([[-1.0, 1.0]])
         self.assertAllClose(output_v, expected_h, 1e-5)
         self.assertAllClose(output_states_v[0], expected_h, 1e-5)

--- a/tensorflow_addons/rnn/cell_test.py
+++ b/tensorflow_addons/rnn/cell_test.py
@@ -27,8 +27,9 @@ from tensorflow_addons.rnn import cell as rnn_cell
 
 
 @test_utils.run_all_in_graph_and_eager_modes
-class RNNCellTest(tf.test.TestCase):
-    def test_NASCell(self):
+class NASCellTest(tf.test.TestCase):
+
+    def test_base(self):
         units = 6
         batch_size = 3
         expected_output = np.array(
@@ -82,7 +83,7 @@ class RNNCellTest(tf.test.TestCase):
         self.assertEqual(new_h.shape[1], units)
         self.assertAllClose(np.concatenate(res[1], axis=1), expected_state)
 
-    def test_NASCell_projection(self):
+    def test_projection(self):
         units = 6
         batch_size = 3
         projection = 5
@@ -142,7 +143,7 @@ class RNNCellTest(tf.test.TestCase):
         self.assertEqual(new_h.shape[1], projection)
         self.assertAllClose(np.concatenate(res[1], axis=1), expected_state)
 
-    def test_NASCell_keras_RNN(self):
+    def test_keras_RNN(self):
         """Tests that NASCell works with keras RNN layer."""
         cell = rnn_cell.NASCell(10)
         seq_input = tf.convert_to_tensor(
@@ -152,7 +153,7 @@ class RNNCellTest(tf.test.TestCase):
         self.evaluate([tf.compat.v1.global_variables_initializer()])
         self.assertEqual(self.evaluate(rnn_outputs).shape, (2, 10))
 
-    def test_NASCell_config(self):
+    def test_config(self):
         cell = rnn_cell.NASCell(10, projection=5, use_bias=True)
 
         expected_config = {
@@ -173,6 +174,279 @@ class RNNCellTest(tf.test.TestCase):
         restored_cell = rnn_cell.NASCell.from_config(config)
         restored_config = restored_cell.get_config()
         self.assertEqual(config, restored_config)
+
+
+@test_utils.run_all_in_graph_and_eager_modes
+class LayerNormBasicLSTMCellTest(tf.test.TestCase):
+
+    # NOTE: all the values in the current test case have been calculated.
+    def testBasicLSTMCell(self):
+        x = tf.ones([1, 2])
+        c0 = tf.constant(0.1 * np.asarray([[0, 1]]), dtype=tf.float32)
+        h0 = tf.constant(0.1 * np.asarray([[2, 3]]), dtype=tf.float32)
+        state0 = [h0, c0]
+        c1 = tf.constant(0.1 * np.asarray([[4, 5]]), dtype=tf.float32)
+        h1 = tf.constant(0.1 * np.asarray([[6, 7]]), dtype=tf.float32)
+        state1 = [h1, c1]
+        state = (state0, state1)
+        const_initializer = tf.constant_initializer(0.5)
+        single_cell = lambda: rnn_cell.LayerNormLSTMCell(
+            2,
+            kernel_initializer=const_initializer,
+            recurrent_initializer=const_initializer)
+        cell = keras.layers.StackedRNNCell([single_cell() for _ in range(2)])
+        output, output_states = cell(x, state)
+        self.evaluate([tf.compat.v1.global_variables_initializer()])
+        output_v, output_states_v = self.evaluate([output, output_states])
+
+        expected_output = np.array([[-0.38079708, 0.38079708]])
+        expected_state0_h = np.array([[-0.38079708, 0.38079708]])
+        expected_state0_c = np.array([[-1.0, 1.0]])
+        expected_state1_h = np.array([[-0.38079708, 0.38079708]])
+        expected_state1_c = np.array([[-1.0, 1.0]])
+
+        actual_state0_h = output_states_v[0][0]
+        actual_state0_c = output_states_v[0][1]
+        actual_state1_h = output_states_v[1][0]
+        actual_state1_c = output_states_v[1][1]
+
+        self.assertAllClose(output_v, expected_output, 1e-5)
+        self.assertAllClose(expected_state0_c, actual_state0_c, 1e-5)
+        self.assertAllClose(expected_state0_h, actual_state0_h, 1e-5)
+        self.assertAllClose(expected_state1_c, actual_state1_c, 1e-5)
+        self.assertAllClose(expected_state1_h, actual_state1_h, 1e-5)
+
+            # with variable_scope.variable_scope(
+            #     "other", initializer=init_ops.constant_initializer(0.5)):
+            #     x = array_ops.zeros(
+            #         [1, 3])  # Test BasicLSTMCell with input_size != num_units.
+            #     c = array_ops.zeros([1, 2])
+            #     h = array_ops.zeros([1, 2])
+            #     state = rnn_cell.LSTMStateTuple(c, h)
+            #     cell = contrib_rnn_cell.LayerNormBasicLSTMCell(2)
+            #     g, out_m = cell(x, state)
+            #     sess.run([variables.global_variables_initializer()])
+            #     res = sess.run(
+            #         [g, out_m], {
+            #             x.name: np.array([[1., 1., 1.]]),
+            #             c.name: 0.1 * np.asarray([[0, 1]]),
+            #             h.name: 0.1 * np.asarray([[2, 3]]),
+            #         })
+            #
+            #     expected_h = np.array([[-0.38079708, 0.38079708]])
+            #     expected_c = np.array([[-1.0, 1.0]])
+            #     self.assertEqual(len(res), 2)
+            #     self.assertAllClose(res[0], expected_h, 1e-5)
+            #     self.assertAllClose(res[1].c, expected_c, 1e-5)
+            #     self.assertAllClose(res[1].h, expected_h, 1e-5)
+
+    # def testBasicLSTMCellWithoutNorm(self):
+    #     """Tests that BasicLSTMCell with layer_norm=False."""
+    #     with self.cached_session() as sess:
+    #         with variable_scope.variable_scope(
+    #             "root", initializer=init_ops.constant_initializer(0.5)):
+    #             x = array_ops.zeros([1, 2])
+    #             c0 = array_ops.zeros([1, 2])
+    #             h0 = array_ops.zeros([1, 2])
+    #             state0 = rnn_cell.LSTMStateTuple(c0, h0)
+    #             c1 = array_ops.zeros([1, 2])
+    #             h1 = array_ops.zeros([1, 2])
+    #             state1 = rnn_cell.LSTMStateTuple(c1, h1)
+    #             state = (state0, state1)
+    #             single_cell = lambda: contrib_rnn_cell.LayerNormBasicLSTMCell(2, layer_norm=False)  # pylint: disable=line-too-long
+    #             cell = rnn_cell.MultiRNNCell([single_cell() for _ in range(2)])
+    #             g, out_m = cell(x, state)
+    #             sess.run([variables.global_variables_initializer()])
+    #             res = sess.run(
+    #                 [g, out_m], {
+    #                     x.name: np.array([[1., 1.]]),
+    #                     c0.name: 0.1 * np.asarray([[0, 1]]),
+    #                     h0.name: 0.1 * np.asarray([[2, 3]]),
+    #                     c1.name: 0.1 * np.asarray([[4, 5]]),
+    #                     h1.name: 0.1 * np.asarray([[6, 7]]),
+    #                 })
+    #
+    #             expected_h = np.array([[0.70230919, 0.72581059]])
+    #             expected_state0_c = np.array([[0.8020075, 0.89599884]])
+    #             expected_state0_h = np.array([[0.56668288, 0.60858738]])
+    #             expected_state1_c = np.array([[1.17500675, 1.26892781]])
+    #             expected_state1_h = np.array([[0.70230919, 0.72581059]])
+    #
+    #             actual_h = res[0]
+    #             actual_state0_c = res[1][0].c
+    #             actual_state0_h = res[1][0].h
+    #             actual_state1_c = res[1][1].c
+    #             actual_state1_h = res[1][1].h
+    #
+    #             self.assertAllClose(actual_h, expected_h, 1e-5)
+    #             self.assertAllClose(expected_state0_c, actual_state0_c, 1e-5)
+    #             self.assertAllClose(expected_state0_h, actual_state0_h, 1e-5)
+    #             self.assertAllClose(expected_state1_c, actual_state1_c, 1e-5)
+    #             self.assertAllClose(expected_state1_h, actual_state1_h, 1e-5)
+    #
+    #         with variable_scope.variable_scope(
+    #             "other", initializer=init_ops.constant_initializer(0.5)):
+    #             x = array_ops.zeros(
+    #                 [1, 3])  # Test BasicLSTMCell with input_size != num_units.
+    #             c = array_ops.zeros([1, 2])
+    #             h = array_ops.zeros([1, 2])
+    #             state = rnn_cell.LSTMStateTuple(c, h)
+    #             cell = contrib_rnn_cell.LayerNormBasicLSTMCell(2, layer_norm=False)
+    #             g, out_m = cell(x, state)
+    #             sess.run([variables.global_variables_initializer()])
+    #             res = sess.run(
+    #                 [g, out_m], {
+    #                     x.name: np.array([[1., 1., 1.]]),
+    #                     c.name: 0.1 * np.asarray([[0, 1]]),
+    #                     h.name: 0.1 * np.asarray([[2, 3]]),
+    #                 })
+    #
+    #             expected_h = np.array([[0.64121795, 0.68166804]])
+    #             expected_c = np.array([[0.88477188, 0.98103917]])
+    #             self.assertEqual(len(res), 2)
+    #             self.assertAllClose(res[0], expected_h, 1e-5)
+    #             self.assertAllClose(res[1].c, expected_c, 1e-5)
+    #             self.assertAllClose(res[1].h, expected_h, 1e-5)
+    #
+    # def testBasicLSTMCellWithStateTuple(self):
+    #     with self.cached_session() as sess:
+    #         with variable_scope.variable_scope(
+    #             "root", initializer=init_ops.constant_initializer(0.5)):
+    #             x = array_ops.zeros([1, 2])
+    #             c0 = array_ops.zeros([1, 2])
+    #             h0 = array_ops.zeros([1, 2])
+    #             state0 = rnn_cell.LSTMStateTuple(c0, h0)
+    #             c1 = array_ops.zeros([1, 2])
+    #             h1 = array_ops.zeros([1, 2])
+    #             state1 = rnn_cell.LSTMStateTuple(c1, h1)
+    #             cell = rnn_cell.MultiRNNCell(
+    #                 [contrib_rnn_cell.LayerNormBasicLSTMCell(2) for _ in range(2)])
+    #             h, (s0, s1) = cell(x, (state0, state1))
+    #             sess.run([variables.global_variables_initializer()])
+    #             res = sess.run(
+    #                 [h, s0, s1], {
+    #                     x.name: np.array([[1., 1.]]),
+    #                     c0.name: 0.1 * np.asarray([[0, 1]]),
+    #                     h0.name: 0.1 * np.asarray([[2, 3]]),
+    #                     c1.name: 0.1 * np.asarray([[4, 5]]),
+    #                     h1.name: 0.1 * np.asarray([[6, 7]]),
+    #                 })
+    #
+    #             expected_h = np.array([[-0.38079708, 0.38079708]])
+    #             expected_h0 = np.array([[-0.38079708, 0.38079708]])
+    #             expected_c0 = np.array([[-1.0, 1.0]])
+    #             expected_h1 = np.array([[-0.38079708, 0.38079708]])
+    #             expected_c1 = np.array([[-1.0, 1.0]])
+    #
+    #             self.assertEqual(len(res), 3)
+    #             self.assertAllClose(res[0], expected_h, 1e-5)
+    #             self.assertAllClose(res[1].c, expected_c0, 1e-5)
+    #             self.assertAllClose(res[1].h, expected_h0, 1e-5)
+    #             self.assertAllClose(res[2].c, expected_c1, 1e-5)
+    #             self.assertAllClose(res[2].h, expected_h1, 1e-5)
+    #
+    # def testBasicLSTMCellWithStateTupleLayerNorm(self):
+    #     """The results of LSTMCell and LayerNormBasicLSTMCell should be the same."""
+    #     with self.cached_session() as sess:
+    #         with variable_scope.variable_scope(
+    #             "root", initializer=init_ops.constant_initializer(0.5)):
+    #             x = array_ops.zeros([1, 2])
+    #             c0 = array_ops.zeros([1, 2])
+    #             h0 = array_ops.zeros([1, 2])
+    #             state0 = rnn_cell_impl.LSTMStateTuple(c0, h0)
+    #             c1 = array_ops.zeros([1, 2])
+    #             h1 = array_ops.zeros([1, 2])
+    #             state1 = rnn_cell_impl.LSTMStateTuple(c1, h1)
+    #             cell = rnn_cell_impl.MultiRNNCell([
+    #                 contrib_rnn_cell.LayerNormLSTMCell(
+    #                     2, layer_norm=True, norm_gain=1.0, norm_shift=0.0)
+    #                 for _ in range(2)
+    #             ])
+    #             h, (s0, s1) = cell(x, (state0, state1))
+    #             sess.run([variables.global_variables_initializer()])
+    #             res = sess.run(
+    #                 [h, s0, s1], {
+    #                     x.name: np.array([[1., 1.]]),
+    #                     c0.name: 0.1 * np.asarray([[0, 1]]),
+    #                     h0.name: 0.1 * np.asarray([[2, 3]]),
+    #                     c1.name: 0.1 * np.asarray([[4, 5]]),
+    #                     h1.name: 0.1 * np.asarray([[6, 7]]),
+    #                 })
+    #
+    #             expected_h = np.array([[-0.38079708, 0.38079708]])
+    #             expected_h0 = np.array([[-0.38079708, 0.38079708]])
+    #             expected_c0 = np.array([[-1.0, 1.0]])
+    #             expected_h1 = np.array([[-0.38079708, 0.38079708]])
+    #             expected_c1 = np.array([[-1.0, 1.0]])
+    #
+    #             self.assertEqual(len(res), 3)
+    #             self.assertAllClose(res[0], expected_h, 1e-5)
+    #             self.assertAllClose(res[1].c, expected_c0, 1e-5)
+    #             self.assertAllClose(res[1].h, expected_h0, 1e-5)
+    #             self.assertAllClose(res[2].c, expected_c1, 1e-5)
+    #             self.assertAllClose(res[2].h, expected_h1, 1e-5)
+    #
+    # def testBasicLSTMCellWithDropout(self):
+    #
+    #     def _is_close(x, y, digits=4):
+    #         delta = x - y
+    #         return delta < 10**(-digits)
+    #
+    #     def _is_close_in(x, items, digits=4):
+    #         for i in items:
+    #             if _is_close(x, i, digits):
+    #                 return True
+    #         return False
+    #
+    #     keep_prob = 0.5
+    #     c_high = 2.9998924946
+    #     c_low = 0.999983298578
+    #     h_low = 0.761552567265
+    #     h_high = 0.995008519604
+    #     num_units = 5
+    #     allowed_low = [1, 2, 3]
+    #
+    #     with self.cached_session() as sess:
+    #         with variable_scope.variable_scope(
+    #             "other", initializer=init_ops.constant_initializer(1)):
+    #             x = array_ops.zeros([1, 5])
+    #             c = array_ops.zeros([1, 5])
+    #             h = array_ops.zeros([1, 5])
+    #             state = rnn_cell.LSTMStateTuple(c, h)
+    #             cell = contrib_rnn_cell.LayerNormBasicLSTMCell(
+    #                 num_units, layer_norm=False, dropout_keep_prob=keep_prob)
+    #
+    #             g, s = cell(x, state)
+    #             sess.run([variables.global_variables_initializer()])
+    #             res = sess.run(
+    #                 [g, s], {
+    #                     x.name: np.ones([1, 5]),
+    #                     c.name: np.ones([1, 5]),
+    #                     h.name: np.ones([1, 5]),
+    #                 })
+    #
+    #             # Since the returned tensors are of size [1,n]
+    #             # get the first component right now.
+    #             actual_h = res[0][0]
+    #             actual_state_c = res[1].c[0]
+    #             actual_state_h = res[1].h[0]
+    #
+    #             # For each item in `c` (the cell inner state) check that
+    #             # it is equal to one of the allowed values `c_high` (not
+    #             # dropped out) or `c_low` (dropped out) and verify that the
+    #             # corresponding item in `h` (the cell activation) is coherent.
+    #             # Count the dropped activations and check that their number is
+    #             # coherent with the dropout probability.
+    #             dropped_count = 0
+    #             self.assertTrue((actual_h == actual_state_h).all())
+    #             for citem, hitem in zip(actual_state_c, actual_state_h):
+    #                 self.assertTrue(_is_close_in(citem, [c_low, c_high]))
+    #                 if _is_close(citem, c_low):
+    #                     self.assertTrue(_is_close(hitem, h_low))
+    #                     dropped_count += 1
+    #                 elif _is_close(citem, c_high):
+    #                     self.assertTrue(_is_close(hitem, h_high))
+    #             self.assertIn(dropped_count, allowed_low)
 
 
 if __name__ == "__main__":

--- a/tensorflow_addons/rnn/cell_test.py
+++ b/tensorflow_addons/rnn/cell_test.py
@@ -28,7 +28,6 @@ from tensorflow_addons.rnn import cell as rnn_cell
 
 @test_utils.run_all_in_graph_and_eager_modes
 class NASCellTest(tf.test.TestCase):
-
     def test_base(self):
         units = 6
         batch_size = 3
@@ -261,10 +260,10 @@ class LayerNormBasicLSTMCellTest(tf.test.TestCase):
         state1 = [h1, c1]
         state = (state0, state1)
 
-        norm_cell = keras.layers.StackedRNNCells([single_cell_without_norm()
-                                                 for _ in range(2)])
-        standard_cell = keras.layers.StackedRNNCells([standard_lstm_cell()
-                                                     for _ in range(2)])
+        norm_cell = keras.layers.StackedRNNCells(
+            [single_cell_without_norm() for _ in range(2)])
+        standard_cell = keras.layers.StackedRNNCells(
+            [standard_lstm_cell() for _ in range(2)])
         norm_out, norm_states = norm_cell(x, state)
         standard_out, standard_states = standard_cell(x, state)
         self.evaluate([tf.compat.v1.global_variables_initializer()])
@@ -286,11 +285,23 @@ class LayerNormBasicLSTMCellTest(tf.test.TestCase):
             "activation": "tanh",
             "recurrent_activation": "sigmoid",
             "use_bias": True,
-            "kernel_initializer": {"class_name": "GlorotUniform",
-                                   "config": {"seed": None}},
-            "recurrent_initializer": {"class_name": "Orthogonal",
-                                      "config": {"seed": None, "gain": 1.0}},
-            "bias_initializer": {"class_name": "Zeros", "config": {}},
+            "kernel_initializer": {
+                "class_name": "GlorotUniform",
+                "config": {
+                    "seed": None
+                }
+            },
+            "recurrent_initializer": {
+                "class_name": "Orthogonal",
+                "config": {
+                    "seed": None,
+                    "gain": 1.0
+                }
+            },
+            "bias_initializer": {
+                "class_name": "Zeros",
+                "config": {}
+            },
             "unit_forget_bias": True,
             "kernel_regularizer": None,
             "recurrent_regularizer": None,
@@ -302,8 +313,14 @@ class LayerNormBasicLSTMCellTest(tf.test.TestCase):
             "recurrent_dropout": 0.,
             "implementation": 2,
             "layer_norm": True,
-            "norm_gamma_initializer": {"class_name": "Ones", "config": {}},
-            "norm_beta_initializer": {"class_name": "Zeros", "config": {}},
+            "norm_gamma_initializer": {
+                "class_name": "Ones",
+                "config": {}
+            },
+            "norm_beta_initializer": {
+                "class_name": "Zeros",
+                "config": {}
+            },
             "norm_epsilon": 1e-3,
         }
         config = cell.get_config()


### PR DESCRIPTION
1. The change was based on contrib.LayerNormBasicLSTMCell, which is popular based on https://tf-contrib-analyzer.herokuapp.com.
2. The cell has been updated to align with keras and v2 standard, eg use keras LSTMCell as base class, get rid of variable scope, etc.
3. The tests have also been ported and updated with graph/eager mode.