### PR TITLE
BLD: switch to tf-nightly

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,8 +56,8 @@ import tensorflow_addons as tfa
 ```
 
 #### Nightly Builds
-There are also nightly builds of TensorFlow Addons under the pip package 
-`tfa-nightly`, which is built against `tf-nightly-2.0-preview`. Nightly builds 
+There are also nightly builds of TensorFlow Addons under the pip package
+`tfa-nightly`, which is built against `tf-nightly`. Nightly builds
 include newer features, but may be less stable than the versioned releases.
 
 ```

--- a/build_deps/requirements.txt
+++ b/build_deps/requirements.txt
@@ -1,2 +1,2 @@
 # TensorFlow greater than this date is manylinux2010 compliant
-tf-nightly-2.0-preview>=2.0.0.dev20190802
+tf-nightly>=2.1.0.dev20191004

--- a/build_deps/requirements_gpu.txt
+++ b/build_deps/requirements_gpu.txt
@@ -1,2 +1,0 @@
-# TensorFlow greater than this date is manylinux2010 compliant
-tf-nightly-gpu-2.0-preview>=2.0.0.dev20190802

--- a/configure.sh
+++ b/configure.sh
@@ -56,11 +56,6 @@ esac
 
 BUILD_DEPS_DIR=build_deps
 REQUIREMENTS_TXT=$BUILD_DEPS_DIR/requirements.txt
-if [[ "$TF_NEED_CUDA" == "1" ]]; then
-    # TODO: delete it when tf2 standard package supports
-    # both cpu and gpu kernel.
-    REQUIREMENTS_TXT=$BUILD_DEPS_DIR/requirements_gpu.txt
-fi
 
 ${PYTHON_VERSION:=python} -m pip install $QUIET_FLAG -r $REQUIREMENTS_TXT
 

--- a/setup.py
+++ b/setup.py
@@ -69,15 +69,11 @@ REQUIRED_PACKAGES = [
 if project_name == TFA_RELEASE:
     # TODO: remove if-else condition when tf supports package consolidation.
     if platform.system() == 'Linux':
-        REQUIRED_PACKAGES.append('tensorflow-gpu == 2.0.0-rc0')
+        REQUIRED_PACKAGES.append('tensorflow-gpu == 2.1.0')
     else:
-        REQUIRED_PACKAGES.append('tensorflow == 2.0.0-rc0')
+        REQUIRED_PACKAGES.append('tensorflow == 2.1.0')
 elif project_name == TFA_NIGHTLY:
-    # TODO: remove if-else condition when tf-nightly supports package consolidation.
-    if platform.system() == 'Linux':
-        REQUIRED_PACKAGES.append('tf-nightly-gpu-2.0-preview')
-    else:
-        REQUIRED_PACKAGES.append('tf-nightly-2.0-preview')
+    REQUIRED_PACKAGES.append('tf-nightly')
 
 
 class BinaryDistribution(Distribution):

--- a/setup.py
+++ b/setup.py
@@ -69,9 +69,9 @@ REQUIRED_PACKAGES = [
 if project_name == TFA_RELEASE:
     # TODO: remove if-else condition when tf supports package consolidation.
     if platform.system() == 'Linux':
-        REQUIRED_PACKAGES.append('tensorflow-gpu == 2.1.0')
+        REQUIRED_PACKAGES.append('tensorflow-gpu == 2.0.0')
     else:
-        REQUIRED_PACKAGES.append('tensorflow == 2.1.0')
+        REQUIRED_PACKAGES.append('tensorflow == 2.0.0')
 elif project_name == TFA_NIGHTLY:
     REQUIRED_PACKAGES.append('tf-nightly')
 


### PR DESCRIPTION
Close #562

Per https://groups.google.com/a/tensorflow.org/forum/#!topic/announce/DIDUrh6LZbo

> TensorFlow 2.0 nightly pip packages are now available under the tf-nightly project starting 10/3/19. tf-nightly-2.0-preview will no longer be updated
>  the nightly `tensorflow` and `tensorflow-gpu` pip packages consolidation as announced previously has been extended to the nightly pip packages as well. 