### PR TITLE
FIX: weightnorm variables

### DIFF
--- a/tensorflow_addons/layers/wrappers.py
+++ b/tensorflow_addons/layers/wrappers.py
@@ -119,7 +119,6 @@ class WeightNormalization(tf.keras.layers.Wrapper):
         or by the input value if self.data_init is True.
         """
         if self.data_init:
-            self._init_norm()
             self._data_dep_init(inputs)
         else:
             self._init_norm()
@@ -131,7 +130,6 @@ class WeightNormalization(tf.keras.layers.Wrapper):
             flat = tf.reshape(self.v, [-1, self.layer_depth])
             self.g.assign(
                 tf.reshape(tf.linalg.norm(flat, axis=0), (self.layer_depth,)))
-            self._compute_weights()
 
     def _data_dep_init(self, inputs):
         """Data dependent initialization."""

--- a/tensorflow_addons/layers/wrappers.py
+++ b/tensorflow_addons/layers/wrappers.py
@@ -93,11 +93,11 @@ class WeightNormalization(tf.keras.layers.Wrapper):
         """Call `Layer`"""
         if not self._initialized:
             self._initialize_weights(inputs)
-            
+
         self._compute_weights()  # Recompute weights for each forward pass
         output = self.layer(inputs)
         return output
-    
+
     def compute_output_shape(self, input_shape):
         return tf.TensorShape(
             self.layer.compute_output_shape(input_shape).as_list())
@@ -155,4 +155,3 @@ class WeightNormalization(tf.keras.layers.Wrapper):
         config = {'data_init': self.data_init}
         base_config = super(WeightNormalization, self).get_config()
         return dict(list(base_config.items()) + list(config.items()))
-        

--- a/tensorflow_addons/layers/wrappers_test.py
+++ b/tensorflow_addons/layers/wrappers_test.py
@@ -75,7 +75,7 @@ class WeightNormalizationTest(tf.test.TestCase):
 
         self.assertTrue(hasattr(model.layers[0], 'g'))
 
-    def test_weightnorm_tflayers(self):
+    def test_weightnorm_applylayer(self):
         images = tf.random.uniform((2, 4, 4, 3))
         wn_wrapper = wrappers.WeightNormalization(
             tf.keras.layers.Conv2D(32, [2, 2]), input_shape=(4, 4, 3))


### PR DESCRIPTION
Closes #216

Looks like assigning the variables using operations during init created an issue in the gradients. Setting their values inside of tf.function as done before appears to fix it. I'm not really thrilled about the lack of test coverage, but also not excited to build a regression test into our unit tests. 

https://colab.research.google.com/drive/1Md7SnyEC5bUfkME1Akth4KKM24ac26NK

After this bugfix is in I'll work on publishing a 0.3 release


