### PR TITLE
Add notifications for failing tests/builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -45,6 +45,7 @@ jobs:
 notifications:
   email:
     recipients:
+      - seanmorgan@outlook.com
       - addons-testing@tensorflow.org
     on_success: never
     on_failure: always

--- a/.travis.yml
+++ b/.travis.yml
@@ -41,3 +41,10 @@ jobs:
         - bash -x -e tools/ci_build/builds/release_macos.sh
       after_success:
         - twine upload -u $PYPI_USER -p $PYPI_PW wheelhouse/*.whl
+
+notifications:
+  email:
+    recipients:
+      - addons-testing@tensorflow.org
+    on_success: never
+    on_failure: always


### PR DESCRIPTION
Quick question: @ewilderj do you know if a travis server will be able to email that address without being in the google group?