### PR TITLE
Add standard flags to build_docs.py

### DIFF
--- a/tools/docs/build_docs.py
+++ b/tools/docs/build_docs.py
@@ -52,12 +52,13 @@ flags.DEFINE_string(
     default=None,
     help='The name of the corresponding branch on github.')
 
-flags.DEFINE_string("output_dir", "/tmp/addons_api",
-                    "Where to output the docs")
-
 CODE_PREFIX_TEMPLATE = "https://github.com/tensorflow/addons/tree/{git_branch}/tensorflow_addons"
 flags.DEFINE_string("code_url_prefix", None,
                     "The url prefix for links to the code.")
+flags.mark_flags_as_mutual_exclusive(['code_url_prefix', 'git_branch'])
+
+flags.DEFINE_string("output_dir", "/tmp/addons_api",
+                    "Where to output the docs")
 
 flags.DEFINE_bool("search_hints", True,
                   "Include metadata search hints in the generated files")
@@ -65,18 +66,16 @@ flags.DEFINE_bool("search_hints", True,
 flags.DEFINE_string("site_path", "addons/api_docs/python",
                     "Path prefix in the _toc.yaml")
 
-flags.mark_flags_as_mutual_exclusive(['code_url_prefix', 'git_branch'])
-
 
 def main(argv):
     if argv[1:]:
         raise ValueError('Unrecognized arguments: {}'.format(argv[1:]))
 
-    if FLAGS.git_branch:
+    if FLAGS.code_url_prefix:
+        code_url_prefix = FLAGS.code_url_prefix
+    elif FLAGS.git_branch:
         code_url_prefix = CODE_PREFIX_TEMPLATE.format(
             git_branch=FLAGS.git_branch)
-    elif FLAGS.code_url_prefix:
-        code_url_prefix = FLAGS.code_url_prefix
     else:
         code_url_prefix = CODE_PREFIX_TEMPLATE.format(git_branch='master')
 

--- a/tools/docs/build_docs.py
+++ b/tools/docs/build_docs.py
@@ -49,31 +49,46 @@ FLAGS = flags.FLAGS
 
 flags.DEFINE_string(
     'git_branch',
-    default='master',
+    default=None,
     help='The name of the corresponding branch on github.')
 
-flags.DEFINE_string(
-    'output_dir',
-    default='docs/api_docs/python/',
-    help='Where to write the resulting docs to.')
+flags.DEFINE_string("output_dir", "/tmp/addons_api",
+                    "Where to output the docs")
 
+CODE_PREFIX_TEMPLATE = "https://github.com/tensorflow/addons/tree/{git_branch}/tensorflow_addons"
+flags.DEFINE_string(
+    "code_url_prefix", None,
+    "The url prefix for links to the code.")
+
+flags.DEFINE_bool("search_hints", True,
+                  "Include metadata search hints in the generated files")
+
+flags.DEFINE_string("site_path", "addons/api_docs/python",
+                    "Path prefix in the _toc.yaml")
+
+flags.mark_flags_as_mutual_exclusive(['code_url_prefix', 'git_branch'])
 
 def main(argv):
     if argv[1:]:
         raise ValueError('Unrecognized arguments: {}'.format(argv[1:]))
 
-    code_url_prefix = ('https://github.com/tensorflow/addons/tree/'
-                       '{git_branch}/tensorflow_addons'.format(
-                           git_branch=FLAGS.git_branch))
-
+    
+    if FLAGS.git_branch:
+      code_url_prefix = CODE_PREFIX_TEMPLATE.format(git_branch=FLAGS.git_branch)
+    elif FLAGS.code_url_prefix:
+      code_url_prefix = FLAGS.code_url_prefix
+    else:
+      code_url_prefix = CODE_PREFIX_TEMPLATE.format(git_branch='master')
+      
     doc_generator = generate_lib.DocGenerator(
         root_title=PROJECT_FULL_NAME,
-        # Replace `tensorflow_docs` with your module, here.
         py_modules=[(PROJECT_SHORT_NAME, tfa)],
         code_url_prefix=code_url_prefix,
         private_map={'tfa': ['__version__', 'utils', 'version']},
-        # This callback cleans up a lot of aliases caused by internal imports.
-        callbacks=[public_api.local_definitions_filter])
+        # This callback usually cleans up a lot of aliases caused by internal imports.
+        callbacks=[public_api.local_definitions_filter], 
+        search_hints=FLAGS.search_hints, 
+        site_path=FLAGS.site_path)
 
     doc_generator.build(FLAGS.output_dir)
 

--- a/tools/docs/build_docs.py
+++ b/tools/docs/build_docs.py
@@ -56,9 +56,8 @@ flags.DEFINE_string("output_dir", "/tmp/addons_api",
                     "Where to output the docs")
 
 CODE_PREFIX_TEMPLATE = "https://github.com/tensorflow/addons/tree/{git_branch}/tensorflow_addons"
-flags.DEFINE_string(
-    "code_url_prefix", None,
-    "The url prefix for links to the code.")
+flags.DEFINE_string("code_url_prefix", None,
+                    "The url prefix for links to the code.")
 
 flags.DEFINE_bool("search_hints", True,
                   "Include metadata search hints in the generated files")
@@ -68,26 +67,27 @@ flags.DEFINE_string("site_path", "addons/api_docs/python",
 
 flags.mark_flags_as_mutual_exclusive(['code_url_prefix', 'git_branch'])
 
+
 def main(argv):
     if argv[1:]:
         raise ValueError('Unrecognized arguments: {}'.format(argv[1:]))
 
-    
     if FLAGS.git_branch:
-      code_url_prefix = CODE_PREFIX_TEMPLATE.format(git_branch=FLAGS.git_branch)
+        code_url_prefix = CODE_PREFIX_TEMPLATE.format(
+            git_branch=FLAGS.git_branch)
     elif FLAGS.code_url_prefix:
-      code_url_prefix = FLAGS.code_url_prefix
+        code_url_prefix = FLAGS.code_url_prefix
     else:
-      code_url_prefix = CODE_PREFIX_TEMPLATE.format(git_branch='master')
-      
+        code_url_prefix = CODE_PREFIX_TEMPLATE.format(git_branch='master')
+
     doc_generator = generate_lib.DocGenerator(
         root_title=PROJECT_FULL_NAME,
         py_modules=[(PROJECT_SHORT_NAME, tfa)],
         code_url_prefix=code_url_prefix,
         private_map={'tfa': ['__version__', 'utils', 'version']},
         # This callback usually cleans up a lot of aliases caused by internal imports.
-        callbacks=[public_api.local_definitions_filter], 
-        search_hints=FLAGS.search_hints, 
+        callbacks=[public_api.local_definitions_filter],
+        search_hints=FLAGS.search_hints,
         site_path=FLAGS.site_path)
 
     doc_generator.build(FLAGS.output_dir)


### PR DESCRIPTION
Hi, 

To generate docs for tensorflow.org we need to standardize the `FLAGS` so this script works with our pipeline without throwing errors about unrecognized flags.

This change doesn't affect the output of the script (except path prefixes is .yaml files) or the current usage described in README.md.

For #226