### PR TITLE
BLD: Remove notification email

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -45,7 +45,6 @@ jobs:
 notifications:
   email:
     recipients:
-      - seanmorgan@outlook.com
       - addons-testing@tensorflow.org
     on_success: never
     on_failure: always


### PR DESCRIPTION
Confirmed that it is successfully able to email the addons-testing mailing list:
https://groups.google.com/a/tensorflow.org/forum/#!topic/addons-testing/2A0gEAS3-gw