### PR TITLE
Use compat.v1 for broadcasted tf.where

### DIFF
--- a/tensorflow_addons/activations/sparsemax.py
+++ b/tensorflow_addons/activations/sparsemax.py
@@ -126,7 +126,8 @@ def _compute_2d_sparsemax(logits, name=None):
     p = tf.math.maximum(
         tf.cast(0, logits.dtype), z - tf.expand_dims(tau_z, -1))
     # If k_z = 0 or if z = nan, then the input is invalid
-    p_safe = tf.where(
+    # TODO: Adjust dimension order for TF2 broadcasting
+    p_safe = tf.compat.v1.where(
         tf.math.logical_or(
             tf.math.equal(k_z, 0), tf.math.is_nan(z_cumsum[:, -1])),
         tf.fill([obs, dims], tf.cast(float("nan"), logits.dtype)), p)

--- a/tensorflow_addons/seq2seq/decoder.py
+++ b/tensorflow_addons/seq2seq/decoder.py
@@ -406,8 +406,10 @@ def dynamic_decode(decoder,
             # Zero out output values past finish
             if impute_finished:
                 emit = tf.nest.map_structure(
-                    lambda out, zero: tf.where(finished, zero, out),
-                    next_outputs, zero_outputs)
+                    # TODO: Adjust dimension order for TF2 broadcasting
+                    lambda out, zero: tf.compat.v1.where(finished, zero, out),
+                    next_outputs,
+                    zero_outputs)
             else:
                 emit = next_outputs
 
@@ -419,7 +421,9 @@ def dynamic_decode(decoder,
                 else:
                     new.set_shape(cur.shape)
                     pass_through = (new.shape.ndims == 0)
-                return new if pass_through else tf.where(finished, cur, new)
+                # TODO: Adjust dimension order for TF2 broadcasting
+                return new if pass_through else tf.compat.v1.where(
+                    finished, cur, new)
 
             if impute_finished:
                 next_state = tf.nest.map_structure(_maybe_copy_state,

--- a/tensorflow_addons/seq2seq/sampler.py
+++ b/tensorflow_addons/seq2seq/sampler.py
@@ -448,9 +448,10 @@ class ScheduledOutputTrainingSampler(TrainingSampler):
                     auxiliary_inputs)
 
             if self.next_inputs_fn is None:
-                return tf.where(sample_ids,
-                                maybe_concatenate_auxiliary_inputs(outputs),
-                                base_next_inputs)
+                # TODO: Adjust dimension order for TF2 broadcasting
+                return tf.compat.v1.where(
+                    sample_ids, maybe_concatenate_auxiliary_inputs(outputs),
+                    base_next_inputs)
 
             where_sampling = tf.cast(tf.where(sample_ids), tf.int32)
             where_not_sampling = tf.cast(


### PR DESCRIPTION
Temporary patch to close #250 and return CI testing. Will make separate issues so that submodule owners can correctly reshape the tensors whenever there is time.