### PR TITLE
Limit GPU testing jobs

### DIFF
--- a/tools/ci_testing/addons_gpu.sh
+++ b/tools/ci_testing/addons_gpu.sh
@@ -25,7 +25,7 @@ fi
 
 set -x
 
-N_JOBS=$1 # Must limit GPU testing to single job to prevent OOM error.
+N_JOBS=1 # Must limit GPU testing to single job to prevent OOM error.
 
 echo ""
 echo "Bazel will use ${N_JOBS} concurrent job(s)."

--- a/tools/ci_testing/addons_gpu.sh
+++ b/tools/ci_testing/addons_gpu.sh
@@ -25,7 +25,7 @@ fi
 
 set -x
 
-N_JOBS=$(grep -c ^processor /proc/cpuinfo)
+N_JOBS=$1 # Must limit GPU testing to single job to prevent OOM error.
 
 echo ""
 echo "Bazel will use ${N_JOBS} concurrent job(s)."


### PR DESCRIPTION
We run into GPU OOM errors if we allow more than one job. TF claims the entire memory of a card so multiple jobs with a single card causes errors. See:
https://source.cloud.google.com/results/invocations/457625fa-7589-40ca-9f59-c097bac89322/targets/tensorflow_addons%2Fubuntu%2Fgpu%2Fpy2%2Fpresubmit/log