### PR TITLE
FIX: MovingAverage from_config, get_config

### DIFF
--- a/tensorflow_addons/optimizers/moving_average.py
+++ b/tensorflow_addons/optimizers/moving_average.py
@@ -47,7 +47,21 @@ class MovingAverage(tf.keras.optimizers.Optimizer):
                  sequential_update=True,
                  name="MovingAverage",
                  **kwargs):
+        """Construct a new MovingAverage optimizer.
 
+        Args:
+            optimizer: str or tf.keras.optimizers.Optimizer that will be used
+                to compute and apply gradients.
+            average_decay: float. Decay to use to maintain the moving averages
+                of trained variables. See tf.train.ExponentialMovingAverage
+                for details.
+            num_updates: Optional count of the number of updates applied to
+                variables. See tf.train.ExponentialMovingAverage for details.
+            sequential_update: Bool. If False, will compute the moving average
+                at the same time as the model is updated, potentially doing
+                benign data races. If True, will update the moving average
+                after gradient updates.
+        """
         super(MovingAverage, self).__init__(name, **kwargs)
 
         if isinstance(optimizer, str):
@@ -108,7 +122,7 @@ class MovingAverage(tf.keras.optimizers.Optimizer):
         return cls(optimizer, **config)
 
     def assign_average_vars(self, var_list):
-        """Update variables in var_list with the running mean of the variables.
+        """Assign variables in var_list with their respective moving averages.
 
         Example:
         ```python

--- a/tensorflow_addons/optimizers/moving_average.py
+++ b/tensorflow_addons/optimizers/moving_average.py
@@ -50,17 +50,25 @@ class MovingAverage(tf.keras.optimizers.Optimizer):
         """Construct a new MovingAverage optimizer.
 
         Args:
-            optimizer: str or tf.keras.optimizers.Optimizer that will be used
-                to compute and apply gradients.
+            optimizer: str or `tf.keras.optimizers.Optimizer` that will be
+                used to compute and apply gradients.
             average_decay: float. Decay to use to maintain the moving averages
-                of trained variables. See tf.train.ExponentialMovingAverage
+                of trained variables. See `tf.train.ExponentialMovingAverage`
                 for details.
             num_updates: Optional count of the number of updates applied to
-                variables. See tf.train.ExponentialMovingAverage for details.
+                variables. See `tf.train.ExponentialMovingAverage` for details.
             sequential_update: Bool. If False, will compute the moving average
                 at the same time as the model is updated, potentially doing
                 benign data races. If True, will update the moving average
                 after gradient updates.
+            name: Optional name for the operations created when applying
+                gradients. Defaults to "MovingAverage".
+            **kwargs: keyword arguments. Allowed to be {`clipnorm`,
+                `clipvalue`, `lr`, `decay`}. `clipnorm` is clip gradients by
+                norm; `clipvalue` is clip gradients by value, `decay` is
+                included for backward compatibility to allow time inverse
+                decay of learning rate. `lr` is included for backward
+                compatibility, recommended to use `learning_rate` instead.
         """
         super(MovingAverage, self).__init__(name, **kwargs)
 

--- a/tensorflow_addons/optimizers/moving_average_test.py
+++ b/tensorflow_addons/optimizers/moving_average_test.py
@@ -107,24 +107,29 @@ class MovingAverageTest(tf.test.TestCase):
         self.evaluate(mean_update)
         self.assertAllClose(model.variables[0].read_value(), [[0.9]])
 
+    def test_optimizer_string(self):
+        _ = MovingAverage('adam')
+
     def test_config(self):
         sgd_opt = tf.keras.optimizers.SGD(
             lr=2.0, nesterov=True, momentum=0.3, decay=0.1)
         opt = MovingAverage(
             sgd_opt,
             average_decay=0.5,
-            num_updates=100,
+            num_updates=None,
             sequential_update=False)
         config = opt.get_config()
 
         self.assertEqual(config['average_decay'], 0.5)
-        self.assertEqual(config['decay'], 0.1)
-        self.assertEqual(config['learning_rate'], 2.0)
-        self.assertEqual(config['momentum'], 0.3)
-        self.assertEqual(config['name'], 'SGD')
-        self.assertEqual(config['nesterov'], True)
-        self.assertEqual(config['num_updates'], 100)
+        self.assertEqual(config['num_updates'], None)
         self.assertEqual(config['sequential_update'], False)
+
+        new_opt = MovingAverage.from_config(config)
+        old_sgd_config = opt._optimizer.get_config()
+        new_sgd_config = new_opt._optimizer.get_config()
+
+        for k1, k2 in zip(old_sgd_config, new_sgd_config):
+            self.assertEqual(old_sgd_config[k1], new_sgd_config[k2])
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
* `get_config` correctly serializes the wrapped optimizer using `tf.keras.optimizers.serialize()`

* `from_config` to deserialize the config correctly, including the wrapped optimizer

* Wrapper optimizer can be specified using keras optimizer strings like: adam, rmsprop, adagrad, etc.

* Add tests for above new functionality

* Minor refactoring in `moving_average.py`