### PR TITLE
DOC: Standardize doc information

### DIFF
--- a/tensorflow_addons/activations/__init__.py
+++ b/tensorflow_addons/activations/__init__.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 # ==============================================================================
-"""A module containing activation routines."""
+"""Addititonal activation functions."""
 
 from __future__ import absolute_import
 from __future__ import division

--- a/tensorflow_addons/callbacks/__init__.py
+++ b/tensorflow_addons/callbacks/__init__.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 # ==============================================================================
-"""A module containing callbacks that conform to Keras API."""
+"""Additional callbacks that conform to Keras API."""
 
 from __future__ import absolute_import
 from __future__ import division

--- a/tensorflow_addons/image/__init__.py
+++ b/tensorflow_addons/image/__init__.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 # ==============================================================================
-"""Image manipulation ops."""
+"""Additional image manipulation ops."""
 from __future__ import absolute_import
 from __future__ import division
 from __future__ import print_function

--- a/tensorflow_addons/metrics/__init__.py
+++ b/tensorflow_addons/metrics/__init__.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 # ==============================================================================
-"""A module containing metrics that conform to Keras API."""
+"""Additional metrics that conform to Keras API."""
 
 from __future__ import absolute_import
 from __future__ import division

--- a/tensorflow_addons/rnn/__init__.py
+++ b/tensorflow_addons/rnn/__init__.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 # ==============================================================================
-"""Customized RNN cells."""
+"""Additional RNN cells that corform to Keras API."""
 
 from __future__ import absolute_import
 from __future__ import division

--- a/tensorflow_addons/seq2seq/__init__.py
+++ b/tensorflow_addons/seq2seq/__init__.py
@@ -12,7 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 # ==============================================================================
-"""Ops for building neural network sequence to sequence decoders and losses."""
+"""Additional ops for building neural network sequence to sequence decoders and
+losses."""
 
 from __future__ import absolute_import
 from __future__ import division

--- a/tensorflow_addons/text/__init__.py
+++ b/tensorflow_addons/text/__init__.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 # ==============================================================================
-"""Text-processing ops."""
+"""Additional text-processing ops."""
 from __future__ import absolute_import
 from __future__ import division
 from __future__ import print_function


### PR DESCRIPTION
Seeing as these doc strings appear on the landing page for our API docs. Probably best that they're a bit more standardized:
https://www.tensorflow.org/addons/api_docs/python/tfa