### PR TITLE
ENH: Automate build

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -38,5 +38,4 @@ wheels/
 /artifacts
 
 # Addons
-.*
 /docs/

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,43 @@
+dist: xenial
+language: minimal
+
+git:
+  quiet: true
+
+services:
+- docker
+
+install:
+- curl https://bootstrap.pypa.io/get-pip.py | sudo -H python
+- sudo -H python -m pip install -q -U twine --ignore-installed six
+- twine --version
+
+stages:
+- test
+- build
+
+jobs:
+  include:
+    # Linux Tests
+    - stage: test
+      name: "Test on Ubuntu 14.04"
+      script:
+      - docker run --rm -v ${PWD}:/addons -w /addons tensorflow/tensorflow:nightly-custom-op make unit-test
+
+    # Linux Builds
+    - stage: build
+      name: "Build on Ubuntu 14.04 for Python 2.7 3.4 3.5 3.6"
+      script:
+      - docker run --rm -v $PWD:/addons -w /addons tensorflow/tensorflow:nightly-custom-op tools/ci_build/builds/release_linux.sh
+      after_success:
+        - twine upload -u $PYPI_USER -p $PYPI_PW wheelhouse/*.whl
+
+    # MacOS Builds
+    - stage: build
+      name: "Build on MacOS for Python 2.7"
+      os: osx
+      osx_image: xcode10
+      script:
+        - bash -x -e tools/ci_build/builds/release_macos.sh
+      after_success:
+        - twine upload -u $PYPI_USER -p $PYPI_PW wheelhouse/*.whl

--- a/.travis.yml
+++ b/.travis.yml
@@ -34,7 +34,7 @@ jobs:
 
     # MacOS Builds
     - stage: build
-      name: "Build on MacOS for Python 2.7"
+      name: "Build on MacOS for Python 2.7 3.4 3.5 3.6"
       os: osx
       osx_image: xcode10
       script:

--- a/README.md
+++ b/README.md
@@ -39,6 +39,52 @@ developments that cannot be integrated into core TensorFlow
 | [tfa.seq2seq](tensorflow_addons/seq2seq/README.md) | Google | @qlzh727 |
 | [tfa.text](tensorflow_addons/text/README.md) |  SIG-Addons |  @seanpmorgan @facaiy |
 
+## Installation
+#### Stable Builds
+To install the latest version, run the following:
+```
+pip install tensorflow-addons
+```
+ 
+**Note:** You will also need [`tensorflow==2.0.0.a0`](https://www.tensorflow.org/alpha) installed.
+
+To use addons:
+
+```python
+import tensorflow as tf
+import tensorflow_addons as tfa
+```
+
+#### Nightly Builds
+There are also nightly builds of TensorFlow Addons under the pip package 
+`tfa-nightly`, which is built against `tf-nightly-2.0-preview`. Nightly builds 
+include newer features, but may be less stable than the versioned releases.
+
+```
+pip install tfa-nightly
+```
+
+#### Installing from Source
+You can also install from source. This requires the [Bazel](
+https://bazel.build/) build system.
+
+```
+git clone https://github.com/tensorflow/addons.git
+cd addons
+
+# This script links project with TensorFlow dependency
+./configure.sh
+
+bazel build build_pip_pkg
+bazel-bin/build_pip_pkg artifacts
+
+pip install artifacts/tensorflow_addons-*.whl
+```
+
+## Examples
+See [`examples/`](examples/)
+for end-to-end examples of various addons.
+
 ## Core Concepts
 
 #### Standardized API within Subpackages
@@ -93,45 +139,6 @@ warning.
 
 2. 90 days gives maintainers ample time to fix their code.
 
-
-## Examples
-See [`examples/`](examples/)
-for end-to-end examples of various addons.
-
-## Installation
-#### Stable Builds
-To install the latest version, run the following:
-```
-pip install tensorflow-addons
-```
- 
-**Note:** You will also need [`tensorflow==2.0.0.a0`](https://www.tensorflow.org/alpha) installed.
-
-To use addons:
-
-```python
-import tensorflow as tf
-import tensorflow_addons as tfa
-```
-
-#### Installing from Source
-You can also install from source. This requires the [Bazel](
-https://bazel.build/) build system.
-
-**Note:** If building from master you must install `tf-nightly-2.0-preview` in the process.
-
-```
-git clone https://github.com/tensorflow/addons.git
-cd addons
-
-# This script links project with TensorFlow dependency
-./configure.sh
-
-bazel build build_pip_pkg
-bazel-bin/build_pip_pkg artifacts
-
-pip install artifacts/tensorflow_addons-*.whl
-```
 
 ## Contributing
 TF-Addons is a community led open source project. As such, the project

--- a/build_pip_pkg.sh
+++ b/build_pip_pkg.sh
@@ -26,6 +26,8 @@ function abspath() {
 
 function main() {
   DEST=${1}
+  BUILD_FLAG=${2}
+
   if [[ -z ${DEST} ]]; then
     echo "No destination dir provided"
     exit 1
@@ -47,7 +49,11 @@ function main() {
   pushd ${TMPDIR}
   echo $(date) : "=== Building wheel"
 
-  python setup.py bdist_wheel > /dev/null
+  if [[ -z ${BUILD_FLAG} ]]; then
+    ${PYTHON_VERSION:=python} setup.py bdist_wheel > /dev/null
+  else
+    ${PYTHON_VERSION:=python} setup.py bdist_wheel "${2}" > /dev/null
+  fi
 
   cp dist/*.whl "${DEST}"
   popd

--- a/configure.sh
+++ b/configure.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # Copyright 2019 The TensorFlow Authors. All Rights Reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -40,11 +40,11 @@ case $reply in
     [yY]*) echo "Installing...";;
     * ) echo "Goodbye!"; exit;;
 esac
-pip install $QUIET_FLAG -r requirements.txt
+${PYTHON_VERSION:=python} -m pip install $QUIET_FLAG -r requirements.txt
 
-TF_CFLAGS=( $(python -c 'import tensorflow as tf; print(" ".join(tf.sysconfig.get_compile_flags()))') )
-TF_LFLAGS="$(python -c 'import tensorflow as tf; print(" ".join(tf.sysconfig.get_link_flags()))')"
-TF_CXX11_ABI_FLAG=( $(python -c 'import tensorflow as tf; print(tf.sysconfig.CXX11_ABI_FLAG)') )
+TF_CFLAGS=( $(${PYTHON_VERSION} -c 'import tensorflow as tf; print(" ".join(tf.sysconfig.get_compile_flags()))') )
+TF_LFLAGS="$(${PYTHON_VERSION} -c 'import tensorflow as tf; print(" ".join(tf.sysconfig.get_link_flags()))')"
+TF_CXX11_ABI_FLAG=( $(${PYTHON_VERSION} -c 'import tensorflow as tf; print(tf.sysconfig.CXX11_ABI_FLAG)') )
 
 SHARED_LIBRARY_DIR=${TF_LFLAGS:2}
 SHARED_LIBRARY_NAME=$(echo $TF_LFLAGS | rev | cut -d":" -f1 | rev)

--- a/setup.py
+++ b/setup.py
@@ -17,10 +17,10 @@
 TensorFlow Addons is a repository of contributions that conform to
 well-established API patterns,but implement new functionality not available in
 core TensorFlow.TensorFlow natively supports a large number of operators,
-layers, metrics, losses, and optimizers. However, in a fast movingfield like
+layers, metrics, losses, and optimizers. However, in a fast moving field like
 ML, there are many interesting new developments that cannot be integrated into
 core TensorFlow (because their broad applicability is not yet clear, or it is
-mostly used by a smallersubset of the community).
+mostly used by a smaller subset of the community).
 """
 
 from __future__ import absolute_import
@@ -28,7 +28,9 @@ from __future__ import division
 from __future__ import print_function
 
 import os
+import sys
 
+from datetime import datetime
 from setuptools import find_packages
 from setuptools import setup
 from setuptools.dist import Distribution
@@ -46,7 +48,13 @@ REQUIRED_PACKAGES = [
     'six >= 1.10.0',
 ]
 
-project_name = 'tensorflow-addons'
+if '--nightly' in sys.argv:
+    project_name = 'tfa-nightly'
+    nightly_idx = sys.argv.index('--nightly')
+    sys.argv.pop(nightly_idx)
+    version['__version__'] += datetime.strftime(datetime.today(), "%Y%m%d")
+else:
+    project_name = 'tensorflow-addons'
 
 
 class BinaryDistribution(Distribution):
@@ -78,7 +86,6 @@ setup(
         'Programming Language :: Python :: 3.4',
         'Programming Language :: Python :: 3.5',
         'Programming Language :: Python :: 3.6',
-        'Programming Language :: Python :: 3.7',
         'Topic :: Scientific/Engineering :: Mathematics',
         'Topic :: Software Development :: Libraries :: Python Modules',
         'Topic :: Software Development :: Libraries',

--- a/tools/ci_build/builds/release_linux.sh
+++ b/tools/ci_build/builds/release_linux.sh
@@ -1,0 +1,48 @@
+#!/usr/bin/env bash
+# Copyright 2019 The TensorFlow Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ==============================================================================
+set -e -x
+
+PYTHON_VERSIONS="python2.7 python3.4 python3.5 python3.6"
+curl -sSOL https://bootstrap.pypa.io/get-pip.py
+add-apt-repository -y ppa:deadsnakes/ppa
+
+for version in ${PYTHON_VERSIONS}; do
+    export PYTHON_VERSION=${version}
+    apt-get -y -qq update && apt-get -y -qq install ${PYTHON_VERSION}
+
+    ${PYTHON_VERSION} get-pip.py -q
+    ${PYTHON_VERSION} -m pip --version
+
+    #Link TF dependency
+    yes 'y' | ./configure.sh --quiet
+
+    # Build
+    bazel build \
+      --noshow_progress \
+      --noshow_loading_progress \
+      --verbose_failures \
+      --test_output=errors \
+      build_pip_pkg
+
+    # Package Whl
+    bazel-bin/build_pip_pkg artifacts --nightly
+
+    # Uncomment and use this command for release branches
+    #bazel-bin/build_pip_pkg artifacts
+done
+
+# Verify Wheels
+./tools/ci_build/builds/wheel_verify.sh

--- a/tools/ci_build/builds/release_macos.sh
+++ b/tools/ci_build/builds/release_macos.sh
@@ -1,0 +1,52 @@
+#!/usr/bin/env bash
+# Copyright 2019 The TensorFlow Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ==============================================================================
+set -e -x
+
+PYTHON_VERSIONS="2.7.15 3.4.9 3.5.6 3.6.6"
+curl -sSOL https://bootstrap.pypa.io/get-pip.py
+brew update
+brew tap bazelbuild/tap
+brew install bazelbuild/tap/bazel
+eval "$(pyenv init -)"
+
+for version in ${PYTHON_VERSIONS}; do
+    export PYENV_VERSION=${version}
+    pyenv install -s $PYENV_VERSION
+
+
+    python get-pip.py -q
+    python -m pip install -q delocate
+
+    #Link TF dependency
+    yes 'y' | sudo ./configure.sh --quiet
+
+    # Build
+    bazel build \
+      --noshow_progress \
+      --noshow_loading_progress \
+      --verbose_failures \
+      --test_output=errors \
+      build_pip_pkg
+
+    # Package Whl
+    bazel-bin/build_pip_pkg artifacts --nightly
+
+    # Uncomment and use this command for release branches
+    #bazel-bin/build_pip_pkg artifacts
+done
+
+## Verify Wheel
+./tools/ci_build/builds/wheel_verify.sh

--- a/tools/ci_build/builds/release_macos.sh
+++ b/tools/ci_build/builds/release_macos.sh
@@ -26,7 +26,6 @@ for version in ${PYTHON_VERSIONS}; do
     export PYENV_VERSION=${version}
     pyenv install -s $PYENV_VERSION
 
-
     python get-pip.py -q
     python -m pip install -q delocate
 

--- a/tools/ci_build/builds/wheel_verify.sh
+++ b/tools/ci_build/builds/wheel_verify.sh
@@ -1,0 +1,27 @@
+#!/bin/bash
+# Copyright 2019 The TensorFlow Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ==============================================================================
+
+set -e
+
+ls artifacts/*
+for f in artifacts/*.whl; do
+  if [[ $(uname) == "Darwin" ]]; then
+    delocate-wheel -w wheelhouse  $f
+  else
+    auditwheel repair $f
+  fi
+done
+ls wheelhouse/*


### PR DESCRIPTION
Closes #76 

Nightlies are being pushed to:
https://pypi.org/project/tfa-nightly/#files

Will set up a nightly cron once this is merged into master. This is also a big help for the 0.4 release which should be happening shortly after TF2 release candidate