### PR TITLE
unify activations and tests

### DIFF
--- a/tensorflow_addons/activations/BUILD
+++ b/tensorflow_addons/activations/BUILD
@@ -19,6 +19,19 @@ py_library(
 )
 
 py_test(
+    name = "activations_test",
+    size = "small",
+    srcs = [
+        "activations_test.py",
+    ],
+    main = "activations_test.py",
+    srcs_version = "PY2AND3",
+    deps = [
+        ":activations",
+    ],
+)
+
+py_test(
     name = "sparsemax_test",
     size = "medium",
     srcs = [

--- a/tensorflow_addons/activations/README.md
+++ b/tensorflow_addons/activations/README.md
@@ -35,6 +35,7 @@ must:
    or `run_all_in_graph_and_eager_modes` (for TestCase subclass)
    decorator.
  * Add a `py_test` to this sub-package's BUILD file.
+ * Add activation name to [activations_test.py](https://github.com/tensorflow/addons/tree/master/tensorflow_addons/activations/activations_test.py) to test searialization.
 
 #### Documentation Requirements
  * Update the table of contents in this sub-package's README.

--- a/tensorflow_addons/activations/README.md
+++ b/tensorflow_addons/activations/README.md
@@ -35,7 +35,7 @@ must:
    or `run_all_in_graph_and_eager_modes` (for TestCase subclass)
    decorator.
  * Add a `py_test` to this sub-package's BUILD file.
- * Add activation name to [activations_test.py](https://github.com/tensorflow/addons/tree/master/tensorflow_addons/activations/activations_test.py) to test searialization.
+ * Add activation name to [activations_test.py](https://github.com/tensorflow/addons/tree/master/tensorflow_addons/activations/activations_test.py) to test serialization.
 
 #### Documentation Requirements
  * Update the table of contents in this sub-package's README.

--- a/tensorflow_addons/activations/activations_test.py
+++ b/tensorflow_addons/activations/activations_test.py
@@ -17,7 +17,6 @@ from __future__ import absolute_import
 from __future__ import division
 from __future__ import print_function
 
-
 import tensorflow as tf
 from tensorflow_addons import activations
 from tensorflow_addons.utils import test_utils
@@ -26,20 +25,21 @@ from tensorflow_addons.utils import test_utils
 @test_utils.run_all_in_graph_and_eager_modes
 class ActivationsTest(tf.test.TestCase):
 
-    ALL_ACTIVATIONS = ["gelu", "hardshrink", "lisht", "sparsemax",
-                       "tanhshrink"]
+    ALL_ACTIVATIONS = [
+        "gelu", "hardshrink", "lisht", "sparsemax", "tanhshrink"
+    ]
 
     def test_serialization(self):
-        for name in ALL_ACTIVATIONS:
+        for name in self.ALL_ACTIVATIONS:
             fn = tf.keras.activations.get(name)
             ref_fn = getattr(activations, name)
             self.assertEqual(fn, ref_fn)
-            config = keras.activations.serialize(fn)
-            fn = keras.activations.deserialize(config)
+            config = tf.keras.activations.serialize(fn)
+            fn = tf.keras.activations.deserialize(config)
             self.assertEqual(fn, ref_fn)
 
     def test_serialization_with_layers(self):
-        for name in ALL_ACTIVATIONS:
+        for name in self.ALL_ACTIVATIONS:
             layer = tf.keras.layers.Dense(
                 3, activation=getattr(activations, name))
             config = tf.keras.layers.serialize(layer)

--- a/tensorflow_addons/activations/activations_test.py
+++ b/tensorflow_addons/activations/activations_test.py
@@ -26,7 +26,8 @@ from tensorflow_addons.utils import test_utils
 @test_utils.run_all_in_graph_and_eager_modes
 class ActivationsTest(tf.test.TestCase):
 
-    ALL_ACTIVATIONS = ["sparsemax", "gelu", "hardshrink", "tanhshrink"]
+    ALL_ACTIVATIONS = ["gelu", "hardshrink", "lisht", "sparsemax",
+                       "tanhshrink"]
 
     def test_serialization(self):
         for name in ALL_ACTIVATIONS:

--- a/tensorflow_addons/activations/activations_test.py
+++ b/tensorflow_addons/activations/activations_test.py
@@ -1,0 +1,48 @@
+# Copyright 2019 The TensorFlow Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ==============================================================================
+
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+
+
+import tensorflow as tf
+from tensorflow_addons import activations
+from tensorflow_addons.utils import test_utils
+
+
+@test_utils.run_all_in_graph_and_eager_modes
+class ActivationsTest(tf.test.TestCase):
+
+    ALL_ACTIVATIONS = ["sparsemax", "gelu", "hardshrink", "tanhshrink"]
+
+    def test_serialization(self):
+        for name in ALL_ACTIVATIONS:
+            fn = tf.keras.activations.get(name)
+            ref_fn = getattr(activations, name)
+            self.assertEqual(fn, ref_fn)
+            config = keras.activations.serialize(fn)
+            fn = keras.activations.deserialize(config)
+            self.assertEqual(fn, ref_fn)
+
+    def test_serialization_with_layers(self):
+        for name in ALL_ACTIVATIONS:
+            layer = tf.keras.layers.Dense(
+                3, activation=getattr(activations, name))
+            config = tf.keras.layers.serialize(layer)
+            deserialized_layer = tf.keras.layers.deserialize(config)
+            self.assertEqual(deserialized_layer.__class__.__name__,
+                             layer.__class__.__name__)
+            self.assertEqual(deserialized_layer.activation.__name__, name)

--- a/tensorflow_addons/activations/gelu_test.py
+++ b/tensorflow_addons/activations/gelu_test.py
@@ -19,8 +19,6 @@ from __future__ import print_function
 
 from absl.testing import parameterized
 
-import math
-
 import numpy as np
 import tensorflow as tf
 from tensorflow_addons.activations import gelu

--- a/tensorflow_addons/activations/gelu_test.py
+++ b/tensorflow_addons/activations/gelu_test.py
@@ -64,19 +64,6 @@ class GeluTest(tf.test.TestCase, parameterized.TestCase):
             x = tf.ones(shape=shape, dtype=tf.float32)
             self.assertAllClose(fn(x), gelu(x))
 
-    def test_serialization(self):
-        config = tf.keras.activations.serialize(gelu)
-        fn = tf.keras.activations.deserialize(config)
-        self.assertEqual(fn, gelu)
-
-    def test_serialization_with_layers(self):
-        layer = tf.keras.layers.Dense(3, activation=gelu)
-        config = tf.keras.layers.serialize(layer)
-        deserialized_layer = tf.keras.layers.deserialize(config)
-        self.assertEqual(deserialized_layer.__class__.__name__,
-                         layer.__class__.__name__)
-        self.assertEqual(deserialized_layer.activation.__name__, "gelu")
-
 
 if __name__ == "__main__":
     tf.test.main()

--- a/tensorflow_addons/activations/hardshrink_test.py
+++ b/tensorflow_addons/activations/hardshrink_test.py
@@ -66,19 +66,6 @@ class HardshrinkTest(tf.test.TestCase, parameterized.TestCase):
             x = tf.ones(shape=shape, dtype=tf.float32)
             self.assertAllClose(fn(x), hardshrink(x))
 
-    def test_serialization(self):
-        config = tf.keras.activations.serialize(hardshrink)
-        fn = tf.keras.activations.deserialize(config)
-        self.assertEqual(fn, hardshrink)
-
-    def test_serialization_with_layers(self):
-        layer = tf.keras.layers.Dense(3, activation=hardshrink)
-        config = tf.keras.layers.serialize(layer)
-        deserialized_layer = tf.keras.layers.deserialize(config)
-        self.assertEqual(deserialized_layer.__class__.__name__,
-                         layer.__class__.__name__)
-        self.assertEqual(deserialized_layer.activation.__name__, "hardshrink")
-
 
 if __name__ == "__main__":
     tf.test.main()

--- a/tensorflow_addons/activations/hardshrink_test.py
+++ b/tensorflow_addons/activations/hardshrink_test.py
@@ -25,11 +25,6 @@ from tensorflow_addons.activations import hardshrink
 from tensorflow_addons.utils import test_utils
 
 
-def _ref_hardshrink(x, lower=-1.0, upper=1.0):
-    x = tf.convert_to_tensor(x)
-    return tf.where(tf.math.logical_or(x < lower, x > upper), x, 0.0)
-
-
 @test_utils.run_all_in_graph_and_eager_modes
 class HardshrinkTest(tf.test.TestCase, parameterized.TestCase):
     def test_invalid(self):
@@ -42,34 +37,25 @@ class HardshrinkTest(tf.test.TestCase, parameterized.TestCase):
                                     ("float32", np.float32),
                                     ("float64", np.float64))
     def test_hardshrink(self, dtype):
-        x = (np.random.rand(2, 3, 4) * 2.0 - 1.0).astype(dtype)
-        self.assertAllCloseAccordingToType(hardshrink(x), _ref_hardshrink(x))
+        x = tf.constant([-2.0, -1.0, 0.0, 1.0, 2.0], dtype=dtype)
+        expected_result = tf.constant([-2.0, 0.0, 0.0, 0.0, 2.0], dtype=dtype)
+        self.assertAllCloseAccordingToType(hardshrink(x), expected_result)
+
+        expected_result = tf.constant([-2.0, -1.0, 0.0, 1.0, 2.0], dtype=dtype)
         self.assertAllCloseAccordingToType(
-            hardshrink(x, -2.0, 2.0), _ref_hardshrink(x, -2.0, 2.0))
-
-    @parameterized.named_parameters(("float16", np.float16),
-                                    ("float32", np.float32),
-                                    ("float64", np.float64))
-    def test_gradients(self, dtype):
-        x = tf.constant([-1.5, -0.5, 0.5, 1.5], dtype=dtype)
-
-        with tf.GradientTape(persistent=True) as tape:
-            tape.watch(x)
-            y_ref = _ref_hardshrink(x)
-            y = hardshrink(x)
-        grad_ref = tape.gradient(y_ref, x)
-        grad = tape.gradient(y, x)
-        self.assertAllCloseAccordingToType(grad, grad_ref)
+            hardshrink(x, lower=-0.5, upper=0.5), expected_result)
 
     @parameterized.named_parameters(("float32", np.float32),
                                     ("float64", np.float64))
     def test_theoretical_gradients(self, dtype):
         # Only test theoretical gradients for float32 and float64
         # because of the instability of float16 while computing jacobian
-        x = tf.constant([-1.5, -0.5, 0.5, 1.5], dtype=dtype)
 
-        theoretical, numerical = tf.test.compute_gradient(
-            lambda x: hardshrink(x), [x])
+        # Hardshrink is not continuous at `lower` and `upper`.
+        # Avoid these two points to make gradients smooth.
+        x = tf.constant([-2.0, -1.5, 0.0, 1.5, 2.0], dtype=dtype)
+
+        theoretical, numerical = tf.test.compute_gradient(hardshrink, [x])
         self.assertAllCloseAccordingToType(theoretical, numerical, atol=1e-4)
 
     def test_unknown_shape(self):
@@ -81,10 +67,9 @@ class HardshrinkTest(tf.test.TestCase, parameterized.TestCase):
             self.assertAllClose(fn(x), hardshrink(x))
 
     def test_serialization(self):
-        ref_fn = hardshrink
-        config = tf.keras.activations.serialize(ref_fn)
+        config = tf.keras.activations.serialize(hardshrink)
         fn = tf.keras.activations.deserialize(config)
-        self.assertEqual(fn, ref_fn)
+        self.assertEqual(fn, hardshrink)
 
     def test_serialization_with_layers(self):
         layer = tf.keras.layers.Dense(3, activation=hardshrink)

--- a/tensorflow_addons/activations/lisht_test.py
+++ b/tensorflow_addons/activations/lisht_test.py
@@ -55,19 +55,6 @@ class LishtTest(tf.test.TestCase, parameterized.TestCase):
             x = tf.ones(shape=shape, dtype=tf.float32)
             self.assertAllClose(fn(x), lisht(x))
 
-    def test_serialization(self):
-        config = tf.keras.activations.serialize(lisht)
-        fn = tf.keras.activations.deserialize(config)
-        self.assertEqual(fn, lisht)
-
-    def test_serialization_with_layers(self):
-        layer = tf.keras.layers.Dense(3, activation=lisht)
-        config = tf.keras.layers.serialize(layer)
-        deserialized_layer = tf.keras.layers.deserialize(config)
-        self.assertEqual(deserialized_layer.__class__.__name__,
-                         layer.__class__.__name__)
-        self.assertEqual(deserialized_layer.activation.__name__, "lisht")
-
 
 if __name__ == "__main__":
     tf.test.main()

--- a/tensorflow_addons/activations/sparsemax.py
+++ b/tensorflow_addons/activations/sparsemax.py
@@ -24,7 +24,7 @@ from tensorflow_addons.utils import keras_utils
 
 @keras_utils.register_keras_custom_object
 @tf.function
-def sparsemax(logits, axis=-1, name=None):
+def sparsemax(logits, axis=-1):
     """Sparsemax activation function [1].
 
     For each batch `i` and class `j` we have
@@ -35,7 +35,6 @@ def sparsemax(logits, axis=-1, name=None):
     Args:
         logits: Input tensor.
         axis: Integer, axis along which the sparsemax operation is applied.
-        name: A name for the operation (optional).
     Returns:
         Tensor, output of sparsemax transformation. Has the same type and
         shape as `logits`.
@@ -50,7 +49,7 @@ def sparsemax(logits, axis=-1, name=None):
     is_last_axis = (axis == -1) or (axis == rank - 1)
 
     if is_last_axis:
-        output = _compute_2d_sparsemax(logits, name=name)
+        output = _compute_2d_sparsemax(logits)
         output.set_shape(shape)
         return output
 
@@ -64,8 +63,7 @@ def sparsemax(logits, axis=-1, name=None):
 
     # Do the actual softmax on its last dimension.
     output = _compute_2d_sparsemax(logits)
-    output = _swap_axis(
-        output, axis_norm, tf.math.subtract(rank_op, 1), name=name)
+    output = _swap_axis(output, axis_norm, tf.math.subtract(rank_op, 1))
 
     # Make shape inference work since transpose may erase its static shape.
     output.set_shape(shape)
@@ -82,7 +80,7 @@ def _swap_axis(logits, dim_index, last_index, **kwargs):
 
 
 @tf.function
-def _compute_2d_sparsemax(logits, name=None):
+def _compute_2d_sparsemax(logits):
     """Performs the sparsemax operation when axis=-1."""
     shape_op = tf.shape(logits)
     obs = tf.math.reduce_prod(shape_op[:-1])
@@ -134,5 +132,5 @@ def _compute_2d_sparsemax(logits, name=None):
                                                    logits.dtype)), p)
 
     # Reshape back to original size
-    p_safe = tf.reshape(p_safe, shape_op, name=name)
+    p_safe = tf.reshape(p_safe, shape_op)
     return p_safe

--- a/tensorflow_addons/activations/sparsemax_test.py
+++ b/tensorflow_addons/activations/sparsemax_test.py
@@ -274,20 +274,6 @@ class SparsemaxTest(tf.test.TestCase):
             lambda logits: sparsemax(logits), [z], delta=1e-6)
         self.assertAllCloseAccordingToType(jacob_sym, jacob_num)
 
-    def test_serialization(self, dtype=None):
-        ref_fn = sparsemax
-        config = tf.keras.activations.serialize(ref_fn)
-        fn = tf.keras.activations.deserialize(config)
-        self.assertEqual(fn, ref_fn)
-
-    def test_serialization_with_layers(self, dtype=None):
-        layer = tf.keras.layers.Dense(3, activation=sparsemax)
-        config = tf.keras.layers.serialize(layer)
-        deserialized_layer = tf.keras.layers.deserialize(config)
-        self.assertEqual(deserialized_layer.__class__.__name__,
-                         layer.__class__.__name__)
-        self.assertEqual(deserialized_layer.activation.__name__, "sparsemax")
-
 
 if __name__ == '__main__':
     tf.test.main()

--- a/tensorflow_addons/activations/tanhshrink_test.py
+++ b/tensorflow_addons/activations/tanhshrink_test.py
@@ -47,19 +47,6 @@ class TanhshrinkTest(tf.test.TestCase, parameterized.TestCase):
         theoretical, numerical = tf.test.compute_gradient(tanhshrink, [x])
         self.assertAllCloseAccordingToType(theoretical, numerical, atol=1e-4)
 
-    def test_serialization(self):
-        config = tf.keras.activations.serialize(tanhshrink)
-        fn = tf.keras.activations.deserialize(config)
-        self.assertEqual(fn, tanhshrink)
-
-    def test_serialization_with_layers(self):
-        layer = tf.keras.layers.Dense(3, activation=tanhshrink)
-        config = tf.keras.layers.serialize(layer)
-        deserialized_layer = tf.keras.layers.deserialize(config)
-        self.assertEqual(deserialized_layer.__class__.__name__,
-                         layer.__class__.__name__)
-        self.assertEqual(deserialized_layer.activation.__name__, "tanhshrink")
-
 
 if __name__ == "__main__":
     tf.test.main()

--- a/tensorflow_addons/activations/tanhshrink_test.py
+++ b/tensorflow_addons/activations/tanhshrink_test.py
@@ -25,37 +25,40 @@ from tensorflow_addons.activations import tanhshrink
 from tensorflow_addons.utils import test_utils
 
 
-def _ref_tanhshrink(x):
-    return x - tf.tanh(x)
-
-
 @test_utils.run_all_in_graph_and_eager_modes
 class TanhshrinkTest(tf.test.TestCase, parameterized.TestCase):
     @parameterized.named_parameters(("float16", np.float16),
                                     ("float32", np.float32),
                                     ("float64", np.float64))
     def test_tanhshrink(self, dtype):
-        x = tf.constant([1.0, 2.0, 3.0], dtype=dtype)
-        self.assertAllCloseAccordingToType(tanhshrink(x), _ref_tanhshrink(x))
+        x = tf.constant([-2.0, -1.0, 0.0, 1.0, 2.0], dtype=dtype)
+        expected_result = tf.constant(
+            [-1.0359724, -0.23840582, 0.0, 0.23840582, 1.0359724], dtype=dtype)
 
-    @parameterized.named_parameters(("float16", np.float16),
-                                    ("float32", np.float32),
+        self.assertAllCloseAccordingToType(tanhshrink(x), expected_result)
+
+    @parameterized.named_parameters(("float32", np.float32),
                                     ("float64", np.float64))
-    def test_gradients(self, dtype):
-        x = tf.constant([1.0, 2.0, 3.0], dtype=dtype)
-        with tf.GradientTape(persistent=True) as tape:
-            tape.watch(x)
-            y_ref = _ref_tanhshrink(x)
-            y = tanhshrink(x)
-        grad_ref = tape.gradient(y_ref, x)
-        grad = tape.gradient(y, x)
-        self.assertAllCloseAccordingToType(grad, grad_ref)
+    def test_theoretical_gradients(self, dtype):
+        # Only test theoretical gradients for float32 and float64
+        # because of the instability of float16 while computing jacobian
+        x = tf.constant([-2.0, -1.0, 0.0, 1.0, 2.0], dtype=dtype)
+
+        theoretical, numerical = tf.test.compute_gradient(tanhshrink, [x])
+        self.assertAllCloseAccordingToType(theoretical, numerical, atol=1e-4)
 
     def test_serialization(self):
-        ref_fn = tanhshrink
-        config = tf.keras.activations.serialize(ref_fn)
+        config = tf.keras.activations.serialize(tanhshrink)
         fn = tf.keras.activations.deserialize(config)
-        self.assertEqual(fn, ref_fn)
+        self.assertEqual(fn, tanhshrink)
+
+    def test_serialization_with_layers(self):
+        layer = tf.keras.layers.Dense(3, activation=tanhshrink)
+        config = tf.keras.layers.serialize(layer)
+        deserialized_layer = tf.keras.layers.deserialize(config)
+        self.assertEqual(deserialized_layer.__class__.__name__,
+                         layer.__class__.__name__)
+        self.assertEqual(deserialized_layer.activation.__name__, "tanhshrink")
 
 
 if __name__ == "__main__":

--- a/tensorflow_addons/custom_ops/activations/cc/kernels/gelu_op.cc
+++ b/tensorflow_addons/custom_ops/activations/cc/kernels/gelu_op.cc
@@ -75,5 +75,5 @@ TF_CALL_GPU_NUMBER_TYPES(REGISTER_GELU_GPU_KERNELS);
 
 #endif  // GOOGLE_CUDA
 
-}  // end namespace addons
+}  // namespace addons
 }  // namespace tensorflow

--- a/tensorflow_addons/custom_ops/activations/cc/kernels/gelu_op.h
+++ b/tensorflow_addons/custom_ops/activations/cc/kernels/gelu_op.h
@@ -59,7 +59,7 @@ struct GeluGrad {
   // Computes GeluGrad backprops.
   //
   // gradients: gradients backpropagated to the Gelu op.
-  // features: the inputs that were passed to the Gelu op.
+  // features: inputs that were passed to the Gelu op.
   // approximate: whether to enable approximation.
   // backprops: gradients to backpropagate to the Gelu inputs.
   void operator()(const Device& d, typename TTypes<T>::ConstTensor gradients,
@@ -138,7 +138,7 @@ void GeluGradOp<Device, T>::OperateNoTemplate(OpKernelContext* context,
           approximate, output->flat<T>());
 }
 
-}  // end namespace addons
+}  // namespace addons
 }  // namespace tensorflow
 
 #undef EIGEN_USE_THREADS

--- a/tensorflow_addons/custom_ops/activations/cc/kernels/gelu_op_gpu.cu.cc
+++ b/tensorflow_addons/custom_ops/activations/cc/kernels/gelu_op_gpu.cu.cc
@@ -32,7 +32,7 @@ using GPUDevice = Eigen::GpuDevice;
 
 TF_CALL_GPU_NUMBER_TYPES(DEFINE_GPU_KERNELS);
 
-}  // end namespace addons
+}  // namespace addons
 }  // namespace tensorflow
 
 #endif  // GOOGLE_CUDA

--- a/tensorflow_addons/custom_ops/activations/cc/kernels/hardshrink_op.cc
+++ b/tensorflow_addons/custom_ops/activations/cc/kernels/hardshrink_op.cc
@@ -77,5 +77,5 @@ TF_CALL_GPU_NUMBER_TYPES(REGISTER_HARDSHRINK_GPU_KERNELS);
 
 #endif  // GOOGLE_CUDA
 
-}  // end namespace addons
+}  // namespace addons
 }  // namespace tensorflow

--- a/tensorflow_addons/custom_ops/activations/cc/kernels/hardshrink_op.h
+++ b/tensorflow_addons/custom_ops/activations/cc/kernels/hardshrink_op.h
@@ -51,7 +51,7 @@ struct HardshrinkGrad {
   // Computes HardshrinkGrad backprops.
   //
   // gradients: gradients backpropagated to the Hardshink op.
-  // features: the inputs that were passed to the Hardshrink op.
+  // features: inputs that were passed to the Hardshrink op.
   // lower: the lower bound for setting values to zeros.
   // upper: the upper bound for setting values to zeros.
   // backprops: gradients to backpropagate to the Hardshrink inputs.
@@ -136,7 +136,7 @@ void HardshrinkGradOp<Device, T>::OperateNoTemplate(OpKernelContext* context,
           upper, output->flat<T>());
 }
 
-}  // end namespace addons
+}  // namespace addons
 }  // namespace tensorflow
 
 #undef EIGEN_USE_THREADS

--- a/tensorflow_addons/custom_ops/activations/cc/kernels/hardshrink_op_gpu.cu.cc
+++ b/tensorflow_addons/custom_ops/activations/cc/kernels/hardshrink_op_gpu.cu.cc
@@ -32,7 +32,7 @@ using GPUDevice = Eigen::GpuDevice;
 
 TF_CALL_GPU_NUMBER_TYPES(DEFINE_GPU_KERNELS);
 
-}  // end namespace addons
+}  // namespace addons
 }  // namespace tensorflow
 
 #endif  // GOOGLE_CUDA

--- a/tensorflow_addons/custom_ops/activations/cc/ops/gelu_op.cc
+++ b/tensorflow_addons/custom_ops/activations/cc/ops/gelu_op.cc
@@ -35,5 +35,5 @@ REGISTER_OP("Addons>GeluGrad")
     .Attr("approximate: bool = true")
     .SetShapeFn(shape_inference::MergeBothInputsShapeFn);
 
-}  // end namespace addons
+}  // namespace addons
 }  // namespace tensorflow

--- a/tensorflow_addons/custom_ops/activations/cc/ops/hardshrink_op.cc
+++ b/tensorflow_addons/custom_ops/activations/cc/ops/hardshrink_op.cc
@@ -18,6 +18,7 @@ limitations under the License.
 #include "tensorflow/core/framework/shape_inference.h"
 
 namespace tensorflow {
+namespace addons {
 
 REGISTER_OP("Addons>Hardshrink")
     .Input("features: T")
@@ -36,4 +37,5 @@ REGISTER_OP("Addons>HardshrinkGrad")
     .Attr("upper: float = 1.0")
     .SetShapeFn(shape_inference::MergeBothInputsShapeFn);
 
+}  // namespace addons
 }  // namespace tensorflow


### PR DESCRIPTION
- Remove `name` arg for sparsemax
- Test theoretical gradients only
- Test outputs against numerical values instead of reference function
- Move serialization test to standalone file to reduce duplicated codes
- CC trivial fix