### PR TITLE
Make gradient tests compatible with eager mode

### DIFF
--- a/tensorflow_addons/image/dense_image_warp_test.py
+++ b/tensorflow_addons/image/dense_image_warp_test.py
@@ -29,10 +29,6 @@ from tensorflow_addons.utils import test_utils
 
 @test_utils.run_all_in_graph_and_eager_modes
 class DenseImageWarpTest(tf.test.TestCase):
-    def setUp(self):
-        np.random.seed(0)
-        tf.random.set_seed(0)
-
     def test_interpolate_small_grid_ij(self):
         grid = tf.constant([[0., 1., 2.], [3., 4., 5.], [6., 7., 8.]],
                            shape=[1, 3, 3, 1])

--- a/tensorflow_addons/image/dense_image_warp_test.py
+++ b/tensorflow_addons/image/dense_image_warp_test.py
@@ -27,11 +27,12 @@ from tensorflow_addons.image import interpolate_bilinear
 from tensorflow_addons.utils import test_utils
 
 
+@test_utils.run_all_in_graph_and_eager_modes
 class DenseImageWarpTest(tf.test.TestCase):
     def setUp(self):
         np.random.seed(0)
+        tf.random.set_seed(0)
 
-    @test_utils.run_in_graph_and_eager_modes
     def test_interpolate_small_grid_ij(self):
         grid = tf.constant([[0., 1., 2.], [3., 4., 5.], [6., 7., 8.]],
                            shape=[1, 3, 3, 1])
@@ -43,7 +44,6 @@ class DenseImageWarpTest(tf.test.TestCase):
 
         self.assertAllClose(expected_results, interp)
 
-    @test_utils.run_in_graph_and_eager_modes
     def test_interpolate_small_grid_xy(self):
         grid = tf.constant([[0., 1., 2.], [3., 4., 5.], [6., 7., 8.]],
                            shape=[1, 3, 3, 1])
@@ -55,7 +55,6 @@ class DenseImageWarpTest(tf.test.TestCase):
 
         self.assertAllClose(expected_results, interp)
 
-    @test_utils.run_in_graph_and_eager_modes
     def test_interpolate_small_grid_batched(self):
         grid = tf.constant([[[0., 1.], [3., 4.]], [[5., 6.], [7., 8.]]],
                            shape=[2, 2, 2, 1])
@@ -134,7 +133,6 @@ class DenseImageWarpTest(tf.test.TestCase):
 
         self.assertAllClose(rand_image, interp)
 
-    @test_utils.run_in_graph_and_eager_modes
     def test_zero_flows(self):
         """Apply _check_zero_flow_correctness() for a few sizes and types."""
         shapes_to_try = [[3, 4, 5, 6], [1, 2, 2, 1]]
@@ -171,7 +169,6 @@ class DenseImageWarpTest(tf.test.TestCase):
                 x_index,
                 low_precision=low_precision)
 
-    @test_utils.run_in_graph_and_eager_modes
     def test_interpolation(self):
         """Apply _check_interpolation_correctness() for a few sizes and
         types."""
@@ -182,7 +179,6 @@ class DenseImageWarpTest(tf.test.TestCase):
                     self._check_interpolation_correctness(
                         shape, im_type, flow_type)
 
-    @test_utils.run_in_graph_and_eager_modes
     def test_gradients_exist(self):
         """Check that backprop can run.
 
@@ -200,9 +196,8 @@ class DenseImageWarpTest(tf.test.TestCase):
         flows = tf.Variable(
             tf.random.normal(shape=flow_shape) * 0.25, dtype=tf.float32)
 
-        interp = dense_image_warp(image, flows)
-
         def loss():
+            interp = dense_image_warp(image, flows)
             return tf.math.reduce_mean(tf.math.square(interp - image))
 
         optimizer = tf.keras.optimizers.Adam(1.0)
@@ -213,7 +208,6 @@ class DenseImageWarpTest(tf.test.TestCase):
         for _ in range(10):
             self.evaluate(minimize_op)
 
-    @test_utils.run_in_graph_and_eager_modes
     def test_size_exception(self):
         """Make sure it throws an exception for images that are too small."""
         shape = [1, 2, 1, 1]

--- a/tensorflow_addons/image/transform_ops_test.py
+++ b/tensorflow_addons/image/transform_ops_test.py
@@ -31,11 +31,6 @@ _DTYPES = set([
 
 
 class ImageOpsTest(tf.test.TestCase):
-    def setUp(self):
-        np.random.seed(0)
-        tf.random.set_seed(0)
-        super(ImageOpsTest, self).setUp()
-
     @test_utils.run_in_graph_and_eager_modes
     def test_compose(self):
         for dtype in _DTYPES:

--- a/tensorflow_addons/image/transform_ops_test.py
+++ b/tensorflow_addons/image/transform_ops_test.py
@@ -73,7 +73,12 @@ class ImageOpsTest(tf.test.TestCase):
         self.assertAllEqual([3, 5], result.shape)
 
     def _test_grad(self, input_shape, output_shape=None):
-        test_image = tf.random.normal(input_shape, dtype=tf.float32)
+        image_size = tf.math.cumprod(input_shape)[-1]
+        image_size = tf.cast(image_size, tf.float32)
+        test_image = tf.reshape(
+            tf.range(0, image_size, dtype=tf.float32), input_shape)
+        # Scale test image to range [0, 0.01]
+        test_image = (test_image / image_size) * 0.01
 
         if output_shape is None:
             resize_shape = None
@@ -94,7 +99,7 @@ class ImageOpsTest(tf.test.TestCase):
         theoretical, numerical = tf.test.compute_gradient(
             transform_fn, [test_image])
 
-        self.assertAllClose(theoretical[0], numerical[0], rtol=1e-4, atol=1e-4)
+        self.assertAllClose(theoretical[0], numerical[0], rtol=1e-6, atol=1e-6)
 
     @test_utils.run_in_graph_and_eager_modes
     def test_grad(self):

--- a/tensorflow_addons/image/transform_ops_test.py
+++ b/tensorflow_addons/image/transform_ops_test.py
@@ -99,7 +99,7 @@ class ImageOpsTest(tf.test.TestCase):
         theoretical, numerical = tf.test.compute_gradient(
             transform_fn, [test_image])
 
-        self.assertAllClose(theoretical[0], numerical[0], rtol=1e-6, atol=1e-6)
+        self.assertAllClose(theoretical[0], numerical[0])
 
     @test_utils.run_in_graph_and_eager_modes
     def test_grad(self):


### PR DESCRIPTION
1. TODO in distort_image_ops_test.py: test gradients in TF2.0 favor.
2. TODO in transform_ops_test.py: use `tf.test.compute_gradient` in TF2.0 version. ~~Note that the tolerance in TF1.x (previous code) is 1e-10, but this will cause < 1% mismatch in TF2.0 gradient checker. It will pass if I set the tolerance to 1e-4 (also tested 1e-5, but failed...).~~
3. There's no need to override `setUp()` method in order to set random seed.
https://github.com/tensorflow/tensorflow/blob/master/tensorflow/python/framework/test_util.py#L1729

reference code:
https://github.com/tensorflow/tensorflow/blob/master/tensorflow/python/keras/optimizer_v2/gradient_descent_test.py#L136