### PR TITLE
DOC: Update doc generator requirements and instructions

### DIFF
--- a/tools/docs/README.md
+++ b/tools/docs/README.md
@@ -2,7 +2,7 @@ Generate API documents
 
 ```bash
 # Install dependencies:
-pip install -r doc_requirements.txt
+pip install -r tools/docs/doc_requirements.txt
 
 # Build tool:
 bazel build tools/docs:build_docs

--- a/tools/docs/doc_requirements.txt
+++ b/tools/docs/doc_requirements.txt
@@ -1,2 +1,3 @@
 git+https://github.com/tensorflow/docs
 pathlib
+pyyaml


### PR DESCRIPTION
Looks like yaml files were added to the api generator:

```
root@30cbf3ddea58:/addons# bazel-bin/tools/docs/build_docs --git_branch=$(git rev-parse --abbrev-ref HEAD)
Traceback (most recent call last):
  File "/addons/bazel-bin/tools/docs/build_docs.runfiles/__main__/tools/docs/build_docs.py", line 36, in <module>
    from tensorflow_docs.api_generator import generate_lib
  File "/usr/local/lib/python2.7/dist-packages/tensorflow_docs/__init__.py", line 7, in <module>
    from tensorflow_docs import api_generator
  File "/usr/local/lib/python2.7/dist-packages/tensorflow_docs/api_generator/__init__.py", line 21, in <module>
    import tensorflow_docs.api_generator.generate_lib
  File "/usr/local/lib/python2.7/dist-packages/tensorflow_docs/api_generator/generate_lib.py", line 38, in <module>
    import yaml
ImportError: No module named yaml
```

https://github.com/tensorflow/docs/blob/master/tools/tensorflow_docs/api_generator/generate_lib.py#L38

