### PR TITLE
fixing extract_image_patches

### DIFF
--- a/tensorflow_addons/image/filters.py
+++ b/tensorflow_addons/image/filters.py
@@ -91,7 +91,7 @@ def median_filter2d(image, filter_shape=(3, 3), name=None):
         for a in range(ch):
             img = image[:, :, a:a + 1]
             img = tf.reshape(img, [1, row, col, 1])
-            slic = tf.image.extract_patches(
+            slic = tf.image.extract_image_patches(
                 img, [1, filter_shapex, filter_shapey, 1], [1, 1, 1, 1],
                 [1, 1, 1, 1],
                 padding='SAME')


### PR DESCRIPTION
tensorflow==2.0.0.a0 does not have any function extract_patches in tf.image. That will be extract_image_patches. I have installed the latest public version of tensorflow==2.0.0.a0.

@seanpmorgan Please restore this.