### PR TITLE
add bazel command to generate API docs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -36,3 +36,7 @@ wheels/
 /.bazelrc
 /bazel-*
 /artifacts
+
+# Addons
+.*
+/docs/

--- a/BUILD
+++ b/BUILD
@@ -6,13 +6,5 @@ sh_binary(
         "MANIFEST.in",
         "setup.py",
         "//tensorflow_addons",
-        "//tensorflow_addons/activations",
-        "//tensorflow_addons/image",
-        "//tensorflow_addons/layers",
-        "//tensorflow_addons/losses",
-        "//tensorflow_addons/optimizers",
-        "//tensorflow_addons/rnn",
-        "//tensorflow_addons/seq2seq",
-        "//tensorflow_addons/text",
     ],
 )

--- a/tensorflow_addons/BUILD
+++ b/tensorflow_addons/BUILD
@@ -8,4 +8,14 @@ py_library(
         "__init__.py",
         "version.py",
     ],
+    deps = [
+        "//tensorflow_addons/activations",
+        "//tensorflow_addons/image",
+        "//tensorflow_addons/layers",
+        "//tensorflow_addons/losses",
+        "//tensorflow_addons/optimizers",
+        "//tensorflow_addons/rnn",
+        "//tensorflow_addons/seq2seq",
+        "//tensorflow_addons/text",
+    ],
 )

--- a/tools/docs/BUILD
+++ b/tools/docs/BUILD
@@ -1,0 +1,19 @@
+# Description:
+#   Doc generator
+
+licenses(["notice"])  # Apache 2.0
+
+exports_files(["LICENSE"])
+
+package(
+    default_visibility = ["//tensorflow_addons:__subpackages__"],
+)
+
+py_binary(
+    name = "build_docs",
+    srcs = ["build_docs.py"],
+    srcs_version = "PY2AND3",
+    deps = [
+        "//tensorflow_addons",
+    ],
+)

--- a/tools/docs/README.md
+++ b/tools/docs/README.md
@@ -1,0 +1,6 @@
+Generate API documents:
+
+```bash
+bazel build tools/docs:build_docs
+bazel-bin/tools/docs/build_docs --git_branch=master --output_dir=docs/api_docs/python/
+```

--- a/tools/docs/README.md
+++ b/tools/docs/README.md
@@ -1,8 +1,20 @@
-Generate API documents:
+Generate API documents
 
 ```bash
+# Install dependencies:
 pip install -r doc_requirements.txt
 
+# Build tool:
 bazel build tools/docs:build_docs
+
+# Generate API doc:
+# Use current branch
+bazel-bin/tools/docs/build_docs --git_branch=$(git rev-parse --abbrev-ref HEAD)
+# or specified explicitly
 bazel-bin/tools/docs/build_docs --git_branch=master --output_dir=docs/api_docs/python/
+
+# Release API doc:
+git add -f doc/
+git commit -m "DOC: xxxxx"
+git push
 ```

--- a/tools/docs/README.md
+++ b/tools/docs/README.md
@@ -1,6 +1,8 @@
 Generate API documents:
 
 ```bash
+pip install -r doc_requirements.txt
+
 bazel build tools/docs:build_docs
 bazel-bin/tools/docs/build_docs --git_branch=master --output_dir=docs/api_docs/python/
 ```

--- a/tools/docs/build_docs.py
+++ b/tools/docs/build_docs.py
@@ -32,8 +32,15 @@ from absl import app
 from absl import flags
 
 import tensorflow_addons
+
 from tensorflow_docs.api_generator import generate_lib
+from tensorflow_docs.api_generator import parser
 from tensorflow_docs.api_generator import public_api
+
+from tensorflow.python.util import tf_inspect
+
+# Use tensorflow's `tf_inspect`, which is aware of `tf_decorator`.
+parser.tf_inspect = tf_inspect
 
 PROJECT_SHORT_NAME = 'tf_addons'
 PROJECT_FULL_NAME = 'TensorFlow Addons'
@@ -64,6 +71,7 @@ def main(argv):
         # Replace `tensorflow_docs` with your module, here.
         py_modules=[(PROJECT_SHORT_NAME, tensorflow_addons)],
         code_url_prefix=code_url_prefix,
+        private_map={'tf_addons': ['__version__', 'utils', 'version']},
         # This callback cleans up a lot of aliases caused by internal imports.
         callbacks=[public_api.local_definitions_filter])
 

