### PR TITLE
BLD: Change test sizes of seq2seq

### DIFF
--- a/tensorflow_addons/seq2seq/BUILD
+++ b/tensorflow_addons/seq2seq/BUILD
@@ -33,7 +33,7 @@ py_test(
 
 py_test(
     name = "basic_decoder_test",
-    size = "medium",
+    size = "small",
     srcs = ["basic_decoder_test.py"],
     deps = [
         ":seq2seq",
@@ -42,7 +42,7 @@ py_test(
 
 py_test(
     name = "beam_search_decoder_test",
-    size = "medium",
+    size = "small",
     srcs = ["beam_search_decoder_test.py"],
     deps = [
         ":seq2seq",
@@ -51,7 +51,7 @@ py_test(
 
 py_test(
     name = "beam_search_ops_test",
-    size = "medium",
+    size = "small",
     srcs = ["beam_search_ops_test.py"],
     deps = [
         ":seq2seq",
@@ -60,7 +60,7 @@ py_test(
 
 py_test(
     name = "decoder_test",
-    size = "medium",
+    size = "small",
     srcs = ["decoder_test.py"],
     deps = [
         ":seq2seq",
@@ -69,7 +69,7 @@ py_test(
 
 py_test(
     name = "loss_test",
-    size = "medium",
+    size = "small",
     srcs = ["loss_test.py"],
     deps = [
         ":seq2seq",


### PR DESCRIPTION
* Prevent warning during bazel test

```
WARNING: //tensorflow_addons/seq2seq:basic_decoder_test: Test execution time (3.8s excluding execution overhead) outside of range for MODERATE tests. Consider setting timeout="short" or size="small".
```