### PR TITLE
Add fallback flag to seq2seq tests

### DIFF
--- a/tensorflow_addons/seq2seq/attention_wrapper_test.py
+++ b/tensorflow_addons/seq2seq/attention_wrapper_test.py
@@ -147,7 +147,7 @@ class AttentionMechanismTest(tf.test.TestCase, parameterized.TestCase):
         x_test = np.random.randint(vocab, size=(self.batch, self.timestep))
         y = np.random.randn(self.batch, self.timestep)
         model = keras.models.Model([inputs, query, state], score)
-        model.compile("rmsprop", "mse")
+        model.compile("rmsprop", "mse", experimental_run_tf_function=False)
         model.fit([x, self.query, self.state], (y, y))
         y_ref = model.predict_on_batch([x_test, self.query, self.state])
 

--- a/tensorflow_addons/seq2seq/attention_wrapper_test.py
+++ b/tensorflow_addons/seq2seq/attention_wrapper_test.py
@@ -147,6 +147,8 @@ class AttentionMechanismTest(tf.test.TestCase, parameterized.TestCase):
         x_test = np.random.randint(vocab, size=(self.batch, self.timestep))
         y = np.random.randn(self.batch, self.timestep)
         model = keras.models.Model([inputs, query, state], score)
+        # Fall back to v1-style Keras training loop until issue with 
+        # using outputs of a layer in another layer's constructor.
         model.compile("rmsprop", "mse", experimental_run_tf_function=False)
         model.fit([x, self.query, self.state], (y, y))
         y_ref = model.predict_on_batch([x_test, self.query, self.state])
@@ -157,6 +159,10 @@ class AttentionMechanismTest(tf.test.TestCase, parameterized.TestCase):
             config, custom_objects={attention_cls.__name__: attention_cls})
         loaded_model.set_weights(weights)
 
+        # Fall back to v1-style Keras training loop until issue with 
+        # using outputs of a layer in another layer's constructor.
+        loaded_model.compile("rmsprop", "mse", experimental_run_tf_function=False)
+        
         y = loaded_model.predict_on_batch([x_test, self.query, self.state])
 
         self.assertAllClose(y_ref, y)

--- a/tensorflow_addons/seq2seq/attention_wrapper_test.py
+++ b/tensorflow_addons/seq2seq/attention_wrapper_test.py
@@ -147,7 +147,7 @@ class AttentionMechanismTest(tf.test.TestCase, parameterized.TestCase):
         x_test = np.random.randint(vocab, size=(self.batch, self.timestep))
         y = np.random.randn(self.batch, self.timestep)
         model = keras.models.Model([inputs, query, state], score)
-        # Fall back to v1 style Keras training loop until issue with 
+        # Fall back to v1 style Keras training loop until issue with
         # using outputs of a layer in another layer's constructor.
         model.compile("rmsprop", "mse", experimental_run_tf_function=False)
         model.fit([x, self.query, self.state], (y, y))
@@ -159,11 +159,11 @@ class AttentionMechanismTest(tf.test.TestCase, parameterized.TestCase):
             config, custom_objects={attention_cls.__name__: attention_cls})
         loaded_model.set_weights(weights)
 
-        # Fall back to v1 style Keras training loop until issue with 
+        # Fall back to v1 style Keras training loop until issue with
         # using outputs of a layer in another layer's constructor.
         loaded_model.compile(
             "rmsprop", "mse", experimental_run_tf_function=False)
-        
+
         y = loaded_model.predict_on_batch([x_test, self.query, self.state])
 
         self.assertAllClose(y_ref, y)

--- a/tensorflow_addons/seq2seq/attention_wrapper_test.py
+++ b/tensorflow_addons/seq2seq/attention_wrapper_test.py
@@ -161,7 +161,8 @@ class AttentionMechanismTest(tf.test.TestCase, parameterized.TestCase):
 
         # Fall back to v1-style Keras training loop until issue with 
         # using outputs of a layer in another layer's constructor.
-        loaded_model.compile("rmsprop", "mse", experimental_run_tf_function=False)
+        loaded_model.compile(
+            "rmsprop", "mse", experimental_run_tf_function=False)
         
         y = loaded_model.predict_on_batch([x_test, self.query, self.state])
 

--- a/tensorflow_addons/seq2seq/attention_wrapper_test.py
+++ b/tensorflow_addons/seq2seq/attention_wrapper_test.py
@@ -147,7 +147,7 @@ class AttentionMechanismTest(tf.test.TestCase, parameterized.TestCase):
         x_test = np.random.randint(vocab, size=(self.batch, self.timestep))
         y = np.random.randn(self.batch, self.timestep)
         model = keras.models.Model([inputs, query, state], score)
-        # Fall back to v1-style Keras training loop until issue with 
+        # Fall back to v1 style Keras training loop until issue with 
         # using outputs of a layer in another layer's constructor.
         model.compile("rmsprop", "mse", experimental_run_tf_function=False)
         model.fit([x, self.query, self.state], (y, y))
@@ -159,7 +159,7 @@ class AttentionMechanismTest(tf.test.TestCase, parameterized.TestCase):
             config, custom_objects={attention_cls.__name__: attention_cls})
         loaded_model.set_weights(weights)
 
-        # Fall back to v1-style Keras training loop until issue with 
+        # Fall back to v1 style Keras training loop until issue with 
         # using outputs of a layer in another layer's constructor.
         loaded_model.compile(
             "rmsprop", "mse", experimental_run_tf_function=False)


### PR DESCRIPTION
This test uses a Keras anti-pattern in where the layer optionally accepts the output of another layer in the constructor. We are in the process of refactoring the v2 training loop to make it work with tf.function (faster! better! stronger!), but this code will need to be updated as a result. For now, we are falling back to the v1 training loop with an experimental flag; @qlzh727 will look for a longer-term solution when he gets through some pressing release issues.

(The flag won't be in the nightlies until tomorrow, but setting up this PR early, and will wait until tests are green to submit.)