### PR TITLE
Make sparsemax deserializable

### DIFF
--- a/tensorflow_addons/activations/sparsemax.py
+++ b/tensorflow_addons/activations/sparsemax.py
@@ -22,8 +22,8 @@ import tensorflow as tf
 from tensorflow_addons.utils import keras_utils
 
 
-@tf.function
 @keras_utils.register_keras_custom_object
+@tf.function
 def sparsemax(logits, axis=-1, name=None):
     """Sparsemax activation function [1].
 

--- a/tensorflow_addons/activations/sparsemax_test.py
+++ b/tensorflow_addons/activations/sparsemax_test.py
@@ -274,6 +274,20 @@ class SparsemaxTest(tf.test.TestCase):
             lambda logits: sparsemax(logits), [z], delta=1e-6)
         self.assertAllCloseAccordingToType(jacob_sym, jacob_num)
 
+    def test_serialization(self, dtype=None):
+        ref_fn = sparsemax
+        config = tf.keras.activations.serialize(ref_fn)
+        fn = tf.keras.activations.deserialize(config)
+        self.assertEqual(fn, ref_fn)
+
+    def test_serialization_with_layers(self, dtype=None):
+        layer = tf.keras.layers.Dense(3, activation=sparsemax)
+        config = tf.keras.layers.serialize(layer)
+        deserialized_layer = tf.keras.layers.deserialize(config)
+        self.assertEqual(deserialized_layer.__class__.__name__,
+                         layer.__class__.__name__)
+        self.assertEqual(deserialized_layer.activation.__name__, "sparsemax")
+
 
 if __name__ == '__main__':
     tf.test.main()

--- a/tensorflow_addons/losses/sparsemax_loss.py
+++ b/tensorflow_addons/losses/sparsemax_loss.py
@@ -23,8 +23,8 @@ from tensorflow_addons.activations.sparsemax import sparsemax
 from tensorflow_addons.utils import keras_utils
 
 
-@tf.function
 @keras_utils.register_keras_custom_object
+@tf.function
 def sparsemax_loss(logits, sparsemax, labels, name=None):
     """Sparsemax loss function [1].
 

--- a/tensorflow_addons/losses/sparsemax_loss_test.py
+++ b/tensorflow_addons/losses/sparsemax_loss_test.py
@@ -226,6 +226,12 @@ class SparsemaxTest(tf.test.TestCase):
             lambda logits: sparsemax_loss(logits, sparsemax(logits), q), [z])
         self.assertAllCloseAccordingToType(jacob_sym, jacob_num)
 
+    def test_serialization(self, dtype=None):
+        ref_fn = sparsemax_loss
+        config = tf.keras.losses.serialize(ref_fn)
+        fn = tf.keras.losses.deserialize(config)
+        self.assertEqual(ref_fn, fn)
+
 
 if __name__ == '__main__':
     tf.test.main()


### PR DESCRIPTION
The order of decorators do matter! If we put `@tf.function` outer, then the function after deserialization will not be the same with the original one (before: `tf.function`, deserialize: python function).

Also, I think serialization/deserialization is also one of the features in keras. Maybe we have to make sure all subclasses from `tf.keras.*` could be serialized/de-serialized and be well tested. 