### PR TITLE
FIX: x_test scaling in weightnormalization example

### DIFF
--- a/tensorflow_addons/examples/layers_weightnormalization.ipynb
+++ b/tensorflow_addons/examples/layers_weightnormalization.ipynb
@@ -230,7 +230,7 @@
         "x_train = x_train.astype('float32')\n",
         "x_test = x_test.astype('float32')\n",
         "x_train /= 255\n",
-        "x_test /= 25"
+        "x_test /= 255"
       ],
       "execution_count": 0,
       "outputs": []


### PR DESCRIPTION
Should be 255 instead of 25.