### PR TITLE
Supporting dynamic shape tensor in sparse_image_warp

### DIFF
--- a/tensorflow_addons/image/sparse_image_warp_test.py
+++ b/tensorflow_addons/image/sparse_image_warp_test.py
@@ -37,6 +37,7 @@ class SparseImageWarpTest(tf.test.TestCase):
         num_points_per_edge = 4
         locs = _get_boundary_locations(image_height, image_width,
                                        num_points_per_edge)
+        locs = self.evaluate(locs)
         num_points = locs.shape[0]
         self.assertEqual(num_points, 4 + 4 * num_points_per_edge)
         locs = [(locs[i, 0], locs[i, 1]) for i in range(num_points)]
@@ -59,6 +60,7 @@ class SparseImageWarpTest(tf.test.TestCase):
         image_height = 5
         image_width = 3
         grid = _get_grid_locations(image_height, image_width)
+        grid = self.evaluate(grid)
         for i in range(image_height):
             for j in range(image_width):
                 self.assertEqual(grid[i, j, 0], i)


### PR DESCRIPTION
Hello,
I am resubmitting this PR here, addons, from [the previous PR](https://github.com/tensorflow/tensorflow/pull/30904).
The current version of `sparse_image_warp.py` only support static shaped tensors. 
This PR is for upgrading [`sparse_image_warp.py`](https://github.com/tensorflow/addons/blob/master/tensorflow_addons/image/sparse_image_warp.py) to support computations of tensor with dynamic shape. 
Updates of [`sparse_image_warp_test.py`](https://github.com/tensorflow/addons/blob/master/tensorflow_addons/image/sparse_image_warp_test.py) is also included.

The functional test is also done with time_warping operation in SpecAugment which requires `sparse_image_warp`. 