### PR TITLE
Revert back to manylinux1 package which breaks spec

### DIFF
--- a/tools/ci_build/builds/wheel_verify.sh
+++ b/tools/ci_build/builds/wheel_verify.sh
@@ -19,9 +19,14 @@ set -e
 if [[ $(uname) == "Darwin" ]]; then
     CMD="delocate-wheel -w wheelhouse"
 else
-    LD_PATH="$(cat .bazelrc | grep TF_SHARED_LIBRARY_DIR | sed 's/"//g' | awk -F'=' '{print $2}')"
-    export LD_LIBRARY_PATH=$LD_LIBRARY_PATH:$LD_PATH
-    CMD="auditwheel repair --plat manylinux2010_x86_64"
+    pip3 install auditwheel==1.5.0
+    sudo pip3 install wheel==0.31.1
+    CMD="auditwheel repair"
+
+#    pip3 install auditwheel==2.0.0
+#    LD_PATH="$(cat .bazelrc | grep TF_SHARED_LIBRARY_DIR | sed 's/"//g' | awk -F'=' '{print $2}')"
+#    export LD_LIBRARY_PATH=$LD_LIBRARY_PATH:$LD_PATH
+#    CMD="auditwheel repair --plat manylinux2010_x86_64"
 fi
 
 ls artifacts/*


### PR DESCRIPTION
This patch will make it so we publish spec breaking (but at least working) manylinux1 packages.

The pinned installs match the previous auditwheel: https://github.com/tensorflow/tensorflow/blob/master/tensorflow/tools/ci_build/install/install_auditwheel.sh

I tested the new pip package against a TF manylinux2010 package and it works.

We can revert this after https://github.com/tensorflow/tensorflow/issues/31807 is solved