### PR TITLE
fix for typo in docstring example f1score metric

### DIFF
--- a/tensorflow_addons/metrics/f_scores.py
+++ b/tensorflow_addons/metrics/f_scores.py
@@ -83,7 +83,7 @@ class FBetaScore(Metric):
     ```python
     actuals = tf.constant([[1, 1, 0],[1, 0, 0]],
               dtype=tf.int32)
-    predis = tf.constant([[1, 0, 0],[1, 0, 1]],
+    preds = tf.constant([[1, 0, 0],[1, 0, 1]],
              dtype=tf.int32)
     # F-Beta Micro
     fb_score = tfa.metrics.FBetaScore(num_classes=3,


### PR DESCRIPTION
fixed small typo in docstring example