### PR TITLE
Standardize lambda with other frameworks

### DIFF
--- a/tensorflow_addons/activations/hardshrink.py
+++ b/tensorflow_addons/activations/hardshrink.py
@@ -27,7 +27,7 @@ _activation_ops_so = tf.load_op_library(
 
 @keras_utils.register_keras_custom_object
 @tf.function
-def hardshrink(x, lower=-1.0, upper=1.0):
+def hardshrink(x, lower=-0.5, upper=0.5):
     """Hard shrink function.
 
     Computes hard shrink function:

--- a/tensorflow_addons/activations/hardshrink_test.py
+++ b/tensorflow_addons/activations/hardshrink_test.py
@@ -37,13 +37,13 @@ class HardshrinkTest(tf.test.TestCase, parameterized.TestCase):
                                     ("float32", np.float32),
                                     ("float64", np.float64))
     def test_hardshrink(self, dtype):
-        x = tf.constant([-2.0, -1.0, 0.0, 1.0, 2.0], dtype=dtype)
+        x = tf.constant([-2.0, -0.5, 0.0, 0.5, 2.0], dtype=dtype)
         expected_result = tf.constant([-2.0, 0.0, 0.0, 0.0, 2.0], dtype=dtype)
         self.assertAllCloseAccordingToType(hardshrink(x), expected_result)
 
-        expected_result = tf.constant([-2.0, -1.0, 0.0, 1.0, 2.0], dtype=dtype)
+        expected_result = tf.constant([-2.0, 0.0, 0.0, 0.0, 2.0], dtype=dtype)
         self.assertAllCloseAccordingToType(
-            hardshrink(x, lower=-0.5, upper=0.5), expected_result)
+            hardshrink(x, lower=-1.0, upper=1.0), expected_result)
 
     @parameterized.named_parameters(("float32", np.float32),
                                     ("float64", np.float64))

--- a/tensorflow_addons/activations/softshrink.py
+++ b/tensorflow_addons/activations/softshrink.py
@@ -27,7 +27,7 @@ _activation_ops_so = tf.load_op_library(
 
 @keras_utils.register_keras_custom_object
 @tf.function
-def softshrink(x, lower=-1.0, upper=1.0):
+def softshrink(x, lower=-0.5, upper=0.5):
     """Soft shrink function.
 
     Computes soft shrink function:

--- a/tensorflow_addons/activations/softshrink_test.py
+++ b/tensorflow_addons/activations/softshrink_test.py
@@ -38,12 +38,12 @@ class SoftshrinkTest(tf.test.TestCase, parameterized.TestCase):
                                     ("float64", np.float64))
     def test_softshrink(self, dtype):
         x = tf.constant([-2.0, -1.0, 0.0, 1.0, 2.0], dtype=dtype)
-        expected_result = tf.constant([-1.0, 0.0, 0.0, 0.0, 1.0], dtype=dtype)
+        expected_result = tf.constant([-1.5, -0.5, 0.0, 0.5, 1.5], dtype=dtype)
         self.assertAllCloseAccordingToType(softshrink(x), expected_result)
 
-        expected_result = tf.constant([-1.5, -0.5, 0.0, 0.5, 1.5], dtype=dtype)
+        expected_result = tf.constant([-1.0, 0.0, 0.0, 0.0, 1.0], dtype=dtype)
         self.assertAllCloseAccordingToType(
-            softshrink(x, lower=-0.5, upper=0.5), expected_result)
+            softshrink(x, lower=-1.0, upper=1.0), expected_result)
 
     @parameterized.named_parameters(("float32", np.float32),
                                     ("float64", np.float64))

--- a/tensorflow_addons/custom_ops/activations/cc/ops/hardshrink_op.cc
+++ b/tensorflow_addons/custom_ops/activations/cc/ops/hardshrink_op.cc
@@ -24,8 +24,8 @@ REGISTER_OP("Addons>Hardshrink")
     .Input("features: T")
     .Output("activations: T")
     .Attr("T: {half, float, double}")
-    .Attr("lower: float = -1.0")
-    .Attr("upper: float = 1.0")
+    .Attr("lower: float = -0.5")
+    .Attr("upper: float = 0.5")
     .SetShapeFn(shape_inference::UnchangedShape);
 
 REGISTER_OP("Addons>HardshrinkGrad")
@@ -33,8 +33,8 @@ REGISTER_OP("Addons>HardshrinkGrad")
     .Input("features: T")
     .Output("backprops: T")
     .Attr("T: {half, float, double}")
-    .Attr("lower: float = -1.0")
-    .Attr("upper: float = 1.0")
+    .Attr("lower: float = -0.5")
+    .Attr("upper: float = 0.5")
     .SetShapeFn(shape_inference::MergeBothInputsShapeFn);
 
 }  // namespace addons

--- a/tensorflow_addons/custom_ops/activations/cc/ops/softshrink_op.cc
+++ b/tensorflow_addons/custom_ops/activations/cc/ops/softshrink_op.cc
@@ -24,8 +24,8 @@ REGISTER_OP("Addons>Softshrink")
     .Input("features: T")
     .Output("activations: T")
     .Attr("T: {half, float, double}")
-    .Attr("lower: float = -1.0")
-    .Attr("upper: float = 1.0")
+    .Attr("lower: float = -0.5")
+    .Attr("upper: float = 0.5")
     .SetShapeFn(shape_inference::UnchangedShape);
 
 REGISTER_OP("Addons>SoftshrinkGrad")
@@ -33,8 +33,8 @@ REGISTER_OP("Addons>SoftshrinkGrad")
     .Input("features: T")
     .Output("backprops: T")
     .Attr("T: {half, float, double}")
-    .Attr("lower: float = -1.0")
-    .Attr("upper: float = 1.0")
+    .Attr("lower: float = -0.5")
+    .Attr("upper: float = 0.5")
     .SetShapeFn(shape_inference::MergeBothInputsShapeFn);
 
 }  // namespace addons


### PR DESCRIPTION
Per this discussion:
https://github.com/tensorflow/addons/pull/570#discussion_r332281330

Matching the default lambda values with other frameworks:
https://github.com/pytorch/pytorch/blob/446a79b95992dee7b987d0f35364fbb4ed1372db/torch/csrc/api/include/torch/nn/options/activation.h#L166

https://github.com/PaddlePaddle/Paddle/blob/8fb569e5b913958619f07243decebc24e5a6aa48/paddle/fluid/operators/activation_op.cc#L393

https://github.com/pytorch/pytorch/blob/446a79b95992dee7b987d0f35364fbb4ed1372db/torch/csrc/api/include/torch/nn/options/activation.h#L33