### PR TITLE
TEST: Upgrade python3 env to py36

### DIFF
--- a/tools/ci_testing/addons_cpu.sh
+++ b/tools/ci_testing/addons_cpu.sh
@@ -31,6 +31,7 @@ if [[ ${PLATFORM} == "darwin" ]]; then
     N_JOBS=$(sysctl -n hw.ncpu)
 else
     N_JOBS=$(grep -c ^processor /proc/cpuinfo)
+    tools/ci_testing/install_py36.sh # Patch to test on py36
 fi
 
 

--- a/tools/ci_testing/addons_gpu.sh
+++ b/tools/ci_testing/addons_gpu.sh
@@ -25,6 +25,7 @@ fi
 
 set -x
 
+tools/ci_testing/install_py36.sh # Patch to test on py36
 N_JOBS=1 # Must limit GPU testing to single job to prevent OOM error.
 
 echo ""

--- a/tools/ci_testing/install_py36.sh
+++ b/tools/ci_testing/install_py36.sh
@@ -1,0 +1,30 @@
+#!/usr/bin/env bash
+# Copyright 2019 The TensorFlow Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# ==============================================================================
+# Needed until docker image defaults to at least py35.
+
+set -e -x
+
+curl -sSOL https://bootstrap.pypa.io/get-pip.py
+add-apt-repository -y ppa:deadsnakes/ppa
+
+apt-get -y -qq update && apt-get -y -qq install python3.6
+
+python3.6 get-pip.py -q
+python3.6 -m pip --version
+
+ln -sfn /usr/bin/python3.6 /usr/bin/python3
+pip3 install scipy  # Pre-installed in custom-op


### PR DESCRIPTION
Closes #279.

Py34 pip packages for tf-nightly have not been produced in ~2 weeks. When the new build env arrives we'll be re-vamping our testing scripts anyway.