### PR TITLE
BLD: Remove py34 support as it no longer published for tf-core

### DIFF
--- a/tools/ci_build/builds/release_linux.sh
+++ b/tools/ci_build/builds/release_linux.sh
@@ -15,7 +15,7 @@
 # ==============================================================================
 set -e -x
 
-PYTHON_VERSIONS="python2.7 python3.4 python3.5 python3.6"
+PYTHON_VERSIONS="python2.7 python3.5 python3.6"
 curl -sSOL https://bootstrap.pypa.io/get-pip.py
 add-apt-repository -y ppa:deadsnakes/ppa
 

--- a/tools/ci_build/builds/release_macos.sh
+++ b/tools/ci_build/builds/release_macos.sh
@@ -15,7 +15,7 @@
 # ==============================================================================
 set -e -x
 
-PYTHON_VERSIONS="2.7.15 3.4.9 3.5.6 3.6.6"
+PYTHON_VERSIONS="2.7.15 3.5.6 3.6.6"
 curl -sSOL https://bootstrap.pypa.io/get-pip.py
 
 # Install Bazel 0.24


### PR DESCRIPTION
Nightly builds are failing since there is no py34 package:
https://travis-ci.org/tensorflow/addons/jobs/568829836

This will get fixed in #389 but I'm currently on vacation so it'll be another week or so. 