### PR TITLE
Fix LayerNormLSTMCell

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,1 @@
-tf-nightly-2.0-preview==2.0.0.dev20190625
+tf-nightly-2.0-preview

--- a/tensorflow_addons/rnn/cell.py
+++ b/tensorflow_addons/rnn/cell.py
@@ -321,10 +321,9 @@ class LayerNormLSTMCell(keras.layers.LSTMCell):
 
     def build(self, input_shape):
         super(LayerNormLSTMCell, self).build(input_shape)
-        norm_input_shape = [input_shape[0], self.units]
-        self.kernel_norm.build(norm_input_shape)
-        self.recurrent_norm.build(norm_input_shape)
-        self.state_norm.build(norm_input_shape)
+        self.kernel_norm.build([input_shape[0], self.units * 4])
+        self.recurrent_norm.build([input_shape[0], self.units * 4])
+        self.state_norm.build([input_shape[0], self.units])
 
     def call(self, inputs, states, training=None):
         h_tm1 = states[0]  # previous memory state


### PR DESCRIPTION
Fix #321.

Bugs are caused by these lines
https://github.com/tensorflow/addons/blob/31750c99bc24620b2d6cba834a5c954e9c666f32/tensorflow_addons/rnn/cell.py#L324-L326
Both kernel_norm and recurrent_norm work on un-split tensors and will take tensors of shape [batch_size, self.units * 4] as input.

Have no idea why previous version could work though...