### PR TITLE
DOC: Clear SIG-Addons as a maintainer

### DIFF
--- a/tensorflow_addons/layers/README.md
+++ b/tensorflow_addons/layers/README.md
@@ -3,11 +3,11 @@
 ## Maintainers
 | Submodule  |  Maintainers  | Contact Info   |
 |:---------- |:----------- |:------------- |
-| maxout |  SIG-Addons | addons@tensorflow.org |
+| maxout |  |  |
 | normalizations | @smokrow | moritz.kroeger@tu-dortmund.de |
-| poincare | SIG-Addons | addons@tensorflow.org |
+| poincare |  |  |
 | sparsemax | @AndreasMadsen | amwwebdk+github@gmail.com |
-| wrappers | SIG-Addons | addons@tensorflow.org |
+| wrappers | @seanpmorgan | seanmorgan@outlook.com |
 
 ## Components
 | Submodule  | Layer |  Reference  |

--- a/tensorflow_addons/losses/README.md
+++ b/tensorflow_addons/losses/README.md
@@ -4,10 +4,10 @@
 | Submodule  |  Maintainers  | Contact Info   |
 |:---------- |:----------- |:------------- |
 | contrastive |  @WindQAQ | windqaq@gmail.com |
-| focal_loss |  SIG-Addons | addons@tensorflow.org |
-| lifted |  SIG-Addons | addons@tensorflow.org |
+| focal_loss |   |  |
+| lifted |  |  |
 | sparsemax_loss | @AndreasMadsen | amwwebdk+github@gmail.com |
-| triplet |  SIG-Addons | addons@tensorflow.org |
+| triplet |   |  |
 
 ## Components
 | Submodule | Loss  | Reference               |

--- a/tensorflow_addons/optimizers/README.md
+++ b/tensorflow_addons/optimizers/README.md
@@ -3,7 +3,7 @@
 ## Maintainers
 | Submodule  | Maintainers  | Contact Info   |
 |:---------- |:------------- |:--------------|
-| lazy_adam |  SIG-Addons | addons@tensorflow.org   |
+| lazy_adam |   |   |
 | moving_average | Dheeraj R. Reddy | dheeraj98reddy@gmail.com |
 | weight_decay_optimizers |  Phil Jund | ijund.phil@googlemail.com   |
 


### PR DESCRIPTION
In preparation for the monthly newsletter / maintainer request. Clearing the legacy SIG-Addons maintainers so it's clear that these are un-maintained.

Obviously if there is a bug the SIG will still look into / fix it -- but for clarity we're looking for submodule maintainers.