--- a/tools/docs/build_docs.py
+++ b/tools/docs/build_docs.py
@@ -35,7 +35,7 @@ import tensorflow_addons
 from tensorflow_docs.api_generator import generate_lib
 from tensorflow_docs.api_generator import public_api
 
-PROJECT_SHORT_NAME = 'tfaddons'
+PROJECT_SHORT_NAME = 'tf_addons'
 PROJECT_FULL_NAME = 'TensorFlow Addons'
 
 FLAGS = flags.FLAGS

--- a/tools/docs/build_docs.py
+++ b/tools/docs/build_docs.py
@@ -31,7 +31,7 @@ from __future__ import print_function
 from absl import app
 from absl import flags
 
-import tensorflow_addons
+import tensorflow_addons as tfa
 
 from tensorflow_docs.api_generator import generate_lib
 from tensorflow_docs.api_generator import parser
@@ -42,7 +42,7 @@ from tensorflow.python.util import tf_inspect
 # Use tensorflow's `tf_inspect`, which is aware of `tf_decorator`.
 parser.tf_inspect = tf_inspect
 
-PROJECT_SHORT_NAME = 'tf_addons'
+PROJECT_SHORT_NAME = 'tfa'
 PROJECT_FULL_NAME = 'TensorFlow Addons'
 
 FLAGS = flags.FLAGS
@@ -69,9 +69,9 @@ def main(argv):
     doc_generator = generate_lib.DocGenerator(
         root_title=PROJECT_FULL_NAME,
         # Replace `tensorflow_docs` with your module, here.
-        py_modules=[(PROJECT_SHORT_NAME, tensorflow_addons)],
+        py_modules=[(PROJECT_SHORT_NAME, tfa)],
         code_url_prefix=code_url_prefix,
-        private_map={'tf_addons': ['__version__', 'utils', 'version']},
+        private_map={'tfa': ['__version__', 'utils', 'version']},
         # This callback cleans up a lot of aliases caused by internal imports.
         callbacks=[public_api.local_definitions_filter])
 

--- a/tools/docs/build_docs.py
+++ b/tools/docs/build_docs.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 # ==============================================================================
-""" Modified from the tfdocs example api reference docs generation script.
+"""Modified from the tfdocs example api reference docs generation script.
 
 This script generates API reference docs.
 
@@ -37,13 +37,17 @@ from tensorflow_docs.api_generator import public_api
 
 PROJECT_SHORT_NAME = 'tfaddons'
 PROJECT_FULL_NAME = 'TensorFlow Addons'
-CODE_URL_PREFIX = 'https://github.com/tensorflow/addons/tree/master/tensorflow_addons'
 
 FLAGS = flags.FLAGS
 
 flags.DEFINE_string(
+    'git_branch',
+    default='master',
+    help='The name of the corresponding branch on github.')
+
+flags.DEFINE_string(
     'output_dir',
-    default='/addons/docs/api_docs/python/',
+    default='docs/api_docs/python/',
     help='Where to write the resulting docs to.')
 
 
@@ -51,11 +55,15 @@ def main(argv):
     if argv[1:]:
         raise ValueError('Unrecognized arguments: {}'.format(argv[1:]))
 
+    code_url_prefix = ('https://github.com/tensorflow/addons/tree/'
+                       '{git_branch}/tensorflow_addons'.format(
+                           git_branch=FLAGS.git_branch))
+
     doc_generator = generate_lib.DocGenerator(
         root_title=PROJECT_FULL_NAME,
         # Replace `tensorflow_docs` with your module, here.
         py_modules=[(PROJECT_SHORT_NAME, tensorflow_addons)],
-        code_url_prefix=CODE_URL_PREFIX,
+        code_url_prefix=code_url_prefix,
         # This callback cleans up a lot of aliases caused by internal imports.
         callbacks=[public_api.local_definitions_filter])
 

--- a/tools/docs/doc_requirements.txt
+++ b/tools/docs/doc_requirements.txt
@@ -1,1 +1,2 @@
 git+https://github.com/tensorflow/docs
+pathlib

--- a/tools/docs/doc_requirements.txt
+++ b/tools/docs/doc_requirements.txt
@@ -1,0 +1,1 @@
+git+https://github.com/tensorflow/docs


### PR DESCRIPTION
Fix #46
Related PRs: #140, #195, #196

```bash
bazel build tools/docs:build_docs
bazel-bin/tools/docs/build_docs --git_branch=master --output_dir=docs/api_docs/python/
```

I push the documnets generated to my repository, and everyone can preview it at https://github.com/facaiy/addons/blob/tf_addons_doc_preview/docs/api_docs/python/tfa.md