### PR TITLE
FIX: Use element_shape in beam_search_decoder

### DIFF
--- a/tensorflow_addons/seq2seq/beam_search_decoder.py
+++ b/tensorflow_addons/seq2seq/beam_search_decoder.py
@@ -497,27 +497,16 @@ class BeamSearchDecoderMixin(object):
         """
         if not isinstance(t, tf.TensorArray):
             return t
-        # pylint: disable=protected-access
-        # This is a bad hack due to the implementation detail of eager/graph TA.
-        # TODO(b/124374427): Update this to use public property of TensorArray.
-        if tf.executing_eagerly():
-            element_shape = t._element_shape
-        else:
-            element_shape = t._element_shape[0]
-        if (not t._infer_shape or not t._element_shape
-                or element_shape.ndims is None or element_shape.ndims < 1):
-            shape = (element_shape if t._infer_shape and t._element_shape else
-                     tf.TensorShape(None))
+        if t.element_shape.ndims is None or t.element_shape.ndims < 1:
             tf.get_logger().warn(
                 "The TensorArray %s in the cell state is not amenable to "
                 "sorting based on the beam search result. For a "
                 "TensorArray to be sorted, its elements shape must be "
                 "defined and have at least a rank of 1, but saw shape: %s" %
-                (t.handle.name, shape))
+                (t.handle.name, t.element_shape))
             return t
-        # pylint: enable=protected-access
         if not _check_static_batch_beam_maybe(
-                element_shape, tf.get_static_value(self._batch_size),
+                t.element_shape, tf.get_static_value(self._batch_size),
                 self._beam_width):
             return t
         t = t.stack()


### PR DESCRIPTION
Commit [1cd4a2b](https://github.com/tensorflow/tensorflow/commit/1cd4a2b5c8a6224423d8d2ed999e528823ff14aa) in TF removed `_element_shape` from TensorArray.