### PR TITLE
Add get-pip.py to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -45,3 +45,6 @@ wheels/
 
 # Addons
 /docs/
+
+# temp for py36 fix
+get-pip.py


### PR DESCRIPTION
https://github.com/tensorflow/addons/commit/8daad7b7ad7f6a2bd728bb589b963e6b8a216000 generates a `get-pip.py` in the root dir. Adding it to gitignore.