### PR TITLE
Use docker script in travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -22,13 +22,13 @@ jobs:
     - stage: test
       name: "Test on Ubuntu 16.04"
       script:
-      - docker run --rm -v ${PWD}:/addons -w /addons tensorflow/tensorflow:custom-op-ubuntu16 make unit-test
+      - bash -x -e tools/run_docker.sh -c 'make unit-test'
 
     # Linux Builds
     - stage: build
       name: "Build on Ubuntu 16.04 for Python 2.7 3.5 3.6 3.7"
       script:
-      - docker run --rm -v $PWD:/addons -w /addons tensorflow/tensorflow:custom-op-ubuntu16 tools/ci_build/builds/release_linux.sh
+      - bash -x -e tools/run_docker.sh -c 'tools/ci_build/builds/release_linux.sh'
       after_success:
         - twine upload -u $PYPI_USER -p $PYPI_PW wheelhouse/*.whl
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -77,7 +77,7 @@ or run manually:
 
 ```bash
 docker run --rm -it -v ${PWD}:/addons -w /addons tensorflow/tensorflow:custom-op-ubuntu16 /bin/bash
-
+pip install --upgrade pip # Pip must be upgraded to install manylinux2010 pkg
 ./configure.sh  # Links project with TensorFlow dependency
 
 bazel test -c opt -k \
@@ -95,6 +95,7 @@ or run manually:
 
 ```bash
 docker run --runtime=nvidia --rm -it -v ${PWD}:/addons -w /addons tensorflow/tensorflow:custom-op-gpu-ubuntu16 /bin/bash
+pip install --upgrade pip # Pip must be upgraded to install manylinux2010 pkg
 ./configure.sh  # Links project with TensorFlow dependency
 
 bazel test -c opt -k \


### PR DESCRIPTION
Travis build failed because pip was out of date (we upgrade pip in our `run_docker` script). It's cleaner to run it this way anyway IMO