### PR TITLE
BLD: Pin bazel version for macos

### DIFF
--- a/tools/ci_build/builds/release_macos.sh
+++ b/tools/ci_build/builds/release_macos.sh
@@ -19,7 +19,7 @@ PYTHON_VERSIONS="2.7.15 3.4.9 3.5.6 3.6.6"
 curl -sSOL https://bootstrap.pypa.io/get-pip.py
 
 # Install Bazel 0.24
-curl https://github.com/bazelbuild/bazel/releases/download/0.24.1/bazel-0.24.1-installer-darwin-x86_64.sh
+wget https://github.com/bazelbuild/bazel/releases/download/0.24.1/bazel-0.24.1-installer-darwin-x86_64.sh
 chmod +x bazel-0.24.1-installer-darwin-x86_64.sh
 ./bazel-0.24.1-installer-darwin-x86_64.sh --user
 export PATH="$PATH:$HOME/bin"

--- a/tools/ci_build/builds/release_macos.sh
+++ b/tools/ci_build/builds/release_macos.sh
@@ -17,9 +17,13 @@ set -e -x
 
 PYTHON_VERSIONS="2.7.15 3.4.9 3.5.6 3.6.6"
 curl -sSOL https://bootstrap.pypa.io/get-pip.py
-brew update
-brew tap bazelbuild/tap
-brew install bazelbuild/tap/bazel
+
+# Install Bazel 0.24
+curl https://github.com/bazelbuild/bazel/releases/download/0.24.1/bazel-0.24.1-installer-darwin-x86_64.sh
+chmod +x bazel-0.24.1-installer-darwin-x86_64.sh
+./bazel-0.24.1-installer-darwin-x86_64.sh --user
+export PATH="$PATH:$HOME/bin"
+
 eval "$(pyenv init -)"
 
 for version in ${PYTHON_VERSIONS}; do


### PR DESCRIPTION
Resolve `load() statements must be called before any other statement. First non-load() statement appears at ` Error.

Seems we could alter the cuda_configure script to be compatible with 0.25, but for now I think we should align our bazel versions anyway.