### PR TITLE
Implement alternatives to some TensorFlow private APIs

### DIFF
--- a/tensorflow_addons/seq2seq/attention_wrapper.py
+++ b/tensorflow_addons/seq2seq/attention_wrapper.py
@@ -30,9 +30,6 @@ from tensorflow_addons.utils import keras_utils
 
 # TODO: Find public API alternatives to these
 from tensorflow.python.keras.engine import base_layer_utils
-from tensorflow.python.ops import rnn_cell_impl
-
-_zero_state_tensors = rnn_cell_impl._zero_state_tensors  # pylint: disable=protected-access
 
 
 class AttentionMechanism(object):
@@ -413,8 +410,7 @@ class _BaseAttentionMechanism(AttentionMechanism, tf.keras.layers.Layer):
           A `dtype` tensor shaped `[batch_size, alignments_size]`
           (`alignments_size` is the values' `max_time`).
         """
-        max_time = self._alignments_size
-        return _zero_state_tensors(max_time, batch_size, dtype)
+        return tf.zeros([batch_size, self._alignments_size], dtype=dtype)
 
     def initial_state(self, batch_size, dtype):
         """Creates the initial state values for the `AttentionWrapper` class.
@@ -1865,8 +1861,9 @@ class AttentionWrapper(tf.keras.layers.AbstractRNNCell):
             return AttentionWrapperState(
                 cell_state=cell_state,
                 time=tf.zeros([], dtype=tf.int32),
-                attention=_zero_state_tensors(self._get_attention_layer_size(),
-                                              batch_size, dtype),
+                attention=tf.zeros(
+                    [batch_size, self._get_attention_layer_size()],
+                    dtype=dtype),
                 alignments=self._item_or_tuple(initial_alignments),
                 attention_state=self._item_or_tuple(
                     attention_mechanism.initial_state(batch_size, dtype)

--- a/tensorflow_addons/seq2seq/decoder.py
+++ b/tensorflow_addons/seq2seq/decoder.py
@@ -25,11 +25,6 @@ import tensorflow as tf
 
 # TODO: Find public API alternatives to these
 from tensorflow.python.ops import control_flow_util
-from tensorflow.python.ops import rnn
-from tensorflow.python.ops import rnn_cell_impl
-
-_transpose_batch_time = rnn._transpose_batch_time  # pylint: disable=protected-access
-_zero_state_tensors = rnn_cell_impl._zero_state_tensors  # pylint: disable=protected-access
 
 
 @six.add_metaclass(abc.ABCMeta)
@@ -260,15 +255,6 @@ class BaseDecoder(tf.keras.layers.Layer):
     # TODO(scottzhu): Add build/get_config/from_config and other layer methods.
 
 
-def _create_zero_outputs(size, dtype, batch_size):
-    """Create a zero outputs Tensor structure."""
-
-    def _create(s, d):
-        return _zero_state_tensors(s, batch_size, d)
-
-    return tf.nest.map_structure(_create, size, dtype)
-
-
 def dynamic_decode(decoder,
                    output_time_major=False,
                    impute_finished=False,
@@ -348,8 +334,10 @@ def dynamic_decode(decoder,
             initial_finished, initial_inputs, initial_state = \
                 decoder.initialize(decoder_init_input, **decoder_init_kwargs)
 
-        zero_outputs = _create_zero_outputs(
-            decoder.output_size, decoder.output_dtype, decoder.batch_size)
+        zero_outputs = tf.nest.map_structure(
+            lambda shape, dtype: tf.zeros(
+                [decoder.batch_size] + shape, dtype=dtype),
+            decoder.output_size, decoder.output_dtype)
 
         if is_xla and maximum_iterations is None:
             raise ValueError(
@@ -505,3 +493,11 @@ def dynamic_decode(decoder,
                                                   final_outputs)
 
     return final_outputs, final_state, final_sequence_lengths
+
+
+def _transpose_batch_time(tensor):
+    shape = tensor.shape
+    if shape.rank is not None and shape.rank < 2:
+        return tensor
+    perm = tf.concat(([1, 0], tf.range(2, tf.rank(tensor))), axis=0)
+    return tf.transpose(tensor, perm)


### PR DESCRIPTION
Most of these functions are small and can be replaced by a simple implementation. However, they included some additional logic about static shapes but it does not seem to be needed here (at least the tests are not covering such cases).

@qlzh727 Let me know if there is a strong reason to rely on these internal functions.