### PR TITLE
Port assert_like_rnncell in addons utils

### DIFF
--- a/tensorflow_addons/seq2seq/attention_wrapper.py
+++ b/tensorflow_addons/seq2seq/attention_wrapper.py
@@ -26,6 +26,8 @@ import numpy as np
 
 import tensorflow as tf
 
+from tensorflow_addons.utils import keras_utils
+
 # TODO: Find public API alternatives to these
 from tensorflow.python.keras.engine import base_layer_utils
 from tensorflow.python.ops import rnn_cell_impl
@@ -1634,7 +1636,7 @@ class AttentionWrapper(tf.keras.layers.AbstractRNNCell):
             `attention_layer` are set simultaneously.
         """
         super(AttentionWrapper, self).__init__(name=name, **kwargs)
-        rnn_cell_impl.assert_like_rnncell("cell", cell)
+        keras_utils.assert_like_rnncell("cell", cell)
         if isinstance(attention_mechanism, (list, tuple)):
             self._is_multi = True
             attention_mechanisms = list(attention_mechanism)

--- a/tensorflow_addons/seq2seq/basic_decoder.py
+++ b/tensorflow_addons/seq2seq/basic_decoder.py
@@ -24,9 +24,7 @@ import tensorflow as tf
 
 from tensorflow_addons.seq2seq import decoder
 from tensorflow_addons.seq2seq import sampler as sampler_py
-
-# TODO: Find public API alternatives to this
-from tensorflow.python.ops import rnn_cell_impl
+from tensorflow_addons.utils import keras_utils
 
 
 class BasicDecoderOutput(
@@ -53,7 +51,7 @@ class BasicDecoder(decoder.BaseDecoder):
           TypeError: if `cell`, `helper` or `output_layer` have an incorrect
           type.
         """
-        rnn_cell_impl.assert_like_rnncell("cell", cell)
+        keras_utils.assert_like_rnncell("cell", cell)
         if not isinstance(sampler, sampler_py.Sampler):
             raise TypeError(
                 "sampler must be a Sampler, received: %s" % (sampler,))

--- a/tensorflow_addons/seq2seq/basic_decoder_test.py
+++ b/tensorflow_addons/seq2seq/basic_decoder_test.py
@@ -22,6 +22,7 @@ import numpy as np
 
 import tensorflow as tf
 
+from tensorflow_addons.seq2seq import attention_wrapper
 from tensorflow_addons.seq2seq import basic_decoder
 from tensorflow_addons.seq2seq import sampler as sampler_py
 from tensorflow_addons.utils import test_utils
@@ -690,6 +691,18 @@ class BasicDecoderTest(test_utils.keras_parameterized.TestCase):
                                 eval_result["step_finished"])
             self.assertAllEqual(expected_step_next_inputs,
                                 eval_result["step_next_inputs"])
+
+    def testBasicDecoderWithAttentionWrapper(self):
+        units = 32
+        vocab_size = 1000
+        attention_mechanism = attention_wrapper.LuongAttention(units)
+        cell = tf.keras.layers.LSTMCell(units)
+        cell = attention_wrapper.AttentionWrapper(cell, attention_mechanism)
+        output_layer = tf.keras.layers.Dense(vocab_size)
+        sampler = sampler_py.TrainingSampler()
+        # BasicDecoder should accept a non initialized AttentionWrapper.
+        decoder = basic_decoder.BasicDecoder(
+            cell, sampler, output_layer=output_layer)
 
 
 if __name__ == "__main__":

--- a/tensorflow_addons/seq2seq/beam_search_decoder.py
+++ b/tensorflow_addons/seq2seq/beam_search_decoder.py
@@ -25,10 +25,8 @@ import tensorflow as tf
 
 from tensorflow_addons.seq2seq import attention_wrapper
 from tensorflow_addons.seq2seq import decoder
+from tensorflow_addons.utils import keras_utils
 from tensorflow_addons.utils.resource_loader import get_path_to_datafile
-
-# TODO: Find public API alternatives to these
-from tensorflow.python.ops import rnn_cell_impl
 
 _beam_search_ops_so = tf.load_op_library(
     get_path_to_datafile("custom_ops/seq2seq/_beam_search_ops.so"))
