### PR TITLE
Update and fix WeightNorm Wrapper.

### DIFF
--- a/tensorflow_addons/layers/wrappers.py
+++ b/tensorflow_addons/layers/wrappers.py
@@ -56,49 +56,10 @@ class WeightNormalization(tf.keras.layers.Wrapper):
     """
 
     def __init__(self, layer, data_init=True, **kwargs):
-        if not isinstance(layer, tf.keras.layers.Layer):
-            raise ValueError(
-                'Please initialize `WeightNormalization` layer with a '
-                '`Layer` instance. You passed: {input}'.format(input=layer))
-
-        self.initialized = True
-        if data_init:
-            self.initialized = False
-
         super(WeightNormalization, self).__init__(layer, **kwargs)
+        self.data_init = data_init
+        self._initialized = False
         self._track_trackable(layer, name='layer')
-
-    def _compute_weights(self):
-        """Generate weights by combining the direction of weight vector with
-        its norm."""
-        with tf.name_scope('compute_weights'):
-            self.layer.kernel = tf.nn.l2_normalize(
-                self.layer.v, axis=self.kernel_norm_axes) * self.layer.g
-
-    def _init_norm(self, weights):
-        """Set the norm of the weight vector."""
-        with tf.name_scope('init_norm'):
-            flat = tf.reshape(weights, [-1, self.layer_depth])
-            return tf.reshape(
-                tf.linalg.norm(flat, axis=0), (self.layer_depth,))
-
-    def _data_dep_init(self, inputs):
-        """Data dependent initialization."""
-
-        with tf.name_scope('data_dep_init'):
-            # Generate data dependent init values
-            activation = self.layer.activation
-            self.layer.activation = None
-            x_init = self.layer.call(inputs)
-            data_norm_axes = list(range(x_init.shape.rank - 1))
-            m_init, v_init = tf.nn.moments(x_init, data_norm_axes)
-            scale_init = 1. / tf.math.sqrt(v_init + 1e-10)
-
-        # Assign data dependent init values
-        self.layer.g = self.layer.g * scale_init
-        self.layer.bias = (-m_init * scale_init)
-        self.layer.activation = activation
-        self.initialized = True
 
     def build(self, input_shape):
         """Build `Layer`"""
@@ -107,7 +68,6 @@ class WeightNormalization(tf.keras.layers.Wrapper):
 
         if not self.layer.built:
             self.layer.build(input_shape)
-            self.layer.built = False
 
             if not hasattr(self.layer, 'kernel'):
                 raise ValueError('`WeightNormalization` must wrap a layer that'
@@ -118,34 +78,77 @@ class WeightNormalization(tf.keras.layers.Wrapper):
             self.kernel_norm_axes = list(
                 range(self.layer.kernel.shape.rank - 1))
 
-            self.layer.v = self.layer.kernel
-            self.layer.g = self.layer.add_variable(
+            self.v = self.layer.kernel
+            self.g = self.add_variable(
                 name="g",
                 shape=(self.layer_depth,),
                 initializer=tf.keras.initializers.get('ones'),
                 dtype=self.layer.kernel.dtype,
-                trainable=True,
-                aggregation=tf.VariableAggregation.MEAN)
-
-            # TODO: Check if this needs control deps in TF2 graph mode
-            self.layer.g.assign(self._init_norm(self.layer.v))
-            self._compute_weights()
-
-            self.layer.built = True
+                trainable=True)
 
         super(WeightNormalization, self).build()
-        self.built = True
 
-    @tf.function
     def call(self, inputs):
         """Call `Layer`"""
-        if not self.initialized:
-            self._data_dep_init(inputs)
+        if not self._initialized:
+            self._initialize_weights(inputs)
 
         self._compute_weights()  # Recompute weights for each forward pass
-        output = self.layer.call(inputs)
+        output = self.layer(inputs)
         return output
 
     def compute_output_shape(self, input_shape):
         return tf.TensorShape(
             self.layer.compute_output_shape(input_shape).as_list())
+
+    def _compute_weights(self):
+        """Generate normalized weights.
+
+        This method will update the value of self.layer.kernel with the
+        normalized value, so that the layer is ready for call().
+        """
+        with tf.name_scope('compute_weights'):
+            self.layer.kernel = tf.nn.l2_normalize(
+                self.v, axis=self.kernel_norm_axes) * self.g
+
+    def _initialize_weights(self, inputs):
+        """Initialize weight g.
+
+        The initial value of g could either from the initial value in v,
+        or by the input value if self.data_init is True.
+        """
+        if self.data_init:
+            self._data_dep_init(inputs)
+        else:
+            self._init_norm()
+        self._initialized = True
+
+    def _init_norm(self):
+        """Set the weight g with the norm of the weight vector."""
+        with tf.name_scope('init_norm'):
+            flat = tf.reshape(self.v, [-1, self.layer_depth])
+            self.g.assign(
+                tf.reshape(tf.linalg.norm(flat, axis=0), (self.layer_depth,)))
+
+    def _data_dep_init(self, inputs):
+        """Data dependent initialization."""
+
+        with tf.name_scope('data_dep_init'):
+            # Generate data dependent init values
+            existing_activation = self.layer.activation
+            self.layer.activation = None
+            x_init = self.layer(inputs)
+            data_norm_axes = list(range(x_init.shape.rank - 1))
+            m_init, v_init = tf.nn.moments(x_init, data_norm_axes)
+            scale_init = 1. / tf.math.sqrt(v_init + 1e-10)
+
+        # Assign data dependent init values
+        self.g.assign(self.g * scale_init)
+        if hasattr(self.layer, 'bias'):
+            self.layer.bias.assign(-m_init * scale_init)
+        self.layer.activation = existing_activation
+
+    def get_config(self):
+        config = {'data_init': self.data_init}
+        base_config = super(WeightNormalization, self).get_config()
+        return dict(list(base_config.items()) + list(config.items()))

--- a/tensorflow_addons/layers/wrappers_test.py
+++ b/tensorflow_addons/layers/wrappers_test.py
@@ -31,7 +31,6 @@ class WeightNormalizationTest(tf.test.TestCase):
         model.add(
             wrappers.WeightNormalization(
                 tf.keras.layers.Dense(2), input_shape=(3, 4)))
-
         model.compile(
             optimizer=tf.keras.optimizers.RMSprop(learning_rate=0.001),
             loss='mse')
@@ -40,7 +39,7 @@ class WeightNormalizationTest(tf.test.TestCase):
             np.random.random((10, 3, 2)),
             epochs=3,
             batch_size=10)
-        self.assertTrue(hasattr(model.layers[0].layer, 'g'))
+        self.assertTrue(hasattr(model.layers[0], 'g'))
 
     def test_weightnorm_dense_train_notinit(self):
         model = tf.keras.models.Sequential()
@@ -56,7 +55,7 @@ class WeightNormalizationTest(tf.test.TestCase):
             np.random.random((10, 3, 2)),
             epochs=3,
             batch_size=10)
-        self.assertTrue(hasattr(model.layers[0].layer, 'g'))
+        self.assertTrue(hasattr(model.layers[0], 'g'))
 
     def test_weightnorm_conv2d(self):
         model = tf.keras.models.Sequential()
@@ -74,18 +73,18 @@ class WeightNormalizationTest(tf.test.TestCase):
             epochs=3,
             batch_size=10)
 
-        self.assertTrue(hasattr(model.layers[0].layer, 'g'))
+        self.assertTrue(hasattr(model.layers[0], 'g'))
 
     def test_weightnorm_tflayers(self):
         images = tf.random.uniform((2, 4, 4, 3))
         wn_wrapper = wrappers.WeightNormalization(
             tf.keras.layers.Conv2D(32, [2, 2]), input_shape=(4, 4, 3))
         wn_wrapper.apply(images)
-        self.assertTrue(hasattr(wn_wrapper.layer, 'g'))
+        self.assertTrue(hasattr(wn_wrapper, 'g'))
 
     def test_weightnorm_nonlayer(self):
         images = tf.random.uniform((2, 4, 43))
-        with self.assertRaises(ValueError):
+        with self.assertRaises(AssertionError):
             wrappers.WeightNormalization(images)
 
     def test_weightnorm_nokernel(self):
@@ -95,7 +94,7 @@ class WeightNormalizationTest(tf.test.TestCase):
 
     def test_weightnorm_keras(self):
         input_data = np.random.random((10, 3, 4)).astype(np.float32)
-        outputs = test_utils.layer_test(
+        test_utils.layer_test(
             wrappers.WeightNormalization,
             kwargs={
                 'layer': tf.keras.layers.Dense(2),


### PR DESCRIPTION
1. Move the weights v and g to the wrapper itself, since they are
more tie to the concept of weight norm, not the wrapped layer.
2. Update the build() method to only create weights, and not do
weights manipulation. Setting the init value based on the inputs
are done in call().
3. Remove the tf.function annotation on call, for debugability.
4. Renamed few function and add some comments for readability.
5. Added get_config() for serialization.