### PR TITLE
Add image thresholding operations

### DIFF
--- a/tensorflow_addons/image/BUILD
+++ b/tensorflow_addons/image/BUILD
@@ -15,6 +15,7 @@ py_library(
         "utils.py",
         "sparse_image_warp.py",
         "interpolate_spline.py",
+        "threshold_ops.py",
     ]),
     data = [
         ":sparse_image_warp_test_data",
@@ -142,6 +143,19 @@ py_test(
         "interpolate_spline_test.py",
     ],
     main = "interpolate_spline_test.py",
+    srcs_version = "PY2AND3",
+    deps = [
+        ":image",
+    ],
+)
+
+py_test(
+    name = "threshold_ops_test",
+    size = "medium",
+    srcs = [
+        "threshold_ops_test.py",
+    ],
+    main = "threshold_ops_test.py",
     srcs_version = "PY2AND3",
     deps = [
         ":image",

--- a/tensorflow_addons/image/README.md
+++ b/tensorflow_addons/image/README.md
@@ -27,9 +27,9 @@
 | transform_ops | transform |  | 
 | translate_ops | translate | |
 | translate_ops | translations_to_projective_transforms | |
-| threshold_ops | basic thresholding | |
-| threshold_ops | adaptive thresholding | |
-| threshold_ops | otsu's thresholding | |
+| threshold_ops | basic_thresholding | |
+| threshold_ops | adaptive_thresholding | |
+| threshold_ops | otsu_thresholding | |
 
 ## Contribution Guidelines
 #### Standard API

--- a/tensorflow_addons/image/README.md
+++ b/tensorflow_addons/image/README.md
@@ -27,6 +27,9 @@
 | transform_ops | transform |  | 
 | translate_ops | translate | |
 | translate_ops | translations_to_projective_transforms | |
+| threshold_ops | basic thresholding | |
+| threshold_ops | adaptive thresholding | |
+| threshold_ops | otsu's thresholding | |
 
 ## Contribution Guidelines
 #### Standard API

--- a/tensorflow_addons/image/__init__.py
+++ b/tensorflow_addons/image/__init__.py
@@ -29,3 +29,4 @@ from tensorflow_addons.image.transform_ops import transform
 from tensorflow_addons.image.sparse_image_warp import sparse_image_warp
 from tensorflow_addons.image.interpolate_spline import interpolate_spline
 from tensorflow_addons.image.translate_ops import translate
+from tensorflow_addons.image.threshold_ops import threshold

--- a/tensorflow_addons/image/__init__.py
+++ b/tensorflow_addons/image/__init__.py
@@ -29,4 +29,6 @@ from tensorflow_addons.image.transform_ops import transform
 from tensorflow_addons.image.sparse_image_warp import sparse_image_warp
 from tensorflow_addons.image.interpolate_spline import interpolate_spline
 from tensorflow_addons.image.translate_ops import translate
-from tensorflow_addons.image.threshold_ops import threshold
+from tensorflow_addons.image.threshold_ops import basic_threshold
+from tensorflow_addons.image.threshold_ops import adaptive_threshold
+from tensorflow_addons.image.threshold_ops import otsu_thresholding

--- a/tensorflow_addons/image/threshold_ops.py
+++ b/tensorflow_addons/image/threshold_ops.py
@@ -1,0 +1,175 @@
+# Copyright 2019 The TensorFlow Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ==============================================================================
+"""Image thresholding ops."""
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+
+import tensorflow as tf
+import numpy as np
+
+@tf.function
+def basic_threshold(image, threshold):
+	"""Applies a basic threshold operation and outputs a binary image.
+	
+	Args:
+	  image: A tensor of shape (num_rows, num_columns, num_channels) (HWC) or
+	  (num_rows, num_columns) (HW). The rank must be statically known (the
+	  shape is not `TensorShape(None)`.
+
+	  threshold: An integer value between 0 and 255 which is used to binarize the image by 
+	  comparing it with the pixel values.
+	
+	Returns:
+	  Binary thresholded image based on the threshold value 
+
+	Raises:
+	  TypeError: If `image` is an invalid type.
+	"""
+	with tf.name_scope(name or "basic_threshold"):
+		image = tf.convert_to_tensor(image, name="image")
+		
+		rank = image.shape.rank
+		if rank != 2 and rank != 3:
+			raise ValueError("Image should be either 2 or 3-dimensional.")
+ 
+		if not isinstance(threshold,int):
+			raise ValueError("Threshold value must be an integer.")
+
+		if rank == 3:
+			image = tf.image.rgb_to_grayscale(image)
+			image = tf.image.convert_image_dtype(image, tf.dtypes.uint8)
+			image = tf.squeeze(image,2)
+		
+		r, c = image.shape
+		image = image.numpy()
+		final = np.zeros((r,c))
+		final[image>threshold] = 255
+		return final
+
+@tf.function
+def adaptive_threshold(image, window):
+	"""
+	Applies a basic threshold operation but instead of applying on complete
+	image it applies on small regions and outputs a binary image(s). Here 
+	threshold is calculated from mean of the region where operation is done. 
+	
+	Args:
+	  image: A tensor of shape (num_rows, num_columns, num_channels) (HWC) or
+	  (num_rows, num_columns) (HW). The rank must be statically known (the
+	  shape is not `TensorShape(None)`.
+	
+	  window: An integer value used as the size of the local region.
+	Returns:
+	  Binary thresholded image.
+
+	Raises:
+	  TypeError: If `image` is an invalid type.
+	"""
+	with tf.name_scope(name or "adaptive_threshold"):
+		image = tf.convert_to_tensor(image, name="image")
+		
+		rank = image.shape.rank
+		if rank != 2 and rank != 3:
+			raise ValueError("Image should be either 2 or 3-dimensional.")
+ 
+		if not isinstance(window,int):
+			raise ValueError("Window size value must be an integer.")
+
+		r, c = image.shape
+		if window > min(r,c):
+			raise ValueError("Window size should be lesser than the size of the image.")
+
+		if rank == 3:
+			image = tf.image.rgb_to_grayscale(image)
+			image = tf.image.convert_image_dtype(image, tf.dtypes.uint8)
+			image = tf.squeeze(image,2)
+		image = image.numpy()
+
+		i = 0
+		final = np.zeros((r,c))
+		while i<r:
+			j = 0
+			r1 = min(i+window, r)
+			while j<c:
+				c1 = min(j+window, c)
+				cur = image[i:r1,j:c1]
+				threshold = np.mean(np.mean(cur,axis=0))
+				res = np.zeros_like(cur)
+				res[cur>threshold] = 255
+				final[i:r1,j:c1] = res
+
+				j += window
+			i += window
+		return final
+
+@tf.function
+def otsu_thresholding(image):
+	"""
+	Applies thresholding on any image using otsu's method which exhaustively
+	searches for the threshold that minimizes the intra-class variance. 
+	
+	Args:
+	  image: A tensor of shape (num_rows, num_columns, num_channels) (HWC) or
+	  (num_rows, num_columns) (HW). The rank must be statically known (the
+	  shape is not `TensorShape(None)`.	
+	Returns:
+	  Binary thresholded image.
+
+	Raises:
+	  TypeError: If `image` is an invalid type.
+	"""
+	with tf.name_scope(name or "otsu_thresholding"):
+		image = tf.convert_to_tensor(image, name="image")
+
+		rank = image.shape.rank
+		if rank != 2 and rank != 3:
+			raise ValueError("Image should be either 2 or 3-dimensional.")
+
+		if image.dtype!=tf.int32:
+			image = tf.cast(image, tf.int32)
+
+		r, c = image.shape
+		hist = tf.math.bincount(image, dtype=tf.int32)
+
+		current_max, threshold = 0, 0
+		total = r * c
+
+		hist = hist.numpy()
+		spre = [0]*256
+		sw = [0]*256
+		spre[0] = hist[0]
+
+		for i in range(1,256):
+			spre[i] = spre[i-1] + hist[i]
+			sw[i] = sw[i-1]  + (i * hist[i])
+
+		for i in range(256):
+			if total - spre[i] == 0:
+				break
+
+			meanB = sw[i]/spre[i]
+			meanF = (sw[255] - sw[i])/(total - spre[i])
+			varBetween = (total - spre[i]) * spre[i] * ((meanB-meanF)**2)
+
+			if varBetween > current_max:
+				current_max = varBetween
+				threshold = i
+
+		final = np.zeros((r,c))
+		image = image.numpy()
+		final[image>threshold] = 255
+
+		return final

--- a/tensorflow_addons/image/threshold_ops_test.py
+++ b/tensorflow_addons/image/threshold_ops_test.py
@@ -17,60 +17,89 @@ from __future__ import absolute_import
 from __future__ import division
 from __future__ import print_function
 
-import numpy as np
 import tensorflow as tf
 from tensorflow_addons.image import basic_threshold
 from tensorflow_addons.image import adaptive_threshold
 from tensorflow_addons.image import otsu_thresholding
 from tensorflow_addons.utils import test_utils
 
+
+@test_utils.run_all_in_graph_and_eager_modes
 class BasicThresholdTest(tf.test.TestCase):
-	def test_invalid_image(self):
-		msg = 'Image should be either 2 or 3-dimensional.'
+    def test_invalid_image(self):
+        msg = 'Image should be either 2 or 3-dimensional.'
 
-		for image_shape in [(28, 28), (36,45,3), (16, 28, 28, 1, 1)]:
-			with self.subTest(dim=len(image_shape)):
-				with self.assertRaisesRegexp(ValueError, msg):
-					basic_threshold(tf.ones(shape=image_shape),127)
+        for image_shape in [(28, 28), (36, 45, 3), (16, 28, 28, 1, 1)]:
+            with self.subTest(dim=len(image_shape)):
+                with self.assertRaisesRegexp(ValueError, msg):
+                    basic_threshold(tf.ones(shape=image_shape), 127)
 
-	def test_thresholding_grayscale(self):
-		image = tf.constant([[5, 150, 220, 49, 110],
-							[81, 251, 20, 180, 99],
-							[239, 7, 129, 47, 235],
-							[88, 84, 115, 171, 75],
-							[145, 150, 250, 64, 32]])
-		threshold = 127
+    def test_thresholding_grayscale(self):
+        image = tf.constant([[5, 150, 220, 49, 110], [81, 251, 20, 180, 99],
+                             [239, 7, 129, 47, 235], [88, 84, 115, 171, 75],
+                             [145, 150, 250, 64, 32]])
+        threshold = 127
 
-		expected_output = np.array([[0, 255, 255, 0, 0],
-									[0, 255, 0, 255, 0],
-									[255, 0, 255, 0, 255],
-									[0, 0, 0, 255, 0],
-									[255, 255, 255, 0, 0]])
+        expected_output = tf.constant(
+            [[0, 255, 255, 0, 0], [0, 255, 0, 255, 0], [255, 0, 255, 0, 255],
+             [0, 0, 0, 255, 0], [255, 255, 255, 0, 0]])
 
-		output = basic_threshold(image,threshold)
-		self.assertAllClose(output,expected_output)
+        output = basic_threshold(image, threshold)
+        self.assertAllClose(output, expected_output)
 
+
+@test_utils.run_all_in_graph_and_eager_modes
 class AdaptiveThresholdTest(tf.test.TestCase):
-	def test_invalid_image(self):
-		msg = 'Image should be either 2 or 3-dimensional.'
+    def test_invalid_image(self):
+        msg = 'Image should be either 2 or 3-dimensional.'
 
-		for image_shape in [(28, 28), (36,45,3), (16, 28, 28, 1, 1)]:
-			with self.subTest(dim=len(image_shape)):
-				with self.assertRaisesRegexp(ValueError, msg):
-					adaptive_threshold(tf.ones(shape=image_shape),5)
+        for image_shape in [(28, 28), (36, 45, 3), (16, 28, 28, 1, 1)]:
+            with self.subTest(dim=len(image_shape)):
+                with self.assertRaisesRegexp(ValueError, msg):
+                    adaptive_threshold(tf.ones(shape=image_shape), 5)
 
-	def test_window_size(self):
-		msg = 'Window size should be lesser than the size of the image.'
-		image_shape = (25,25)
-		for window_size in [3, 5, 15, 30, 10]:
-			with self.assertRaisesRegexp(ValueError, msg):
-				adaptive_threshold(tf.ones(shape=image_shape),window_size)
+    def test_window_size(self):
+        msg = 'Window size should be lesser than the size of the image.'
+        image_shape = (25, 25)
+        for window_size in [3, 5, 15, 30, 10]:
+            with self.assertRaisesRegexp(ValueError, msg):
+                adaptive_threshold(tf.ones(shape=image_shape), window_size)
 
+    def test_thresholding_grayscale(self):
+        image = tf.constant([[5, 150, 220, 49, 110], [81, 251, 20, 180, 99],
+                             [239, 7, 129, 47, 235], [88, 84, 115, 171, 75],
+                             [145, 150, 250, 64, 32]])
+        window = 2
+
+        expected_output = tf.constant([[0.0, 255.0, 255.0, 0.0, 0.0],
+                                       [0.0, 255.0, 0.0, 255.0, 0.0],
+                                       [255.0, 0.0, 255.0, 0.0, 255.0],
+                                       [0.0, 0.0, 0.0, 255.0, 0.0],
+                                       [0.0, 255.0, 255.0, 0.0, 0.0]])
+
+        output = adaptive_threshold(image, window)
+        self.assertAllClose(output, expected_output)
+
+
+@test_utils.run_all_in_graph_and_eager_modes
 class OtsuThresholdTest(tf.test.TestCase):
-	def test_invalid_image(self):
-		msg = 'Image should be either 2 or 3-dimensional.'
+    def test_invalid_image(self):
+        msg = 'Image should be either 2 or 3-dimensional.'
 
-		for image_shape in [(28, 28), (36,45,3), (16, 28, 28, 1, 1)]:
-			with self.subTest(dim=len(image_shape)):
-				with self.assertRaisesRegexp(ValueError, msg):
-					otsu_thresholding(tf.ones(shape=image_shape))
+        for image_shape in [(28, 28), (36, 45, 3), (16, 28, 28, 1, 1)]:
+            with self.subTest(dim=len(image_shape)):
+                with self.assertRaisesRegexp(ValueError, msg):
+                    otsu_thresholding(tf.ones(shape=image_shape))
+
+    def test_thresholding_grayscale(self):
+        image = tf.constant([[5, 150, 220, 49, 110], [81, 251, 20, 180, 99],
+                             [239, 7, 129, 47, 235], [88, 84, 115, 171, 75],
+                             [145, 150, 250, 64, 32]])
+
+        expected_output = tf.constant([[0, 255, 255, 0,
+                                        0], [0, 255, 0, 255, 0],
+                                       [255, 0, 0, 0, 255], [0, 0, 0, 255, 0],
+                                       [255, 255, 255, 0, 0]])
+
+        output = otsu_thresholding(image)
+        self.assertAllClose(output, expected_output)

--- a/tensorflow_addons/image/threshold_ops_test.py
+++ b/tensorflow_addons/image/threshold_ops_test.py
@@ -1,0 +1,76 @@
+# Copyright 2019 The TensorFlow Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the 'License');
+# you may noa use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an 'AS IS' BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ==============================================================================
+
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+
+import numpy as np
+import tensorflow as tf
+from tensorflow_addons.image import basic_threshold
+from tensorflow_addons.image import adaptive_threshold
+from tensorflow_addons.image import otsu_thresholding
+from tensorflow_addons.utils import test_utils
+
+class BasicThresholdTest(tf.test.TestCase):
+	def test_invalid_image(self):
+		msg = 'Image should be either 2 or 3-dimensional.'
+
+		for image_shape in [(28, 28), (36,45,3), (16, 28, 28, 1, 1)]:
+			with self.subTest(dim=len(image_shape)):
+				with self.assertRaisesRegexp(ValueError, msg):
+					basic_threshold(tf.ones(shape=image_shape),127)
+
+	def test_thresholding_grayscale(self):
+		image = tf.constant([[5, 150, 220, 49, 110],
+							[81, 251, 20, 180, 99],
+							[239, 7, 129, 47, 235],
+							[88, 84, 115, 171, 75],
+							[145, 150, 250, 64, 32]])
+		threshold = 127
+
+		expected_output = np.array([[0, 255, 255, 0, 0],
+									[0, 255, 0, 255, 0],
+									[255, 0, 255, 0, 255],
+									[0, 0, 0, 255, 0],
+									[255, 255, 255, 0, 0]])
+
+		output = basic_threshold(image,threshold)
+		self.assertAllClose(output,expected_output)
+
+class AdaptiveThresholdTest(tf.test.TestCase):
+	def test_invalid_image(self):
+		msg = 'Image should be either 2 or 3-dimensional.'
+
+		for image_shape in [(28, 28), (36,45,3), (16, 28, 28, 1, 1)]:
+			with self.subTest(dim=len(image_shape)):
+				with self.assertRaisesRegexp(ValueError, msg):
+					adaptive_threshold(tf.ones(shape=image_shape),5)
+
+	def test_window_size(self):
+		msg = 'Window size should be lesser than the size of the image.'
+		image_shape = (25,25)
+		for window_size in [3, 5, 15, 30, 10]:
+			with self.assertRaisesRegexp(ValueError, msg):
+				adaptive_threshold(tf.ones(shape=image_shape),window_size)
+
+class OtsuThresholdTest(tf.test.TestCase):
+	def test_invalid_image(self):
+		msg = 'Image should be either 2 or 3-dimensional.'
+
+		for image_shape in [(28, 28), (36,45,3), (16, 28, 28, 1, 1)]:
+			with self.subTest(dim=len(image_shape)):
+				with self.assertRaisesRegexp(ValueError, msg):
+					otsu_thresholding(tf.ones(shape=image_shape))


### PR DESCRIPTION
Implementation of some thresholding operations. Feature requested in issue [ 358](https://github.com/tensorflow/addons/issues/358). This includes implementation of basic thresholding, adaptive thresholding, and otsu's thresholding methods.