### PR TITLE
Link to cudart_static and remove cuda_libs

### DIFF
--- a/tensorflow_addons/custom_ops/activations/BUILD
+++ b/tensorflow_addons/custom_ops/activations/BUILD
@@ -21,8 +21,8 @@ cc_library(
         "@local_config_tf//:libtensorflow_framework",
         "@local_config_tf//:tf_header_lib",
     ] + if_cuda_is_configured([
-        "@local_config_cuda//cuda:cuda_libs",
         "@local_config_cuda//cuda:cuda_headers",
+        "@local_config_cuda//cuda:cudart_static",
     ]),
     alwayslink = 1,
 )
@@ -43,8 +43,8 @@ cc_library(
         "@local_config_tf//:libtensorflow_framework",
         "@local_config_tf//:tf_header_lib",
     ] + if_cuda_is_configured([
-        "@local_config_cuda//cuda:cuda_libs",
         "@local_config_cuda//cuda:cuda_headers",
+        "@local_config_cuda//cuda:cudart_static",
     ]),
     alwayslink = 1,
 )
@@ -65,8 +65,8 @@ cc_library(
         "@local_config_tf//:libtensorflow_framework",
         "@local_config_tf//:tf_header_lib",
     ] + if_cuda_is_configured([
-        "@local_config_cuda//cuda:cuda_libs",
         "@local_config_cuda//cuda:cuda_headers",
+        "@local_config_cuda//cuda:cudart_static",
     ]),
     alwayslink = 1,
 )

--- a/tensorflow_addons/custom_ops/image/BUILD
+++ b/tensorflow_addons/custom_ops/image/BUILD
@@ -21,8 +21,8 @@ cc_library(
         "@local_config_tf//:libtensorflow_framework",
         "@local_config_tf//:tf_header_lib",
     ] + if_cuda_is_configured([
-        "@local_config_cuda//cuda:cuda_libs",
         "@local_config_cuda//cuda:cuda_headers",
+        "@local_config_cuda//cuda:cudart_static",
     ]),
     alwayslink = 1,
 )
@@ -62,8 +62,8 @@ cc_library(
         "@local_config_tf//:libtensorflow_framework",
         "@local_config_tf//:tf_header_lib",
     ] + if_cuda_is_configured([
-        "@local_config_cuda//cuda:cuda_libs",
         "@local_config_cuda//cuda:cuda_headers",
+        "@local_config_cuda//cuda:cudart_static",
     ]),
     alwayslink = 1,
 )
@@ -84,8 +84,8 @@ cc_library(
         "@local_config_tf//:libtensorflow_framework",
         "@local_config_tf//:tf_header_lib",
     ] + if_cuda_is_configured([
-        "@local_config_cuda//cuda:cuda_libs",
         "@local_config_cuda//cuda:cuda_headers",
+        "@local_config_cuda//cuda:cudart_static",
     ]),
     alwayslink = 1,
 )

--- a/tensorflow_addons/custom_ops/layers/BUILD
+++ b/tensorflow_addons/custom_ops/layers/BUILD
@@ -40,8 +40,8 @@ cc_library(
         "@local_config_tf//:libtensorflow_framework",
         "@local_config_tf//:tf_header_lib",
     ] + if_cuda_is_configured([
-        "@local_config_cuda//cuda:cuda_libs",
         "@local_config_cuda//cuda:cuda_headers",
+        "@local_config_cuda//cuda:cudart_static",
         "@cub_archive//:cub",
     ]),
     alwayslink = 1,

--- a/tensorflow_addons/custom_ops/seq2seq/BUILD
+++ b/tensorflow_addons/custom_ops/seq2seq/BUILD
@@ -40,8 +40,8 @@ cc_library(
         "@local_config_tf//:libtensorflow_framework",
         "@local_config_tf//:tf_header_lib",
     ] + if_cuda_is_configured([
-        "@local_config_cuda//cuda:cuda_libs",
         "@local_config_cuda//cuda:cuda_headers",
+        "@local_config_cuda//cuda:cudart_static",
     ]),
     alwayslink = 1,
 )


### PR DESCRIPTION
This is what is done in the TensorFlow codebase for custom ops:

https://github.com/tensorflow/tensorflow/blob/r2.0/tensorflow/tensorflow.bzl#L1771-L1772

After building a pip package with this change, I no longer get the error reported in #532.

Fixes #532.