### PR TITLE
[WIP] Spectral normalization layer

### DIFF
--- a/tensorflow_addons/layers/wrappers_test.py
+++ b/tensorflow_addons/layers/wrappers_test.py
@@ -141,12 +141,12 @@ class SpectralNormalizationTest(tf.test.TestCase):
 
         self.assertTrue(hasattr(model.layers[0], 'u'))
 
-    def test_spectralnorm_applylayer(self):
+    def test_applylayer(self):
         images = tf.random.uniform((2, 4, 4, 3))
-        wn_wrapper = wrappers.SpectralNormalization(
+        sn_wrapper = wrappers.SpectralNormalization(
             tf.keras.layers.Conv2D(32, [2, 2]), input_shape=(4, 4, 3))
-        wn_wrapper.apply(images)
-        self.assertTrue(hasattr(wn_wrapper, 'u'))
+        sn_wrapper.apply(images)
+        self.assertTrue(hasattr(sn_wrapper, 'u'))
 
     def test_no_layer(self):
         images = tf.random.uniform((2, 4, 43))


### PR DESCRIPTION
Implements SpectralNormalization layer [1].

This is still work in progress, but would be great to get some feedback on this. Things that still need to be done:
- [ ] Make sure that the data shapes and axes are handled correctly
- [ ] Make sure that the `u` and `layer.kernel` assignments are handled correctly
- [ ] Test the wrapper

[1] Miyato, T., Kataoka, T., Koyama, M., & Yoshida, Y. (2018). Spectral normalization for generative adversarial networks. arXiv preprint [arXiv:1802.05957](https://arxiv.org/pdf/1802.05957.pdf).