### PR TITLE
Add unknown shape tests for adjust_hue_in_yip and random_hsv_in_yiq

### DIFF
--- a/tensorflow_addons/image/distort_image_ops_test.py
+++ b/tensorflow_addons/image/distort_image_ops_test.py
@@ -113,13 +113,15 @@ class AdjustHueInYiqTest(tf.test.TestCase):
 
     def test_adjust_hsv_in_yiq_unknown_shape(self):
         fn = distort_image_ops.adjust_hsv_in_yiq.get_concrete_function(
-            tf.TensorSpec(shape=None, dtype=tf.double))
+            tf.TensorSpec(shape=None, dtype=tf.float64))
         for shape in (2, 3, 3), (4, 2, 3, 3):
             image_np = np.random.rand(*shape) * 255.
             image_tf = tf.constant(image_np)
             self.assertAllClose(
                 self._adjust_hue_in_yiq_np(image_np, 0),
-                self.evaluate(fn(image_tf)), rtol=2e-4, atol=1e-4)
+                self.evaluate(fn(image_tf)),
+                rtol=2e-4,
+                atol=1e-4)
 
     def test_random_hsv_in_yiq_unknown_shape(self):
         fn = distort_image_ops.random_hsv_in_yiq.get_concrete_function(

--- a/tensorflow_addons/image/distort_image_ops_test.py
+++ b/tensorflow_addons/image/distort_image_ops_test.py
@@ -111,6 +111,23 @@ class AdjustHueInYiqTest(tf.test.TestCase):
                                       "but instead has 4 channels"):
             self.evaluate(self._adjust_hue_in_yiq_tf(x_np, delta_h))
 
+    def test_adjust_hsv_in_yiq_unknown_shape(self):
+        fn = distort_image_ops.adjust_hsv_in_yiq.get_concrete_function(
+            tf.TensorSpec(shape=None, dtype=tf.double))
+        for shape in (2, 3, 3), (4, 2, 3, 3):
+            image_np = np.random.rand(*shape) * 255.
+            image_tf = tf.constant(image_np)
+            self.assertAllClose(
+                self._adjust_hue_in_yiq_np(image_np, 0),
+                self.evaluate(fn(image_tf)), rtol=2e-4, atol=1e-4)
+
+    def test_random_hsv_in_yiq_unknown_shape(self):
+        fn = distort_image_ops.random_hsv_in_yiq.get_concrete_function(
+            tf.TensorSpec(shape=None, dtype=tf.float32))
+        for shape in (2, 3, 3), (4, 2, 3, 3):
+            image_tf = tf.ones(shape)
+            self.assertAllEqual(fn(image_tf), fn(image_tf))
+
 
 @test_utils.run_all_in_graph_and_eager_modes
 class AdjustValueInYiqTest(tf.test.TestCase):
@@ -172,6 +189,7 @@ class AdjustValueInYiqTest(tf.test.TestCase):
             self.evaluate(self._adjust_value_in_yiq_tf(x_np, scale))
 
 
+@test_utils.run_all_in_graph_and_eager_modes
 class AdjustSaturationInYiqTest(tf.test.TestCase):
     def _adjust_saturation_in_yiq_tf(self, x_np, scale):
         x = tf.constant(x_np)
@@ -185,7 +203,6 @@ class AdjustSaturationInYiqTest(tf.test.TestCase):
         y_v = x_np * scale + gray * (1 - scale)
         return y_v
 
-    @test_utils.run_in_graph_and_eager_modes
     def test_adjust_random_saturation_in_yiq(self):
         x_shapes = [
             [2, 2, 3],
@@ -223,7 +240,6 @@ class AdjustSaturationInYiqTest(tf.test.TestCase):
                 y_tf = self._adjust_saturation_in_yiq_tf(x_np, scale)
                 self.assertAllClose(y_tf, y_baseline, rtol=2e-4, atol=1e-4)
 
-    @test_utils.run_in_graph_and_eager_modes
     def test_invalid_shapes(self):
         x_np = np.random.rand(2, 3) * 255.
         scale = np.random.rand() * 2.0 - 1.0


### PR DESCRIPTION
This PRs adds the unknown shape tests for `adjust_hue_in_yip` and `random_hsv_in_yiq` (related to #332) and cleans up the test script a little bit. 