### PR TITLE
 Add LayerNormLSTMCell to RNN cell

### DIFF
--- a/tensorflow_addons/rnn/cell.py
+++ b/tensorflow_addons/rnn/cell.py
@@ -40,14 +40,14 @@ class NASCell(keras.layers.AbstractRNNCell):
     _NAS_BASE = 8
 
     def __init__(self,
-        units,
-        projection=None,
-        use_bias=False,
-        kernel_initializer="glorot_uniform",
-        recurrent_initializer="glorot_uniform",
-        projection_initializer="glorot_uniform",
-        bias_initializer="zeros",
-        **kwargs):
+                 units,
+                 projection=None,
+                 use_bias=False,
+                 kernel_initializer="glorot_uniform",
+                 recurrent_initializer="glorot_uniform",
+                 projection_initializer="glorot_uniform",
+                 bias_initializer="zeros",
+                 **kwargs):
         """Initialize the parameters for a NAS cell.
 
         Args:

--- a/tensorflow_addons/rnn/cell.py
+++ b/tensorflow_addons/rnn/cell.py
@@ -40,14 +40,14 @@ class NASCell(keras.layers.AbstractRNNCell):
     _NAS_BASE = 8
 
     def __init__(self,
-                 units,
-                 projection=None,
-                 use_bias=False,
-                 kernel_initializer="glorot_uniform",
-                 recurrent_initializer="glorot_uniform",
-                 projection_initializer="glorot_uniform",
-                 bias_initializer="zeros",
-                 **kwargs):
+        units,
+        projection=None,
+        use_bias=False,
+        kernel_initializer="glorot_uniform",
+        recurrent_initializer="glorot_uniform",
+        projection_initializer="glorot_uniform",
+        bias_initializer="zeros",
+        **kwargs):
         """Initialize the parameters for a NAS cell.
 
         Args:
@@ -208,3 +208,177 @@ class NASCell(keras.layers.AbstractRNNCell):
         }
         base_config = super(NASCell, self).get_config()
         return dict(list(base_config.items()) + list(config.items()))
