### PR TITLE
Sync custom-op

### DIFF
--- a/build_deps/gpu/cuda/BUILD.tpl
+++ b/build_deps/gpu/cuda/BUILD.tpl
@@ -1,3 +1,5 @@
+load(":build_defs.bzl", "cuda_header_library")
+
 licenses(["restricted"])  # MPL2, portions GPL v3, LGPL v3, BSD-like
 
 package(default_visibility = ["//visibility:public"])
@@ -37,11 +39,12 @@ config_setting(
     visibility = ["//visibility:public"],
 )
 
-cc_library(
+cuda_header_library(
     name = "cuda_headers",
     hdrs = [
         %{cuda_headers}
     ],
+    include_prefix = "third_party/gpus",
     includes = [
         ".",
         "cuda/include",

--- a/build_deps/gpu/cuda/build_defs.bzl.tpl
+++ b/build_deps/gpu/cuda/build_defs.bzl.tpl
@@ -31,3 +31,32 @@ def if_cuda_is_configured(x):
     if cuda_is_configured():
       return x
     return []
+
+def cuda_header_library(
+        name,
+        hdrs,
+        include_prefix = None,
+        strip_include_prefix = None,
+        deps = [],
+        **kwargs):
+    """Generates a cc_library containing both virtual and system include paths.
+
+    Generates both a header-only target with virtual includes plus the full
+    target without virtual includes. This works around the fact that bazel can't
+    mix 'includes' and 'include_prefix' in the same target."""
+
+    native.cc_library(
+        name = name + "_virtual",
+        hdrs = hdrs,
+        include_prefix = include_prefix,
+        strip_include_prefix = strip_include_prefix,
+        deps = deps,
+        visibility = ["//visibility:private"],
+    )
+
+    native.cc_library(
+        name = name,
+        textual_hdrs = hdrs,
+        deps = deps + [":%s_virtual" % name],
+        **kwargs
+    )

--- a/build_deps/requirements.txt
+++ b/build_deps/requirements.txt
@@ -1,1 +1,1 @@
-tf-nightly-2.0-preview
+tf-nightly-2.0-preview==2.0.0.dev20190731

--- a/build_deps/requirements_gpu.txt
+++ b/build_deps/requirements_gpu.txt
@@ -1,1 +1,1 @@
-tf-nightly-gpu-2.0-preview
+tf-nightly-gpu-2.0-preview==2.0.0.dev20190731


### PR DESCRIPTION
Prefix of cuda include path is changed in core Tensorflow so we need to sync build files in custom-op.
Need this PR for [beam_search_ops_gpu.cc](https://github.com/tensorflow/addons/blob/d57ffc2296a599542833da6c1c1482799ce811ad/tensorflow_addons/custom_ops/seq2seq/cc/kernels/beam_search_ops_gpu.cu.cc#L21) and [adjust_hsv_in_yiq_op_gpu.cu.cc](https://github.com/tensorflow/addons/blob/master/tensorflow_addons/custom_ops/image/cc/kernels/adjust_hsv_in_yiq_op_gpu.cu.cc#L21). We could keep working on GPU kernel building after this :-)

Related links:
https://github.com/tensorflow/custom-op/commit/b267cc546365f30963ef2f6b690ff0a4e7391913#diff-0c845043da8b3200ae16b7a3e1781cc2
https://github.com/tensorflow/tensorflow/blob/master/tensorflow/core/util/gpu_kernel_helper.h#L22