@@ -274,7 +272,7 @@ class BeamSearchDecoderMixin(object):
           TypeError: if `cell` is not an instance of `RNNCell`,
             or `output_layer` is not an instance of `tf.keras.layers.Layer`.
         """
-        rnn_cell_impl.assert_like_rnncell("cell", cell)  # pylint: disable=protected-access
+        keras_utils.assert_like_rnncell("cell", cell)
         if (output_layer is not None
                 and not isinstance(output_layer, tf.keras.layers.Layer)):
             raise TypeError("output_layer must be a Layer, received: %s" %

--- a/tensorflow_addons/utils/keras_utils.py
+++ b/tensorflow_addons/utils/keras_utils.py
@@ -67,3 +67,48 @@ def normalize_tuple(value, n, name):
                                  'including element ' + str(single_value) +
                                  ' of type' + ' ' + str(type(single_value)))
         return value_tuple
+
+
+def _hasattr(obj, attr_name):
+    # If possible, avoid retrieving the attribute as the object might run some
+    # lazy computation in it.
+    if attr_name in dir(obj):
+        return True
+    try:
+        getattr(obj, attr_name)
+    except AttributeError:
+        return False
+    else:
+        return True
+
+
+def assert_like_rnncell(cell_name, cell):
+    """Raises a TypeError if cell is not like a
+    tf.keras.layers.AbstractRNNCell.
+
+    Args:
+      cell_name: A string to give a meaningful error referencing to the name
+        of the function argument.
+      cell: The object which should behave like a
+        tf.keras.layers.AbstractRNNCell.
+
+    Raises:
+      TypeError: A human-friendly exception.
+    """
+    conditions = [
+        _hasattr(cell, "output_size"),
+        _hasattr(cell, "state_size"),
+        _hasattr(cell, "get_initial_state"),
+        callable(cell),
+    ]
+
+    errors = [
+        "'output_size' property is missing",
+        "'state_size' property is missing",
+        "'get_initial_state' method is required", "is not callable"
+    ]
+
+    if not all(conditions):
+        errors = [error for error, cond in zip(errors, conditions) if not cond]
+        raise TypeError("The argument {!r} ({}) is not an RNNCell: {}.".format(
+            cell_name, cell, ", ".join(errors)))

--- a/tensorflow_addons/utils/keras_utils_test.py
+++ b/tensorflow_addons/utils/keras_utils_test.py
@@ -18,20 +18,41 @@ from __future__ import division
 from __future__ import print_function
 
 import tensorflow as tf
-from tensorflow_addons.utils.keras_utils import normalize_tuple
+
+from tensorflow_addons.utils import keras_utils
 
 
 class NormalizeTupleTest(tf.test.TestCase):
     def test_normalize_tuple(self):
-        self.assertEqual((2, 2, 2), normalize_tuple(2, n=3, name='strides'))
+        self.assertEqual((2, 2, 2),
+                         keras_utils.normalize_tuple(2, n=3, name='strides'))
         self.assertEqual((2, 1, 2),
-                         normalize_tuple((2, 1, 2), n=3, name='strides'))
+                         keras_utils.normalize_tuple((2, 1, 2),
+                                                     n=3,
+                                                     name='strides'))
 
         with self.assertRaises(ValueError):
-            normalize_tuple((2, 1), n=3, name='strides')
+            keras_utils.normalize_tuple((2, 1), n=3, name='strides')
 
         with self.assertRaises(ValueError):
-            normalize_tuple(None, n=3, name='strides')
+            keras_utils.normalize_tuple(None, n=3, name='strides')
+
+
+class AssertRNNCellTest(tf.test.TestCase):
+    def test_standard_cell(self):
+        keras_utils.assert_like_rnncell("cell", tf.keras.layers.LSTMCell(10))
+
+    def test_non_cell(self):
+        with self.assertRaises(TypeError):
+            keras_utils.assert_like_rnncell("cell", tf.keras.layers.Dense(10))
+
+    def test_custom_cell(self):
+        class CustomCell(tf.keras.layers.AbstractRNNCell):
+            @property
+            def output_size(self):
+                raise ValueError("assert_like_rnncell should not run code")
+
+        keras_utils.assert_like_rnncell("cell", CustomCell())
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
This function was a TensorFlow private API so it's probably better to own it at this point. It was ported with 2 changes:

* Reference to `zero_state` is removed
* `_hasattr` will first check if the attribute can be found by name before using `getattr`. This is to allow cells that run some lazy computation in their attribute.

Fixes #511.