+
+
+@keras_utils.register_keras_custom_object
+class LayerNormLSTMCell(keras.layers.LSTMCell):
+    """LSTM cell with layer normalization and recurrent dropout.
+
+    This class adds layer normalization and recurrent dropout to a LSTM unit.
+    Layer normalization implementation is based on:
+
+      https://arxiv.org/abs/1607.06450.
+
+    "Layer Normalization" Jimmy Lei Ba, Jamie Ryan Kiros, Geoffrey E. Hinton
+
+    and is applied before the internal nonlinearities.
+    Recurrent dropout is base on:
+
+      https://arxiv.org/abs/1603.05118
+
+    "Recurrent Dropout without Memory Loss"
+    Stanislau Semeniuta, Aliaksei Severyn, Erhardt Barth.
+    """
+
+    def __init__(self,
+                 units,
+                 activation='tanh',
+                 recurrent_activation='sigmoid',
+                 use_bias=True,
+                 kernel_initializer='glorot_uniform',
+                 recurrent_initializer='orthogonal',
+                 bias_initializer='zeros',
+                 unit_forget_bias=True,
+                 kernel_regularizer=None,
+                 recurrent_regularizer=None,
+                 bias_regularizer=None,
+                 kernel_constraint=None,
+                 recurrent_constraint=None,
+                 bias_constraint=None,
+                 dropout=0.,
+                 recurrent_dropout=0.,
+                 layer_norm=True,
+                 norm_gamma_initializer='ones',
+                 norm_beta_initializer='zeros',
+                 norm_epsilon=1e-3,
+                 **kwargs):
+        """Initializes the LSTM cell.
+
+        Args:
+          units: Positive integer, dimensionality of the output space.
+          activation: Activation function to use. Default: hyperbolic tangent
+            (`tanh`). If you pass `None`, no activation is applied (ie.
+            "linear" activation: `a(x) = x`).
+          recurrent_activation: Activation function to use for the recurrent
+            step. Default: sigmoid (`sigmoid`). If you pass `None`, no
+            activation is applied (ie. "linear" activation: `a(x) = x`).
+          use_bias: Boolean, whether the layer uses a bias vector.
+          kernel_initializer: Initializer for the `kernel` weights matrix, used
+            for the linear transformation of the inputs.
+          recurrent_initializer: Initializer for the `recurrent_kernel` weights
+            matrix, used for the linear transformation of the recurrent state.
+          bias_initializer: Initializer for the bias vector.
+          unit_forget_bias: Boolean. If True, add 1 to the bias of the forget
+            gate at initialization. Setting it to true will also force
+            `bias_initializer="zeros"`. This is recommended in [Jozefowicz et
+              al.](http://www.jmlr.org/proceedings/papers/v37/jozefowicz15.pdf)
+          kernel_regularizer: Regularizer function applied to the `kernel`
+            weights matrix.
+          recurrent_regularizer: Regularizer function applied to
+            the `recurrent_kernel` weights matrix.
+          bias_regularizer: Regularizer function applied to the bias vector.
+          kernel_constraint: Constraint function applied to the `kernel`
+            weights matrix.
+          recurrent_constraint: Constraint function applied to the
+            `recurrent_kernel` weights matrix.
+          bias_constraint: Constraint function applied to the bias vector.
+          dropout: Float between 0 and 1. Fraction of the units to drop for the
+            linear transformation of the inputs.
+          recurrent_dropout: Float between 0 and 1. Fraction of the units to
+            drop for the linear transformation of the recurrent state.
+          layer_norm: If `True`, layer normalization will be applied.
+          norm_gamma_initializer: Initializer for the layer normalization gain
+            initial value. If `layer_norm` has been set to `False`, this
+            argument will be ignored.
+          norm_beta_initializer: Initializer for the layer normalization shift
+            initial value. If `layer_norm` has been set to `False`, this
+            argument will be ignored.
+          **kwargs: Dict, the other keyword arguments for layer creation.
+        """
+        super(LayerNormLSTMCell, self).__init__(
+            units,
+            activation=activation,
+            recurrent_activation=recurrent_activation,
+            use_bias=use_bias,
+            kernel_initializer=kernel_initializer,
+            recurrent_initializer=recurrent_initializer,
+            bias_initializer=bias_initializer,
+            unit_forget_bias=unit_forget_bias,
+            kernel_regularizer=kernel_regularizer,
+            recurrent_regularizer=recurrent_regularizer,
+            bias_regularizer=bias_regularizer,
+            kernel_constraint=kernel_constraint,
+            recurrent_constraint=recurrent_constraint,
+            bias_constraint=bias_constraint,
+            dropout=dropout,
+            recurrent_dropout=recurrent_dropout,
+            **kwargs)
+        self.layer_norm = layer_norm
+        self.norm_gamma_initializer = keras.initializers.get(
+            norm_gamma_initializer)
+        self.norm_beta_initializer = keras.initializers.get(
+            norm_beta_initializer)
+        self.norm_epsilon = norm_epsilon
+        if self.layer_norm:
+            self.kernel_norm = self._create_norm_layer('kernel_norm')
+            self.recurrent_norm = self._create_norm_layer('recurrent_norm')
+            self.state_norm = self._create_norm_layer('state_norm')
+
+    def build(self, input_shape):
+        super(LayerNormLSTMCell, self).build(input_shape)
+        if self.layer_norm:
+            norm_input_shape = [input_shape[0], self.units]
+            self.kernel_norm.build(norm_input_shape)
+            self.recurrent_norm.build(norm_input_shape)
+            self.state_norm.build(norm_input_shape)
+
+    def call(self, inputs, states, training=None):
+        if not self.layer_norm:
+            return super(LayerNormLSTMCell, self).call(
+                inputs, states, training=training)
+        # For the layer norm implementation
+        h_tm1 = states[0]  # previous memory state
+        c_tm1 = states[1]  # previous carry state
+
+        # Linear calculation
+        dp_mask = self.get_dropout_mask_for_cell(inputs, training, count=4)
+        rec_dp_mask = self.get_recurrent_dropout_mask_for_cell(
+            h_tm1, training, count=4)
+        if 0. < self.dropout < 1.:
+            inputs *= dp_mask[0]
+        z = self.kernel_norm(keras.backend.dot(inputs, self.kernel))
+
+        if 0. < self.recurrent_dropout < 1.:
+            h_tm1 *= rec_dp_mask[0]
+        z += self.recurrent_norm(
+            keras.backend.dot(h_tm1, self.recurrent_kernel))
+        if self.use_bias:
+            z = keras.backend.bias_add(z, self.bias)
+
+        # Apply the layer normalization for each of the gate.
+        z = tf.split(z, num_or_size_splits=4, axis=1)
+        c, o = self._compute_carry_and_output_fused(z, c_tm1)
+        c = self.state_norm(c)
+        h = o * self.activation(c)
+        return h, [h, c]
+
+    def get_config(self):
+        config = {
+            'layer_norm':
+                self.layer_norm,
+            'norm_gamma_initializer':
+                keras.initializers.serialize(self.norm_gamma_initializer),
+            'norm_beta_initializer':
+                keras.initializers.serialize(self.norm_beta_initializer),
+            'norm_epsilon':
+                self.norm_epsilon,
+        }
+        base_config = super(LayerNormLSTMCell, self).get_config()
+        return dict(list(base_config.items()) + list(config.items()))
+
+    def _create_norm_layer(self, name):
+        return keras.layers.LayerNormalization(
+            beta_initializer=self.norm_beta_initializer,
+            gamma_initializer=self.norm_gamma_initializer,
+            epsilon=self.norm_epsilon,
+            name=name)

