### PR TITLE
CLN: Remove outdated python RegisterShape

### DIFF
--- a/tensorflow_addons/image/distance_transform.py
+++ b/tensorflow_addons/image/distance_transform.py
@@ -18,16 +18,12 @@ from __future__ import division
 from __future__ import print_function
 
 import tensorflow as tf
-from tensorflow.python.framework import common_shapes
-from tensorflow.python.framework import ops
 from tensorflow_addons.utils.resource_loader import get_path_to_datafile
 
 _image_ops_so = tf.load_op_library(
     get_path_to_datafile("custom_ops/image/_image_ops.so"))
 
 tf.no_gradient("EuclideanDistanceTransform")
-ops.RegisterShape("EuclideanDistanceTransform")(
-    common_shapes.call_cpp_shape_fn)
 
 
 @tf.function

--- a/tensorflow_addons/image/transform_ops.py
+++ b/tensorflow_addons/image/transform_ops.py
@@ -18,8 +18,6 @@ from __future__ import division
 from __future__ import print_function
 
 import tensorflow as tf
-from tensorflow.python.framework import common_shapes
-from tensorflow.python.framework import ops
 from tensorflow_addons.utils.resource_loader import get_path_to_datafile
 
 _image_ops_so = tf.load_op_library(
@@ -29,9 +27,6 @@ _IMAGE_DTYPES = set([
     tf.dtypes.uint8, tf.dtypes.int32, tf.dtypes.int64, tf.dtypes.float16,
     tf.dtypes.float32, tf.dtypes.float64
 ])
-
-ops.RegisterShape("ImageProjectiveTransformV2")(
-    common_shapes.call_cpp_shape_fn)
 
 
 @tf.function


### PR DESCRIPTION
Removing private API and I believe these are leftover from a TF version from long ago.

0.11 Release mentions removing the python SetShape, and I see no uses of this in TF core repository. I belive the C++ SetShape is all that is required:
https://github.com/tensorflow/tensorflow/blob/master/tensorflow/python/framework/ops.py#L2798