### PR TITLE
FIX: Use keras loss

### DIFF
--- a/tensorflow_addons/seq2seq/loss.py
+++ b/tensorflow_addons/seq2seq/loss.py
@@ -143,7 +143,7 @@ def sequence_loss(logits,
         return crossent
 
 
-class SequenceLoss(tf.losses.Loss):
+class SequenceLoss(tf.keras.losses.Loss):
     """Weighted cross-entropy loss for a sequence of logits."""
 
     def __init__(self,


### PR DESCRIPTION
Fixes today's broken nightly.

Just curious -- I guess the decision has been made to remove the tf.* aliases? I think its a nice API clean-up personally but I wasn't aware this was happening.