--- a/tensorflow_addons/rnn/cell.py
+++ b/tensorflow_addons/rnn/cell.py
@@ -222,7 +222,7 @@ class LayerNormLSTMCell(keras.layers.LSTMCell):
     "Layer Normalization" Jimmy Lei Ba, Jamie Ryan Kiros, Geoffrey E. Hinton
 
     and is applied before the internal nonlinearities.
-    Recurrent dropout is base on:
+    Recurrent dropout is based on:
 
       https://arxiv.org/abs/1603.05118
 
@@ -293,6 +293,9 @@ class LayerNormLSTMCell(keras.layers.LSTMCell):
           norm_beta_initializer: Initializer for the layer normalization shift
             initial value. If `layer_norm` has been set to `False`, this
             argument will be ignored.
+          norm_epsilon: Float, the epsilon value for normalization layers. If
+            `layer_norm` has been set to `False`, this argument will be
+            ignored.
           **kwargs: Dict, the other keyword arguments for layer creation.
         """
         super(LayerNormLSTMCell, self).__init__(
@@ -340,7 +343,6 @@ class LayerNormLSTMCell(keras.layers.LSTMCell):
         h_tm1 = states[0]  # previous memory state
         c_tm1 = states[1]  # previous carry state
 
-        # Linear calculation
         dp_mask = self.get_dropout_mask_for_cell(inputs, training, count=4)
         rec_dp_mask = self.get_recurrent_dropout_mask_for_cell(
             h_tm1, training, count=4)
@@ -355,7 +357,6 @@ class LayerNormLSTMCell(keras.layers.LSTMCell):
         if self.use_bias:
             z = keras.backend.bias_add(z, self.bias)
 
-        # Apply the layer normalization for each of the gate.
         z = tf.split(z, num_or_size_splits=4, axis=1)
         c, o = self._compute_carry_and_output_fused(z, c_tm1)
         c = self.state_norm(c)

--- a/tensorflow_addons/rnn/cell.py
+++ b/tensorflow_addons/rnn/cell.py
@@ -365,13 +365,13 @@ class LayerNormLSTMCell(keras.layers.LSTMCell):
     def get_config(self):
         config = {
             'layer_norm':
-                self.layer_norm,
+            self.layer_norm,
             'norm_gamma_initializer':
-                keras.initializers.serialize(self.norm_gamma_initializer),
+            keras.initializers.serialize(self.norm_gamma_initializer),
             'norm_beta_initializer':
-                keras.initializers.serialize(self.norm_beta_initializer),
+            keras.initializers.serialize(self.norm_beta_initializer),
             'norm_epsilon':
-                self.norm_epsilon,
+            self.norm_epsilon,
         }
         base_config = super(LayerNormLSTMCell, self).get_config()
         return dict(list(base_config.items()) + list(config.items()))

--- a/tensorflow_addons/rnn/cell_test.py
+++ b/tensorflow_addons/rnn/cell_test.py
@@ -176,10 +176,10 @@ class NASCellTest(tf.test.TestCase):
 
 
 @test_utils.run_all_in_graph_and_eager_modes
-class LayerNormBasicLSTMCellTest(tf.test.TestCase):
+class LayerNormLSTMCellTest(tf.test.TestCase):
 
     # NOTE: all the values in the current test case have been calculated.
-    def testBasicLSTMCell(self):
+    def testCellOutput(self):
         x = tf.ones([1, 2], dtype=tf.float32)
         c0 = tf.constant(0.1 * np.asarray([[0, 1]]), dtype=tf.float32)
         h0 = tf.constant(0.1 * np.asarray([[2, 3]]), dtype=tf.float32)
@@ -237,43 +237,6 @@ class LayerNormBasicLSTMCellTest(tf.test.TestCase):
         self.assertAllClose(output_states_v[0], expected_h, 1e-5)
         self.assertAllClose(output_states_v[1], expected_c, 1e-5)
 
-    def testBasicLSTMCellWithoutNorm(self):
-        """Tests that BasicLSTMCell with layer_norm=False."""
-        const_initializer = tf.constant_initializer(0.5)
-        single_cell_without_norm = lambda: rnn_cell.LayerNormLSTMCell(
-            units=2,
-            kernel_initializer=const_initializer,
-            recurrent_initializer=const_initializer,
-            bias_initializer=const_initializer,
-            layer_norm=False)
-        standard_lstm_cell = lambda: keras.layers.LSTMCell(
-            units=2,
-            kernel_initializer=const_initializer,
-            recurrent_initializer=const_initializer,
-            bias_initializer=const_initializer)
-        x = tf.ones([1, 2], dtype=tf.float32)
-        c0 = tf.constant(0.1 * np.asarray([[0, 1]]), dtype=tf.float32)
-        h0 = tf.constant(0.1 * np.asarray([[2, 3]]), dtype=tf.float32)
-        state0 = [h0, c0]
-        c1 = tf.constant(0.1 * np.asarray([[4, 5]]), dtype=tf.float32)
-        h1 = tf.constant(0.1 * np.asarray([[6, 7]]), dtype=tf.float32)
-        state1 = [h1, c1]
-        state = (state0, state1)
-
-        norm_cell = keras.layers.StackedRNNCells(
-            [single_cell_without_norm() for _ in range(2)])
-        standard_cell = keras.layers.StackedRNNCells(
-            [standard_lstm_cell() for _ in range(2)])
-        norm_out, norm_states = norm_cell(x, state)
-        standard_out, standard_states = standard_cell(x, state)
-        self.evaluate([tf.compat.v1.global_variables_initializer()])
-        norm_out_v, norm_states_v = self.evaluate([norm_out, norm_states])
-        standard_out_v, standard_states_v = self.evaluate(
-            [standard_out, standard_states])
-
-        self.assertAllClose(norm_out_v, standard_out_v)
-        self.assertAllClose(norm_states_v, standard_states_v)
-
     def test_config(self):
         cell = rnn_cell.LayerNormLSTMCell(10)
 
@@ -312,7 +275,6 @@ class LayerNormBasicLSTMCellTest(tf.test.TestCase):
             "dropout": 0.,
             "recurrent_dropout": 0.,
             "implementation": 2,
-            "layer_norm": True,
             "norm_gamma_initializer": {
                 "class_name": "Ones",
                 "config": {}

--- a/tensorflow_addons/rnn/cell_test.py
+++ b/tensorflow_addons/rnn/cell_test.py
@@ -27,8 +27,9 @@ from tensorflow_addons.rnn import cell as rnn_cell
 
 
 @test_utils.run_all_in_graph_and_eager_modes
-class RNNCellTest(tf.test.TestCase):
-    def test_NASCell(self):
+class NASCellTest(tf.test.TestCase):
+
+    def test_base(self):
         units = 6
         batch_size = 3
         expected_output = np.array(
@@ -82,7 +83,7 @@ class RNNCellTest(tf.test.TestCase):
         self.assertEqual(new_h.shape[1], units)
         self.assertAllClose(np.concatenate(res[1], axis=1), expected_state)
 
-    def test_NASCell_projection(self):
+    def test_projection(self):
         units = 6
         batch_size = 3
         projection = 5
@@ -142,7 +143,7 @@ class RNNCellTest(tf.test.TestCase):
         self.assertEqual(new_h.shape[1], projection)
         self.assertAllClose(np.concatenate(res[1], axis=1), expected_state)
 
-    def test_NASCell_keras_RNN(self):
+    def test_keras_RNN(self):
         """Tests that NASCell works with keras RNN layer."""
         cell = rnn_cell.NASCell(10)
         seq_input = tf.convert_to_tensor(
@@ -152,7 +153,7 @@ class RNNCellTest(tf.test.TestCase):
         self.evaluate([tf.compat.v1.global_variables_initializer()])
         self.assertEqual(self.evaluate(rnn_outputs).shape, (2, 10))
 
-    def test_NASCell_config(self):
+    def test_config(self):
         cell = rnn_cell.NASCell(10, projection=5, use_bias=True)
 
         expected_config = {
@@ -171,6 +172,162 @@ class RNNCellTest(tf.test.TestCase):
         self.assertEqual(config, expected_config)
 
         restored_cell = rnn_cell.NASCell.from_config(config)
+        restored_config = restored_cell.get_config()
+        self.assertEqual(config, restored_config)
+
+
+@test_utils.run_all_in_graph_and_eager_modes
+class LayerNormBasicLSTMCellTest(tf.test.TestCase):
+
+    # NOTE: all the values in the current test case have been calculated.
+    def testBasicLSTMCell(self):
+        x = tf.ones([1, 2], dtype=tf.float32)
+        c0 = tf.constant(0.1 * np.asarray([[0, 1]]), dtype=tf.float32)
+        h0 = tf.constant(0.1 * np.asarray([[2, 3]]), dtype=tf.float32)
+        state0 = [h0, c0]
+        c1 = tf.constant(0.1 * np.asarray([[4, 5]]), dtype=tf.float32)
+        h1 = tf.constant(0.1 * np.asarray([[6, 7]]), dtype=tf.float32)
+        state1 = [h1, c1]
+        state = (state0, state1)
+        const_initializer = tf.constant_initializer(0.5)
+        single_cell = lambda: rnn_cell.LayerNormLSTMCell(
+            units=2,
+            kernel_initializer=const_initializer,
+            recurrent_initializer=const_initializer,
+            bias_initializer=const_initializer,
+            norm_epsilon=1e-12)
+        cell = keras.layers.StackedRNNCells([single_cell() for _ in range(2)])
+        output, output_states = cell(x, state)
+        self.evaluate([tf.compat.v1.global_variables_initializer()])
+        output_v, output_states_v = self.evaluate([output, output_states])
+
+        expected_output = np.array([[-0.47406167, 0.47406143]])
+        expected_state0_c = np.array([[-1., 1.]])
+        expected_state0_h = np.array([[-0.47406167, 0.47406143]])
+        expected_state1_c = np.array([[-1., 1.]])
+        expected_state1_h = np.array([[-0.47406167, 0.47406143]])
+
+        actual_state0_h = output_states_v[0][0]
+        actual_state0_c = output_states_v[0][1]
+        actual_state1_h = output_states_v[1][0]
+        actual_state1_c = output_states_v[1][1]
+
+        self.assertAllClose(output_v, expected_output, 1e-5)
+        self.assertAllClose(expected_state0_c, actual_state0_c, 1e-5)
+        self.assertAllClose(expected_state0_h, actual_state0_h, 1e-5)
+        self.assertAllClose(expected_state1_c, actual_state1_c, 1e-5)
+        self.assertAllClose(expected_state1_h, actual_state1_h, 1e-5)
+
+        # Test BasicLSTMCell with input_size != num_units.
+        x = tf.ones([1, 3], dtype=tf.float32)
+        c = tf.constant(0.1 * np.asarray([[0, 1]]), dtype=tf.float32)
+        h = tf.constant(0.1 * np.asarray([[2, 3]]), dtype=tf.float32)
+        state = [h, c]
+        cell = rnn_cell.LayerNormLSTMCell(
+            units=2,
+            kernel_initializer=const_initializer,
+            recurrent_initializer=const_initializer,
+            bias_initializer=const_initializer,
+            norm_epsilon=1e-12)
+        output, output_states = cell(x, state)
+        self.evaluate([tf.compat.v1.global_variables_initializer()])
+        output_v, output_states_v = self.evaluate([output, output_states])
+        expected_h = np.array([[-0.47406167, 0.47406143]])
+        expected_c = np.array([[-1.0, 1.0]])
+        self.assertAllClose(output_v, expected_h, 1e-5)
+        self.assertAllClose(output_states_v[0], expected_h, 1e-5)
+        self.assertAllClose(output_states_v[1], expected_c, 1e-5)
+
+    def testBasicLSTMCellWithoutNorm(self):
+        """Tests that BasicLSTMCell with layer_norm=False."""
+        const_initializer = tf.constant_initializer(0.5)
+        single_cell_without_norm = lambda: rnn_cell.LayerNormLSTMCell(
+            units=2,
+            kernel_initializer=const_initializer,
+            recurrent_initializer=const_initializer,
+            bias_initializer=const_initializer,
+            layer_norm=False)
+        standard_lstm_cell = lambda: keras.layers.LSTMCell(
+            units=2,
+            kernel_initializer=const_initializer,
+            recurrent_initializer=const_initializer,
+            bias_initializer=const_initializer)
+        x = tf.ones([1, 2], dtype=tf.float32)
+        c0 = tf.constant(0.1 * np.asarray([[0, 1]]), dtype=tf.float32)
+        h0 = tf.constant(0.1 * np.asarray([[2, 3]]), dtype=tf.float32)
+        state0 = [h0, c0]
+        c1 = tf.constant(0.1 * np.asarray([[4, 5]]), dtype=tf.float32)
+        h1 = tf.constant(0.1 * np.asarray([[6, 7]]), dtype=tf.float32)
+        state1 = [h1, c1]
+        state = (state0, state1)
+
+        norm_cell = keras.layers.StackedRNNCells(
+            [single_cell_without_norm() for _ in range(2)])
+        standard_cell = keras.layers.StackedRNNCells(
+            [standard_lstm_cell() for _ in range(2)])
+        norm_out, norm_states = norm_cell(x, state)
+        standard_out, standard_states = standard_cell(x, state)
+        self.evaluate([tf.compat.v1.global_variables_initializer()])
+        norm_out_v, norm_states_v = self.evaluate([norm_out, norm_states])
+        standard_out_v, standard_states_v = self.evaluate(
+            [standard_out, standard_states])
+
+        self.assertAllClose(norm_out_v, standard_out_v)
+        self.assertAllClose(norm_states_v, standard_states_v)
+
+    def test_config(self):
+        cell = rnn_cell.LayerNormLSTMCell(10)
+
+        expected_config = {
+            "dtype": None,
+            "name": "layer_norm_lstm_cell",
+            "trainable": True,
+            "units": 10,
+            "activation": "tanh",
+            "recurrent_activation": "sigmoid",
+            "use_bias": True,
+            "kernel_initializer": {
+                "class_name": "GlorotUniform",
+                "config": {
+                    "seed": None
+                }
+            },
+            "recurrent_initializer": {
+                "class_name": "Orthogonal",
+                "config": {
+                    "seed": None,
+                    "gain": 1.0
+                }
+            },
+            "bias_initializer": {
+                "class_name": "Zeros",
+                "config": {}
+            },
+            "unit_forget_bias": True,
+            "kernel_regularizer": None,
+            "recurrent_regularizer": None,
+            "bias_regularizer": None,
+            "kernel_constraint": None,
+            "recurrent_constraint": None,
+            "bias_constraint": None,
+            "dropout": 0.,
+            "recurrent_dropout": 0.,
+            "implementation": 2,
+            "layer_norm": True,
+            "norm_gamma_initializer": {
+                "class_name": "Ones",
+                "config": {}
+            },
+            "norm_beta_initializer": {
+                "class_name": "Zeros",
+                "config": {}
+            },
+            "norm_epsilon": 1e-3,
+        }
+        config = cell.get_config()
+        self.assertEqual(config, expected_config)
+
+        restored_cell = rnn_cell.LayerNormLSTMCell.from_config(config)
         restored_config = restored_cell.get_config()
         self.assertEqual(config, restored_config)
 

--- a/tensorflow_addons/rnn/cell_test.py
+++ b/tensorflow_addons/rnn/cell_test.py
@@ -28,7 +28,6 @@ from tensorflow_addons.rnn import cell as rnn_cell
 
 @test_utils.run_all_in_graph_and_eager_modes
 class NASCellTest(tf.test.TestCase):
-
     def test_base(self):
         units = 6
         batch_size = 3


### PR DESCRIPTION
1. The change was based on contrib.LayerNormBasicLSTMCell, which is
popular based on https://tf-contrib-analyzer.herokuapp.com.

2. The cell has been updated to align with keras and v2 standard,
eg use keras LSTMCell as base class, get rid of variable scope, etc.

3. The implementation has been updated to match the original paper.
There are 3 norm performed. One for input kernel, second one for
recurrent kernel, and finally for the carry state before activation.
More importantly, the first 2 norm are based on fused gates, rather
than the existing implementation (individual gates separately).

4. Adding the bias when normalization is on. I think missing the bias
was an oversight for the original implementation, and I have confirmed
this with original author of the contrib code.

5. Update the unit test with the correct value.