### PR TITLE
TST: reopen moving_average_test

### DIFF
--- a/tensorflow_addons/optimizers/moving_average_test.py
+++ b/tensorflow_addons/optimizers/moving_average_test.py
@@ -26,8 +26,6 @@ from tensorflow_addons.utils import test_utils
 @test_utils.run_all_in_graph_and_eager_modes
 class MovingAverageTest(tf.test.TestCase):
     def test_run(self):
-        self.skipTest(
-            "Wait for https://github.com/tensorflow/tensorflow/issues/31582")
         for sequential_update in [True, False]:
             var0 = tf.Variable([1.0, 2.0])
             var1 = tf.Variable([3.0, 4.0])
@@ -89,8 +87,6 @@ class MovingAverageTest(tf.test.TestCase):
                 MovingAverage(base_opt, 0.5, sequential_update)
 
     def test_model_weights_update(self):
-        self.skipTest(
-            "Wait for https://github.com/tensorflow/tensorflow/issues/31582")
         grad = tf.Variable([[0.1]])
         model = tf.keras.Sequential([
             tf.keras.layers.Dense(


### PR DESCRIPTION
revert #416

The bug https://github.com/tensorflow/tensorflow/issues/31582 is fixed by https://github.com/tensorflow/tensorflow/commit/dc3534c6a502d2830634f51e08de507163aac952