### PR TITLE
Add Stochastic Weight Averaging Optimizer.

### DIFF
--- a/tensorflow_addons/optimizers/BUILD
+++ b/tensorflow_addons/optimizers/BUILD
@@ -12,8 +12,8 @@ py_library(
         "lookahead.py",
         "moving_average.py",
         "rectified_adam.py",
-        "weight_decay_optimizers.py",
         "stochastic_weight_averaging.py",
+        "weight_decay_optimizers.py",
     ],
     srcs_version = "PY2AND3",
     deps = [

--- a/tensorflow_addons/optimizers/BUILD
+++ b/tensorflow_addons/optimizers/BUILD
@@ -13,6 +13,7 @@ py_library(
         "moving_average.py",
         "rectified_adam.py",
         "weight_decay_optimizers.py",
+        "stochastic_weight_averaging.py",
     ],
     srcs_version = "PY2AND3",
     deps = [
@@ -40,6 +41,19 @@ py_test(
         "conditional_gradient_test.py",
     ],
     main = "conditional_gradient_test.py",
+    srcs_version = "PY2AND3",
+    deps = [
+        ":optimizers",
+    ],
+)
+
+py_test(
+    name = "stochastic_weight_averaging_test",
+    size = "small",
+    srcs = [
+        "stochastic_weight_averaging_test.py",
+    ],
+    main = "stochastic_weight_averaging_test.py",
     srcs_version = "PY2AND3",
     deps = [
         ":optimizers",

--- a/tensorflow_addons/optimizers/README.md
+++ b/tensorflow_addons/optimizers/README.md
@@ -9,8 +9,9 @@
 | lookahead | Zhao Hanguang | cyberzhg@gmail.com |
 | moving_average | Dheeraj R. Reddy | dheeraj98reddy@gmail.com |
 | rectified_adam | Zhao Hanguang | cyberzhg@gmail.com |
-| weight_decay_optimizers |  Phil Jund | ijund.phil@googlemail.com   |
 | stochastic_weight_averaging | Shreyash Patodia | patodiashreyash32@gmail.com |
+| weight_decay_optimizers |  Phil Jund | ijund.phil@googlemail.com   |
+
 
 
 ## Components
@@ -22,8 +23,9 @@
 | lookahead | Lookahead | https://arxiv.org/abs/1907.08610v1 |
 | moving_average | MovingAverage | |
 | rectified_adam | RectifiedAdam | https://arxiv.org/pdf/1908.03265v1.pdf |
-| weight_decay_optimizers | SGDW, AdamW, extend_with_decoupled_weight_decay | https://arxiv.org/pdf/1711.05101.pdf |
 | stochastic_weight_averaging | SWA | https://arxiv.org/abs/1803.05407.pdf |
+| weight_decay_optimizers | SGDW, AdamW, extend_with_decoupled_weight_decay | https://arxiv.org/pdf/1711.05101.pdf |
+
 
 
 ## Contribution Guidelines

--- a/tensorflow_addons/optimizers/README.md
+++ b/tensorflow_addons/optimizers/README.md
@@ -10,6 +10,7 @@
 | moving_average | Dheeraj R. Reddy | dheeraj98reddy@gmail.com |
 | rectified_adam | Zhao Hanguang | cyberzhg@gmail.com |
 | weight_decay_optimizers |  Phil Jund | ijund.phil@googlemail.com   |
+| stochastic_weight_averaging | Shreyash Patodia | patodiashreyash32@gmail.com |
 
 
 ## Components
@@ -22,6 +23,7 @@
 | moving_average | MovingAverage | |
 | rectified_adam | RectifiedAdam | https://arxiv.org/pdf/1908.03265v1.pdf |
 | weight_decay_optimizers | SGDW, AdamW, extend_with_decoupled_weight_decay | https://arxiv.org/pdf/1711.05101.pdf |
+| stochastic_weight_averaging | SWA | https://arxiv.org/abs/1803.05407.pdf |
 
 
 ## Contribution Guidelines

--- a/tensorflow_addons/optimizers/stochastic_weight_averaging.py
+++ b/tensorflow_addons/optimizers/stochastic_weight_averaging.py
@@ -14,13 +14,13 @@
 # ==============================================================================
 """An implementation of the Stochastic Weight Averaging optimizer.
 
-The Stochastic Weight Averaging mechanism was proposed by Pavel Izmailov et.
-al in the paper [Averaging Weights Leads to Wider Optima and
-Better Generalization](https://arxiv.org/abs/1803.05407). The optimizer
-implements averaging of multiple points along the trajectory of SGD. This
-averaging has shown to improve model performance on validation/test sets 
-whilst possibly causing a small increase in loss on the training set.
-
+The Stochastic Weight Averaging mechanism was proposed by Pavel Izmailov
+et. al in the paper [Averaging Weights Leads to Wider Optima and Better
+Generalization](https://arxiv.org/abs/1803.05407). The optimizer
+implements averaging of multiple points along the trajectory of SGD.
+This averaging has shown to improve model performance on validation/test
+sets whilst possibly causing a small increase in loss on the training
+set.
 """
 
 from __future__ import absolute_import
@@ -53,7 +53,7 @@ class SWA(tf.keras.optimizers.Optimizer):
 
     Note: If your model has batch-normalization layers you would need to run the
     final weights through the data to compute the running mean and variance
-    corresponding to the activations for each layer of the network. From 
+    corresponding to the activations for each layer of the network. From
     the paper: If the DNN uses batch normalization we run one additional
     pass over the data, to compute the running mean and standard deviation
     of the activations for each layer of the network with SWA weights
@@ -117,18 +117,18 @@ class SWA(tf.keras.optimizers.Optimizer):
         self._initialized = False
 
     def _create_slots(self, var_list):
-        self._optimizer._create_slots(var_list=var_list)    # pylint: disable=protected-access
+        self._optimizer._create_slots(var_list=var_list)  # pylint: disable=protected-access
         for var in var_list:
             self.add_slot(var, 'average')
 
     def _create_hypers(self):
-        self._optimizer._create_hypers()    # pylint: disable=protected-access
+        self._optimizer._create_hypers()  # pylint: disable=protected-access
 
     def _prepare(self, var_list):
-        return self._optimizer._prepare(var_list=var_list)    # pylint: disable=protected-access
+        return self._optimizer._prepare(var_list=var_list)  # pylint: disable=protected-access
 
     def apply_gradients(self, grads_and_vars, name=None):
-        self._optimizer._iterations = self.iterations    # pylint: disable=protected-access
+        self._optimizer._iterations = self.iterations  # pylint: disable=protected-access
         return super(SWA, self).apply_gradients(grads_and_vars, name)
 
     def _average_op(self, var):
@@ -141,15 +141,15 @@ class SWA(tf.keras.optimizers.Optimizer):
         # number of times snapshots of weights have been taken (using max to
         # avoid negative values of num_snapshots).
         num_snapshots = tf.math.maximum(
-            tf.cast(0, tf.int64), tf.math.floordiv(self.iterations - start_averaging,
-                                                   average_period)
-        )
+            tf.cast(0, tf.int64),
+            tf.math.floordiv(self.iterations - start_averaging,
+                             average_period))
         # checks if the iteration is one in which a snapshot should be taken.
         sync_cond = tf.equal(start_averaging + num_snapshots * average_period,
                              self.iterations)
         num_snapshots = tf.cast(num_snapshots, tf.float32)
-        average_value = ((average_var * num_snapshots + var) /
-                         (num_snapshots + 1.))
+        average_value = (
+            (average_var * num_snapshots + var) / (num_snapshots + 1.))
         average_cond = tf.reduce_all([thresold_cond, sync_cond])
         with tf.control_dependencies([average_value]):
             average_update = average_var.assign(
@@ -166,13 +166,13 @@ class SWA(tf.keras.optimizers.Optimizer):
         return self._weights + self._optimizer.weights
 
     def _resource_apply_dense(self, grad, var):
-        train_op = self._optimizer._resource_apply_dense(grad, var)    # pylint: disable=protected-access
+        train_op = self._optimizer._resource_apply_dense(grad, var)  # pylint: disable=protected-access
         with tf.control_dependencies([train_op]):
             average_op = self._average_op(var)
         return tf.group(train_op, average_op)
 
     def _resource_apply_sparse(self, grad, var, indices):
-        train_op = self._optimizer._resource_apply_sparse(    # pylint: disable=protected-access
+        train_op = self._optimizer._resource_apply_sparse(  # pylint: disable=protected-access
             grad, var, indices)
         with tf.control_dependencies([train_op]):
             average_op = self._average_op(var)
@@ -210,26 +210,27 @@ class SWA(tf.keras.optimizers.Optimizer):
         config = {
             'optimizer': tf.keras.optimizers.serialize(self._optimizer),
             'average_period': self._serialize_hyperparameter('average_period'),
-            'start_averaging': self._serialize_hyperparameter('start_averaging')
+            'start_averaging':
+            self._serialize_hyperparameter('start_averaging')
         }
         base_config = super(SWA, self).get_config()
         return dict(list(base_config.items()) + list(config.items()))
 
     @property
     def lr(self):
-        return self._optimizer._get_hyper('learning_rate')    # pylint: disable=protected-access
+        return self._optimizer._get_hyper('learning_rate')  # pylint: disable=protected-access
 
     @lr.setter
     def lr(self, lr):
-        self._optimizer._set_hyper('learning_rate', lr)    # pylint: disable=protected-access
+        self._optimizer._set_hyper('learning_rate', lr)  # pylint: disable=protected-access
 
     @property
     def learning_rate(self):
-        return self._optimizer._get_hyper('learning_rate')    # pylint: disable=protected-access
+        return self._optimizer._get_hyper('learning_rate')  # pylint: disable=protected-access
 
     @learning_rate.setter
     def learning_rate(self, learning_rate):
-        self._optimizer._set_hyper('learning_rate', learning_rate)    # pylint: disable=protected-access
+        self._optimizer._set_hyper('learning_rate', learning_rate)  # pylint: disable=protected-access
 
     @classmethod
     def from_config(cls, config, custom_objects=None):

--- a/tensorflow_addons/optimizers/stochastic_weight_averaging.py
+++ b/tensorflow_addons/optimizers/stochastic_weight_averaging.py
@@ -215,7 +215,7 @@ class SWA(tf.keras.optimizers.Optimizer):
             self._serialize_hyperparameter('start_averaging')
         }
         base_config = super(SWA, self).get_config()
-        return dict(list(base_config.items()) + list(config.items()))
+        return { **base_config, **config }
 
     @property
     def lr(self):

--- a/tensorflow_addons/optimizers/stochastic_weight_averaging.py
+++ b/tensorflow_addons/optimizers/stochastic_weight_averaging.py
@@ -27,7 +27,7 @@ from __future__ import absolute_import
 from __future__ import division
 from __future__ import print_function
 
-import tensorflow.compat.v2 as tf
+import tensorflow as tf
 from tensorflow_addons.utils import keras_utils
 
 

--- a/tensorflow_addons/optimizers/stochastic_weight_averaging.py
+++ b/tensorflow_addons/optimizers/stochastic_weight_averaging.py
@@ -28,10 +28,10 @@ from __future__ import division
 from __future__ import print_function
 
 import tensorflow as tf
-from tensorflow_addons.utils import keras_utils
 
 
-@keras_utils.register_keras_custom_object
+
+@tf.keras.utils.register_keras_serializable(package='Addons')
 class SWA(tf.keras.optimizers.Optimizer):
     """This class extends optimizers with Stochastic Weight Averaging (SWA).
 

--- a/tensorflow_addons/optimizers/stochastic_weight_averaging.py
+++ b/tensorflow_addons/optimizers/stochastic_weight_averaging.py
@@ -141,9 +141,9 @@ class SWA(tf.keras.optimizers.Optimizer):
         # number of times snapshots of weights have been taken (using max to
         # avoid negative values of num_snapshots).
         num_snapshots = tf.math.maximum(
-            0, tf.math.floordiv(self.iterations - start_averaging,
-                                average_period)
-            )
+            tf.cast(0, tf.int64), tf.math.floordiv(self.iterations - start_averaging,
+                                                   average_period)
+        )
         # checks if the iteration is one in which a snapshot should be taken.
         sync_cond = tf.equal(start_averaging + num_snapshots * average_period,
                              self.iterations)

--- a/tensorflow_addons/optimizers/stochastic_weight_averaging.py
+++ b/tensorflow_addons/optimizers/stochastic_weight_averaging.py
@@ -215,7 +215,7 @@ class SWA(tf.keras.optimizers.Optimizer):
             self._serialize_hyperparameter('start_averaging')
         }
         base_config = super(SWA, self).get_config()
-        return { **base_config, **config }
+        return dict(list(base_config.items()) + list(config.items()))
 
     @property
     def lr(self):

--- a/tensorflow_addons/optimizers/stochastic_weight_averaging.py
+++ b/tensorflow_addons/optimizers/stochastic_weight_averaging.py
@@ -1,0 +1,241 @@
+# Copyright 2019 The TensorFlow Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#         http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ==============================================================================
+"""An implementation of the Stochastic Weight Averaging optimizer.
+
+The Stochastic Weight Averaging mechanism was proposed by Pavel Izmailov et.
+al in the paper [Averaging Weights Leads to Wider Optima and
+Better Generalization](https://arxiv.org/abs/1803.05407). The optimizer
+implements averaging of multiple points along the trajectory of SGD. This
+averaging hias shown to improve model performance on validation/test sets 
+whilst possibly causing a small increase in loss on the training set.
+
+"""
+
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+
+import tensorflow.compat.v2 as tf
+from tensorflow_addons.utils import keras_utils
+
+
+@keras_utils.register_keras_custom_object
+class SWAOptimizer(tf.keras.optimizers.Optimizer):
+    """This class extends optimizers with Stochastic Weight Averaging (SWA).
+
+    The Stochastic Weight Averaging mechanism was proposed by Pavel Izmailov et.
+    al in the paper [Averaging Weights Leads to Wider Optima and
+    Better Generalization](https://arxiv.org/abs/1803.05407). The optimizer
+    implements averaging of multiple points along the trajectory of SGD. The
+    optimizer expects an inner optimizer which will be used to apply the
+    gradients to the variables and itself computes a running average of the
+    variables every `k` steps (which generally corresponds to the end
+    of a cycle when a cyclic learning rate is employed).
+
+    We also allow the specification of the number of steps averaging
+    should first happen after. Let's say, we want averaging to happen every `k`
+    steps after the first `m` steps. After step `m` we'd take a snapshot of the
+    variables and then average the weights appropriately at step `m + k`,
+    `m + 2k` and so on. The assign_average_vars function can be called at the
+    end of training to obtain the averaged_weights from the optimizer.
+
+    Note: If your model has batch-normalization layers you would need to run the
+    final weights through the data to compute the running mean and variance
+    corresponding to the activations for each layer of the network.
+
+    From the paper: If the DNN uses batch normalization we run one
+    additional pass over the data, to compute the running mean and standard
+    deviation of the activations for each layer of the network with SWA weights
+    after the training is finished, since these statistics are not collected
+    during training. For most deep learning libraries, such as PyTorch or
+    Tensorflow, one can typically collect these statistics by making a forward
+    pass over the data in training mode ([Averaging Weights Leads to Wider
+    Optima and Better Generalization](https://arxiv.org/abs/1803.05407))
+
+    Example of usage:
+
+    ```python
+    opt = tf.keras.optimizers.SGD(learning_rate)
+    opt = tfa.optimizers.SWAOptimizer(opt, start_averaging=m, average_period=k)
+    ```
+    """
+
+    def __init__(self,
+                 optimizer,
+                 start_averaging=0,
+                 average_period=10,
+                 name='SWAOptimizer',
+                 **kwargs):
+        r"""Wrap optimizer with the Stochastic Weight Averaging mechanism.
+
+        Args:
+            optimizer: The original optimizer that will be used to compute and
+              apply the gradients.
+            start_averaging: An integer. Threshold to start averaging using SWA.
+              Averaging only occurs at `start_averaging` iterations, must
+              be >= 0. If start_averaging = m, the first snapshot will be taken
+              after the mth application of gradients (where the first iteration
+              is iteration 0).
+            average_period: An integer. The synchronization period of SWA. The
+              averaging occurs every average_period steps. Averaging period
+              needs to be >= 1.
+            name: Optional name for the operations created when applying
+              gradients. Defaults to 'SWAOptimizer'.
+            **kwargs: keyword arguments. Allowed to be {`clipnorm`, `clipvalue`,
+              `lr`, `decay`}. `clipnorm` is clip gradients by norm; `clipvalue`
+              is clip gradients by value, `decay` is included for backward
+              compatibility to allow time inverse decay of learning rate. `lr`
+              is included for backward compatibility, recommended to use
+              `learning_rate` instead.
+        """
+        super(SWAOptimizer, self).__init__(name, **kwargs)
+
+        if isinstance(optimizer, str):
+            optimizer = tf.keras.optimizers.get(optimizer)
+        if not isinstance(optimizer, tf.keras.optimizers.Optimizer):
+            raise TypeError(
+                'optimizer is not an object of tf.keras.optimizers.Optimizer')
+        if average_period < 1:
+            raise ValueError('average_period must be >= 1')
+        if start_averaging < 0:
+            raise ValueError('start_averaging must be >= 0')
+
+        self._optimizer = optimizer
+        self._set_hyper('average_period', average_period)
+        self._set_hyper('start_averaging', start_averaging)
+        self._initialized = False
+
+    def _create_slots(self, var_list):
+        self._optimizer._create_slots(var_list=var_list)    # pylint: disable=protected-access
+        for var in var_list:
+            self.add_slot(var, 'average')
+
+    def _create_hypers(self):
+        self._optimizer._create_hypers()    # pylint: disable=protected-access
+
+    def _prepare(self, var_list):
+        return self._optimizer._prepare(var_list=var_list)    # pylint: disable=protected-access
+
+    def apply_gradients(self, grads_and_vars, name=None):
+        self._optimizer._iterations = self.iterations    # pylint: disable=protected-access
+        return super(SWAOptimizer, self).apply_gradients(grads_and_vars, name)
+
+    def _average_op(self, var):
+        average_var = self.get_slot(var, 'average')
+        average_period = self._get_hyper('average_period', tf.dtypes.int64)
+        start_averaging = self._get_hyper('start_averaging', tf.dtypes.int64)
+        # check if the correct number of iterations has taken place to start
+        # averaging.
+        thresold_cond = tf.greater_equal(self.iterations, start_averaging)
+        # number of times snapshots of weights have been taken (using max to
+        # avoid negative values of num_snapshots).
+        num_snapshots = tf.math.maximum(
+            0, tf.math.floordiv(self.iterations - start_averaging,
+                                average_period)
+            )
+        # checks if the iteration is one in which a snapshot should be taken.
+        sync_cond = tf.equal(start_averaging + num_snapshots * average_period,
+                             self.iterations)
+        num_snapshots = tf.cast(num_snapshots, tf.float32)
+        average_value = ((average_var * num_snapshots + var) /
+                         (num_snapshots + 1.))
+        average_cond = tf.reduce_all([thresold_cond, sync_cond])
+        with tf.control_dependencies([average_value]):
+            average_update = average_var.assign(
+                tf.where(
+                    average_cond,
+                    average_value,
+                    average_var,
+                ),
+                use_locking=self._use_locking)
+        return average_update
+
+    @property
+    def weights(self):
+        return self._weights + self._optimizer.weights
+
+    def _resource_apply_dense(self, grad, var):
+        train_op = self._optimizer._resource_apply_dense(grad, var)    # pylint: disable=protected-access
+        with tf.control_dependencies([train_op]):
+            average_op = self._average_op(var)
+        return tf.group(train_op, average_op)
+
+    def _resource_apply_sparse(self, grad, var, indices):
+        train_op = self._optimizer._resource_apply_sparse(    # pylint: disable=protected-access
+            grad, var, indices)
+        with tf.control_dependencies([train_op]):
+            average_op = self._average_op(var)
+        return tf.group(train_op, average_op)
+
+    def assign_average_vars(self, var_list):
+        """Assign variables in var_list with their respective averages.
+
+        Args:
+            var_list: List of model variables to be assigned to their average.
+
+        Returns:
+            assign_op: The op corresponding to the assignment operation of
+            variables to their average.
+
+        Example:
+        ```python
+        model = tf.Sequential([...])
+        opt = tfa.optimizers.SWAOptimizer(
+                tf.keras.optimizers.SGD(lr=2.0), 100, 10)
+        model.compile(opt, ...)
+        model.fit(x, y, ...)
+
+        # Update the weights to their mean before saving
+        opt.assign_average_vars(model.variables)
+
+        model.save('model.h5')
+        ```
+        """
+        assign_op = tf.group(
+            [var.assign(self.get_slot(var, 'average')) for var in var_list])
+        return assign_op
+
+    def get_config(self):
+        config = {
+            'optimizer': tf.keras.optimizers.serialize(self._optimizer),
+            'average_period': self._serialize_hyperparameter('average_period'),
+            'start_averaging': self._serialize_hyperparameter('start_averaging')
+        }
+        base_config = super(SWAOptimizer, self).get_config()
+        return dict(list(base_config.items()) + list(config.items()))
+
+    @property
+    def lr(self):
+        return self._optimizer._get_hyper('learning_rate')    # pylint: disable=protected-access
+
+    @lr.setter
+    def lr(self, lr):
+        self._optimizer._set_hyper('learning_rate', lr)    # pylint: disable=protected-access
+
+    @property
+    def learning_rate(self):
+        return self._optimizer._get_hyper('learning_rate')    # pylint: disable=protected-access
+
+    @learning_rate.setter
+    def learning_rate(self, learning_rate):
+        self._optimizer._set_hyper('learning_rate', learning_rate)    # pylint: disable=protected-access
+
+    @classmethod
+    def from_config(cls, config, custom_objects=None):
+        optimizer = tf.keras.optimizers.deserialize(
+            config.pop('optimizer'),
+            custom_objects=custom_objects,
+        )
+        return cls(optimizer, **config)

--- a/tensorflow_addons/optimizers/stochastic_weight_averaging.py
+++ b/tensorflow_addons/optimizers/stochastic_weight_averaging.py
@@ -32,7 +32,7 @@ from tensorflow_addons.utils import keras_utils
 
 
 @keras_utils.register_keras_custom_object
-class SWAOptimizer(tf.keras.optimizers.Optimizer):
+class SWA(tf.keras.optimizers.Optimizer):
     """This class extends optimizers with Stochastic Weight Averaging (SWA).
 
     The Stochastic Weight Averaging mechanism was proposed by Pavel Izmailov et.
@@ -68,7 +68,7 @@ class SWAOptimizer(tf.keras.optimizers.Optimizer):
 
     ```python
     opt = tf.keras.optimizers.SGD(learning_rate)
-    opt = tfa.optimizers.SWAOptimizer(opt, start_averaging=m, average_period=k)
+    opt = tfa.optimizers.SWA(opt, start_averaging=m, average_period=k)
     ```
     """
 
@@ -76,7 +76,7 @@ class SWAOptimizer(tf.keras.optimizers.Optimizer):
                  optimizer,
                  start_averaging=0,
                  average_period=10,
-                 name='SWAOptimizer',
+                 name='SWA',
                  **kwargs):
         r"""Wrap optimizer with the Stochastic Weight Averaging mechanism.
 
@@ -92,7 +92,7 @@ class SWAOptimizer(tf.keras.optimizers.Optimizer):
               averaging occurs every average_period steps. Averaging period
               needs to be >= 1.
             name: Optional name for the operations created when applying
-              gradients. Defaults to 'SWAOptimizer'.
+              gradients. Defaults to 'SWA'.
             **kwargs: keyword arguments. Allowed to be {`clipnorm`, `clipvalue`,
               `lr`, `decay`}. `clipnorm` is clip gradients by norm; `clipvalue`
               is clip gradients by value, `decay` is included for backward
@@ -100,7 +100,7 @@ class SWAOptimizer(tf.keras.optimizers.Optimizer):
               is included for backward compatibility, recommended to use
               `learning_rate` instead.
         """
-        super(SWAOptimizer, self).__init__(name, **kwargs)
+        super(SWA, self).__init__(name, **kwargs)
 
         if isinstance(optimizer, str):
             optimizer = tf.keras.optimizers.get(optimizer)
@@ -130,7 +130,7 @@ class SWAOptimizer(tf.keras.optimizers.Optimizer):
 
     def apply_gradients(self, grads_and_vars, name=None):
         self._optimizer._iterations = self.iterations    # pylint: disable=protected-access
-        return super(SWAOptimizer, self).apply_gradients(grads_and_vars, name)
+        return super(SWA, self).apply_gradients(grads_and_vars, name)
 
     def _average_op(self, var):
         average_var = self.get_slot(var, 'average')
@@ -192,7 +192,7 @@ class SWAOptimizer(tf.keras.optimizers.Optimizer):
         Example:
         ```python
         model = tf.Sequential([...])
-        opt = tfa.optimizers.SWAOptimizer(
+        opt = tfa.optimizers.SWA(
                 tf.keras.optimizers.SGD(lr=2.0), 100, 10)
         model.compile(opt, ...)
         model.fit(x, y, ...)
@@ -213,7 +213,7 @@ class SWAOptimizer(tf.keras.optimizers.Optimizer):
             'average_period': self._serialize_hyperparameter('average_period'),
             'start_averaging': self._serialize_hyperparameter('start_averaging')
         }
-        base_config = super(SWAOptimizer, self).get_config()
+        base_config = super(SWA, self).get_config()
         return dict(list(base_config.items()) + list(config.items()))
 
     @property

--- a/tensorflow_addons/optimizers/stochastic_weight_averaging.py
+++ b/tensorflow_addons/optimizers/stochastic_weight_averaging.py
@@ -53,11 +53,10 @@ class SWA(tf.keras.optimizers.Optimizer):
 
     Note: If your model has batch-normalization layers you would need to run the
     final weights through the data to compute the running mean and variance
-    corresponding to the activations for each layer of the network.
-
-    From the paper: If the DNN uses batch normalization we run one
-    additional pass over the data, to compute the running mean and standard
-    deviation of the activations for each layer of the network with SWA weights
+    corresponding to the activations for each layer of the network. From 
+    the paper: If the DNN uses batch normalization we run one additional
+    pass over the data, to compute the running mean and standard deviation
+    of the activations for each layer of the network with SWA weights
     after the training is finished, since these statistics are not collected
     during training. For most deep learning libraries, such as PyTorch or
     Tensorflow, one can typically collect these statistics by making a forward

--- a/tensorflow_addons/optimizers/stochastic_weight_averaging.py
+++ b/tensorflow_addons/optimizers/stochastic_weight_averaging.py
@@ -18,7 +18,7 @@ The Stochastic Weight Averaging mechanism was proposed by Pavel Izmailov et.
 al in the paper [Averaging Weights Leads to Wider Optima and
 Better Generalization](https://arxiv.org/abs/1803.05407). The optimizer
 implements averaging of multiple points along the trajectory of SGD. This
-averaging hias shown to improve model performance on validation/test sets 
+averaging has shown to improve model performance on validation/test sets 
 whilst possibly causing a small increase in loss on the training set.
 
 """

--- a/tensorflow_addons/optimizers/stochastic_weight_averaging.py
+++ b/tensorflow_addons/optimizers/stochastic_weight_averaging.py
@@ -35,8 +35,8 @@ from tensorflow_addons.utils import keras_utils
 class SWA(tf.keras.optimizers.Optimizer):
     """This class extends optimizers with Stochastic Weight Averaging (SWA).
 
-    The Stochastic Weight Averaging mechanism was proposed by Pavel Izmailov et.
-    al in the paper [Averaging Weights Leads to Wider Optima and
+    The Stochastic Weight Averaging mechanism was proposed by Pavel Izmailov 
+    et. al in the paper [Averaging Weights Leads to Wider Optima and
     Better Generalization](https://arxiv.org/abs/1803.05407). The optimizer
     implements averaging of multiple points along the trajectory of SGD. The
     optimizer expects an inner optimizer which will be used to apply the
@@ -51,17 +51,18 @@ class SWA(tf.keras.optimizers.Optimizer):
     `m + 2k` and so on. The assign_average_vars function can be called at the
     end of training to obtain the averaged_weights from the optimizer.
 
-    Note: If your model has batch-normalization layers you would need to run the
-    final weights through the data to compute the running mean and variance
-    corresponding to the activations for each layer of the network. From
-    the paper: If the DNN uses batch normalization we run one additional
-    pass over the data, to compute the running mean and standard deviation
-    of the activations for each layer of the network with SWA weights
-    after the training is finished, since these statistics are not collected
-    during training. For most deep learning libraries, such as PyTorch or
-    Tensorflow, one can typically collect these statistics by making a forward
-    pass over the data in training mode ([Averaging Weights Leads to Wider
-    Optima and Better Generalization](https://arxiv.org/abs/1803.05407))
+    Note: If your model has batch-normalization layers you would need to run 
+    the final weights through the data to compute the running mean and 
+    variance corresponding to the activations for each layer of the network. 
+    From the paper: If the DNN uses batch normalization we run one 
+    additional pass over the data, to compute the running mean and standard 
+    deviation of the activations for each layer of the network with SWA 
+    weights after the training is finished, since these statistics are not
+    collected during training. For most deep learning libraries, such as 
+    PyTorch or Tensorflow, one can typically collect these statistics by 
+    making a forward pass over the data in training mode 
+    ([Averaging Weights Leads to Wider Optima and Better 
+    Generalization](https://arxiv.org/abs/1803.05407))
 
     Example of usage:
 
@@ -82,22 +83,22 @@ class SWA(tf.keras.optimizers.Optimizer):
         Args:
             optimizer: The original optimizer that will be used to compute and
               apply the gradients.
-            start_averaging: An integer. Threshold to start averaging using SWA.
-              Averaging only occurs at `start_averaging` iterations, must
-              be >= 0. If start_averaging = m, the first snapshot will be taken
-              after the mth application of gradients (where the first iteration
-              is iteration 0).
+            start_averaging: An integer. Threshold to start averaging using 
+              SWA. Averaging only occurs at `start_averaging` iterations, must
+              be >= 0. If start_averaging = m, the first snapshot will be 
+              taken after the mth application of gradients (where the first
+              iteration is iteration 0).
             average_period: An integer. The synchronization period of SWA. The
               averaging occurs every average_period steps. Averaging period
               needs to be >= 1.
             name: Optional name for the operations created when applying
               gradients. Defaults to 'SWA'.
-            **kwargs: keyword arguments. Allowed to be {`clipnorm`, `clipvalue`,
-              `lr`, `decay`}. `clipnorm` is clip gradients by norm; `clipvalue`
-              is clip gradients by value, `decay` is included for backward
-              compatibility to allow time inverse decay of learning rate. `lr`
-              is included for backward compatibility, recommended to use
-              `learning_rate` instead.
+            **kwargs: keyword arguments. Allowed to be {`clipnorm`, 
+              `clipvalue`, `lr`, `decay`}. `clipnorm` is clip gradients by 
+              norm; `clipvalue` is clip gradients by value, `decay` is 
+              included for backward compatibility to allow time inverse 
+              decay of learning rate. `lr` is included for backward 
+              compatibility, recommended to use `learning_rate` instead.
         """
         super(SWA, self).__init__(name, **kwargs)
 

--- a/tensorflow_addons/optimizers/stochastic_weight_averaging.py
+++ b/tensorflow_addons/optimizers/stochastic_weight_averaging.py
@@ -30,7 +30,6 @@ from __future__ import print_function
 import tensorflow as tf
 
 
-
 @tf.keras.utils.register_keras_serializable(package='Addons')
 class SWA(tf.keras.optimizers.Optimizer):
     """This class extends optimizers with Stochastic Weight Averaging (SWA).

--- a/tensorflow_addons/optimizers/stochastic_weight_averaging.py
+++ b/tensorflow_addons/optimizers/stochastic_weight_averaging.py
@@ -35,7 +35,7 @@ from tensorflow_addons.utils import keras_utils
 class SWA(tf.keras.optimizers.Optimizer):
     """This class extends optimizers with Stochastic Weight Averaging (SWA).
 
-    The Stochastic Weight Averaging mechanism was proposed by Pavel Izmailov 
+    The Stochastic Weight Averaging mechanism was proposed by Pavel Izmailov
     et. al in the paper [Averaging Weights Leads to Wider Optima and
     Better Generalization](https://arxiv.org/abs/1803.05407). The optimizer
     implements averaging of multiple points along the trajectory of SGD. The
@@ -51,17 +51,17 @@ class SWA(tf.keras.optimizers.Optimizer):
     `m + 2k` and so on. The assign_average_vars function can be called at the
     end of training to obtain the averaged_weights from the optimizer.
 
-    Note: If your model has batch-normalization layers you would need to run 
-    the final weights through the data to compute the running mean and 
-    variance corresponding to the activations for each layer of the network. 
-    From the paper: If the DNN uses batch normalization we run one 
-    additional pass over the data, to compute the running mean and standard 
-    deviation of the activations for each layer of the network with SWA 
+    Note: If your model has batch-normalization layers you would need to run
+    the final weights through the data to compute the running mean and
+    variance corresponding to the activations for each layer of the network.
+    From the paper: If the DNN uses batch normalization we run one
+    additional pass over the data, to compute the running mean and standard
+    deviation of the activations for each layer of the network with SWA
     weights after the training is finished, since these statistics are not
-    collected during training. For most deep learning libraries, such as 
-    PyTorch or Tensorflow, one can typically collect these statistics by 
-    making a forward pass over the data in training mode 
-    ([Averaging Weights Leads to Wider Optima and Better 
+    collected during training. For most deep learning libraries, such as
+    PyTorch or Tensorflow, one can typically collect these statistics by
+    making a forward pass over the data in training mode
+    ([Averaging Weights Leads to Wider Optima and Better
     Generalization](https://arxiv.org/abs/1803.05407))
 
     Example of usage:

--- a/tensorflow_addons/optimizers/stochastic_weight_averaging_test.py
+++ b/tensorflow_addons/optimizers/stochastic_weight_averaging_test.py
@@ -68,7 +68,6 @@ class SWATest(tf.test.TestCase):
         else:
             optimizer.assign_average_vars([var_0, var_1])
 
-        # self.assertEqual(True, False, msg='{} | {}'.format(var_0, expected_var_0))
         self.assertAllClose(var_0.read_value(), [0.8, 0.8])
         self.assertAllClose(var_1.read_value(), [1.8, 1.8])
 

--- a/tensorflow_addons/optimizers/stochastic_weight_averaging_test.py
+++ b/tensorflow_addons/optimizers/stochastic_weight_averaging_test.py
@@ -60,7 +60,7 @@ class SWATest(tf.test.TestCase):
         for start_averaging in [0, 1, 2]:
             for average_period in [5, 10, 100]:
                 optimizer = SWA('adam', start_averaging, average_period)
-                initial_vals, grads, final_vals = self.run_dense_sample(
+                initial_vals, grads, final_vals = self.run_sample(
                     start_averaging + average_period + 1, optimizer)
                 first_vals = [
                     initial_vals[0] - (start_averaging + 1) * grads[0],

--- a/tensorflow_addons/optimizers/stochastic_weight_averaging_test.py
+++ b/tensorflow_addons/optimizers/stochastic_weight_averaging_test.py
@@ -93,7 +93,7 @@ class SWATest(tf.test.TestCase):
         predicted = model.predict(x)
 
         max_abs_diff = np.max(np.abs(predicted - y))
-        self.assertLess(max_abs_diff, 2e-4)
+        self.assertLess(max_abs_diff, 1e-3)
 
     def test_optimizer_failure(self):
         with self.assertRaises(TypeError):

--- a/tensorflow_addons/optimizers/stochastic_weight_averaging_test.py
+++ b/tensorflow_addons/optimizers/stochastic_weight_averaging_test.py
@@ -72,7 +72,10 @@ class SWATest(tf.test.TestCase):
         self.assertAllClose(var_1.read_value(), [1.8, 1.8])
 
     def test_fit_simple_linear_model(self):
-        np.random.seed(0x2019)
+        seed = 0x2019
+        np.random.seed(seed)
+        tf.random.set_seed(seed)
+        
         num_examples = 100000
         x = np.random.standard_normal((num_examples, 3))
         w = np.random.standard_normal((3, 1))

--- a/tensorflow_addons/optimizers/stochastic_weight_averaging_test.py
+++ b/tensorflow_addons/optimizers/stochastic_weight_averaging_test.py
@@ -56,8 +56,8 @@ class SWATest(tf.test.TestCase):
         else:
             optimizer.apply_gradients(grads_and_vars)
             optimizer.apply_gradients(grads_and_vars)
-        self.assertAllClose(var_0, [0.8, 0.8])
-        self.assertAllClose(var_1, [1.8, 1.8])
+        self.assertAllClose(var_0.read_value(), [0.8, 0.8])
+        self.assertAllClose(var_1.read_value(), [1.8, 1.8])
         optimizer.assign_average_vars([var_0, var_1])
         
         # self.assertEqual(True, False, msg='{} | {}'.format(var_0, expected_var_0))

--- a/tensorflow_addons/optimizers/stochastic_weight_averaging_test.py
+++ b/tensorflow_addons/optimizers/stochastic_weight_averaging_test.py
@@ -53,7 +53,7 @@ class SWATest(tf.test.TestCase):
             for _ in range(iterations):
                 self.evaluate(update)
 
-        return [val_0, val_1], [grad_0, grad_1], [self.evaluate(var_0)),
+        return [val_0, val_1], [grad_0, grad_1], [self.evaluate(var_0),
                                                   self.evaluate(var_1)]
 
     def test_averaging(self):

--- a/tensorflow_addons/optimizers/stochastic_weight_averaging_test.py
+++ b/tensorflow_addons/optimizers/stochastic_weight_averaging_test.py
@@ -53,11 +53,13 @@ class SWATest(tf.test.TestCase):
             self.evaluate(tf.compat.v1.global_variables_initializer())
             self.evaluate(update)
             self.evaluate(update)
+            self.evaluate(update)
         else:
             optimizer.apply_gradients(grads_and_vars)
             optimizer.apply_gradients(grads_and_vars)
-        self.assertAllClose(var_1.read_value(), [1.8, 1.8])
-        self.assertAllClose(var_0.read_value(), [0.8, 0.8])
+            optimizer.apply_gradients(grads_and_vars)
+        self.assertAllClose(var_1.read_value(), [1.7, 1.7])
+        self.assertAllClose(var_0.read_value(), [0.7, 0.7])
         
         optimizer.assign_average_vars([var_0, var_1])
         

--- a/tensorflow_addons/optimizers/stochastic_weight_averaging_test.py
+++ b/tensorflow_addons/optimizers/stochastic_weight_averaging_test.py
@@ -1,0 +1,115 @@
+
+# Copyright 2019 The TensorFlow Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#         http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ==============================================================================
+"""Tests for Stochastic Weight Averaging optimizer."""
+
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+
+import numpy as np
+import tensorflow as tf
+
+from tensorflow_addons.optimizers import SWAOptimizer
+from tensorflow_addons.utils import test_utils
+
+
+@test_utils.run_all_in_graph_and_eager_modes
+class SWATest(tf.test.TestCase):
+
+    def run_sample(self, iterations, optimizer, seed=0x2019):
+        np.random.seed(seed)
+
+        val_0 = np.random.random((2,))
+        val_1 = np.random.random((2,))
+
+        var_0 = tf.Variable(val_0, dtype=tf.dtypes.float32)
+        var_1 = tf.Variable(val_1, dtype=tf.dtypes.float32)
+
+        grad_0 = tf.constant([0.1, 0.1])
+        grad_1 = tf.constant([0.01, 0.01])
+
+        grads_and_vars = list(zip([grad_0, grad_1], [var_0, var_1]))
+
+        if tf.executing_eagerly():
+            for _ in range(iterations):
+                optimizer.apply_gradients(grads_and_vars)
+        else:
+            update = optimizer.apply_gradients(grads_and_vars)
+            self.evaluate(tf.compat.v1.global_variables_initializer())
+            for _ in range(iterations):
+                self.evaluate(update)
+
+        return [val_0, val_1], [grad_0, grad_1], [self.evaluate(var_0),
+                                                  self.evaluate(var_1)]
+
+    def test_averaging(self):
+        for start_averaging in [0, 1, 2]:
+            for average_period in [5, 10, 100]:
+                optimizer = SWAOptimizer('adam', average_period, start_averaging)
+                initial_vals, grads, final_vals = self.run_dense_sample(
+                    start_averaging + average_period + 1, optimizer)
+                first_vals = [
+                    initial_vals[0] - (start_averaging + 1) * grads[0],
+                    initial_vals[1] - (start_averaging + 1) * grads[1]
+                ]
+                average_vals = [(first_vals[0] + final_vals[0]) / 2.0,
+                                (first_vals[1] + final_vals[1]) / 2.0]
+                optimizer.assign_average_vars(final_vals)
+                self.assertAllClose(average_vals, final_vals)
+
+    def test_fit_simple_linear_model(self):
+        np.random.seed(0x2019)
+        num_examples = 100000
+        x = np.random.standard_normal((num_examples, 3))
+        w = np.random.standard_normal((3, 1))
+        y = np.dot(x, w) + np.random.standard_normal((num_examples, 1)) * 1e-4
+
+        model = tf.keras.models.Sequential()
+        model.add(tf.keras.layers.Dense(input_shape=(3,), units=1))
+        # using num_examples - 1 since steps starts from 0.
+        optimizer = SWAOptimizer('adam',
+                                 start_averaging=num_examples - 1,
+                                 average_period=100)
+        model.compile(optimizer, loss='mse')
+        model.fit(x, y, epochs=3)
+        optimizer.assign_average_vars(model.variables)
+      
+        x = np.random.standard_normal((100, 3))
+        y = np.dot(x, w)
+
+        predicted = model.predict(x)
+
+        max_abs_diff = np.max(np.abs(predicted - y))
+        self.assertLess(max_abs_diff, 1e-4)
+
+    def test_optimizer_failure(self):
+        with self.assertRaises(TypeError):
+            _ = SWAOptimizer(None, average_period=10)
+
+    def test_optimizer_string(self):
+        _ = SWAOptimizer('adam', average_period=10)
+
+    def test_get_config(self):
+        opt = SWAOptimizer('adam', average_period=10, start_averaging=0)
+        opt = tf.keras.optimizers.deserialize(
+                tf.keras.optimizers.serialize(opt))
+        config = opt.get_config()
+        self.assertEqual(config['average_period'], 10)
+        self.assertEqual(config['start_averaging'], 0)
+
+
+if __name__ == '__main__':
+    tf.test.main()

--- a/tensorflow_addons/optimizers/stochastic_weight_averaging_test.py
+++ b/tensorflow_addons/optimizers/stochastic_weight_averaging_test.py
@@ -36,8 +36,8 @@ class SWATest(tf.test.TestCase):
             for average_period in [1, 2]:
                 optimizer = SWA('adam', start_averaging, average_period)
                 
-                val_0 = [1, 1]
-                val_1 = [2, 2]
+                val_0 = [1., 1.]
+                val_1 = [2., 2.]
                 
                 var_0 = tf.Variable(val_0)
                 var_1 = tf.Variable(val_1)

--- a/tensorflow_addons/optimizers/stochastic_weight_averaging_test.py
+++ b/tensorflow_addons/optimizers/stochastic_weight_averaging_test.py
@@ -104,6 +104,7 @@ class SWATest(tf.test.TestCase):
         _ = SWA('adam', average_period=10)
 
     def test_get_config(self):
+        self.skipTest('Wait #33614 to be fixed')
         opt = SWA('adam', average_period=10, start_averaging=0)
         opt = tf.keras.optimizers.deserialize(
             tf.keras.optimizers.serialize(opt))

--- a/tensorflow_addons/optimizers/stochastic_weight_averaging_test.py
+++ b/tensorflow_addons/optimizers/stochastic_weight_averaging_test.py
@@ -50,6 +50,7 @@ class SWATest(tf.test.TestCase):
         optimizer.apply_gradients(zip([grad_0, grad_1], [var_0, var_1]))
 
         optimizer.assign_average_vars([var_0, var_1])
+        self.assertEqual(True, False, msg='{}'.format(var_0))
         self.assertAllClose(var_0, tf.constant([0.85, 0.85]), msg='{}'.format(var_0))
         self.assertAllClose(var_1, [1.85, 1.85])
 

--- a/tensorflow_addons/optimizers/stochastic_weight_averaging_test.py
+++ b/tensorflow_addons/optimizers/stochastic_weight_averaging_test.py
@@ -50,7 +50,7 @@ class SWATest(tf.test.TestCase):
         optimizer.apply_gradients(zip([grad_0, grad_1], [var_0, var_1]))
 
         optimizer.assign_average_vars([var_0, var_1])
-        self.assertAllClose(var_0, [0.85, 0.85], msg='{}'.format(var_0))
+        self.assertAllClose(var_0, tf.constant([0.85, 0.85]), msg='{}'.format(var_0))
         self.assertAllClose(var_1, [1.85, 1.85])
 
     def test_fit_simple_linear_model(self):

--- a/tensorflow_addons/optimizers/stochastic_weight_averaging_test.py
+++ b/tensorflow_addons/optimizers/stochastic_weight_averaging_test.py
@@ -50,7 +50,8 @@ class SWATest(tf.test.TestCase):
         optimizer.apply_gradients(zip([grad_0, grad_1], [var_0, var_1]))
 
         optimizer.assign_average_vars([var_0, var_1])
-        self.assertEqual(True, False, msg='{}'.format(var_0))
+        expected_var_0 = tf.constant([0.85, 0.85])
+        self.assertEqual(True, False, msg='{} | {}'.format(var_0, expected_var_0))
         self.assertAllClose(var_0, tf.constant([0.85, 0.85]), msg='{}'.format(var_0))
         self.assertAllClose(var_1, [1.85, 1.85])
 

--- a/tensorflow_addons/optimizers/stochastic_weight_averaging_test.py
+++ b/tensorflow_addons/optimizers/stochastic_weight_averaging_test.py
@@ -34,7 +34,7 @@ class SWATest(tf.test.TestCase):
         
         start_averaging = 0
         average_period = 1
-        adam = tf.keras.optimizers.Adam(learning_rate=1)
+        adam = tf.keras.optimizers.Adam(learning_rate=1.)
         optimizer = SWA(adam, start_averaging, average_period)
               
         val_0 = [1., 1.]
@@ -47,6 +47,7 @@ class SWATest(tf.test.TestCase):
         grad_0 = tf.constant(grad_val_0)
         grad_1 = tf.constant(grad_val_1)    
         grads_and_vars = zip([grad_0, grad_1], [var_0, var_1])
+       
         if not tf.executing_eagerly():
             update = optimizer.apply_gradients(grads_and_vars)
             self.evaluate(tf.compat.v1.global_variables_initializer())
@@ -55,6 +56,8 @@ class SWATest(tf.test.TestCase):
         else:
             optimizer.apply_gradients(grads_and_vars)
             optimizer.apply_gradients(grads_and_vars)
+        self.assertAllClose(var_0, [0.8, 0.8])
+        self.assertAllClose(var_1, [1.8, 1.8])
         optimizer.assign_average_vars([var_0, var_1])
         
         # self.assertEqual(True, False, msg='{} | {}'.format(var_0, expected_var_0))

--- a/tensorflow_addons/optimizers/stochastic_weight_averaging_test.py
+++ b/tensorflow_addons/optimizers/stochastic_weight_averaging_test.py
@@ -36,14 +36,15 @@ class SWATest(tf.test.TestCase):
             for average_period in [1, 2]:
                 optimizer = SWA('adam', start_averaging, average_period)
                 
-                val_0 = [1., 1.]
-                val_1 = [2., 2.]
+                val_0 = np.array([1., 1.])
+                val_1 = np.array([2., 2.])
                 
                 var_0 = tf.Variable(val_0)
                 var_1 = tf.Variable(val_1)
                 
-                grad_val_0 = [0.1, 0.1]
-                grad_val_1 = [0.1, 0.1]
+                grad_val_0 = np.array([0.1, 0.1])
+                grad_val_1 = np.array([0.1, 0.1])
+                
                 grad_0 = tf.constant(grad_val_0)
                 grad_1 = tf.constant(grad_val_1)
                 

--- a/tensorflow_addons/optimizers/stochastic_weight_averaging_test.py
+++ b/tensorflow_addons/optimizers/stochastic_weight_averaging_test.py
@@ -45,9 +45,16 @@ class SWATest(tf.test.TestCase):
         grad_val_1 = [0.1, 0.1]
         grad_0 = tf.constant(grad_val_0)
         grad_1 = tf.constant(grad_val_1)    
-                
-        optimizer.apply_gradients(zip([grad_0, grad_1], [var_0, var_1]))
-        optimizer.apply_gradients(zip([grad_0, grad_1], [var_0, var_1]))
+        grads_and_vars = zip([grad_0, grad_1], [var_0, var_1])
+        if not tf.executing_eagerly():
+            update = optimizer.apply_gradients(grads_and_vars)
+            self.evaluate(tf.compat.v1.global_variables_initializer())
+            self.evaluate(update)
+            self.evaluate(update)
+        else:
+            optimizer.apply_gradients(grads_and_vars)
+            optimizer.apply_gradients(grads_and_vars)
+       
 
         optimizer.assign_average_vars([var_0, var_1])
         expected_var_0 = tf.constant([0.85, 0.85])

--- a/tensorflow_addons/optimizers/stochastic_weight_averaging_test.py
+++ b/tensorflow_addons/optimizers/stochastic_weight_averaging_test.py
@@ -54,10 +54,14 @@ class SWATest(tf.test.TestCase):
             self.evaluate(update)
             self.evaluate(update)
             self.evaluate(update)
+            update = optimizer.assign_average_vars([var_0, var_1])
+            self.evaluate(update)
         else:
             optimizer.apply_gradients(grads_and_vars)
             optimizer.apply_gradients(grads_and_vars)
             optimizer.apply_gradients(grads_and_vars)
+            optimizer.assign_average_vars([var_0, var_1])
+            
         self.assertAllClose(var_1.read_value(), [1.7, 1.7])
         self.assertAllClose(var_0.read_value(), [0.7, 0.7])
         

--- a/tensorflow_addons/optimizers/stochastic_weight_averaging_test.py
+++ b/tensorflow_addons/optimizers/stochastic_weight_averaging_test.py
@@ -54,22 +54,25 @@ class SWATest(tf.test.TestCase):
             self.evaluate(update)
             self.evaluate(update)
             self.evaluate(update)
-            update = optimizer.assign_average_vars([var_0, var_1])
-            self.evaluate(update)
+            
         else:
             optimizer.apply_gradients(grads_and_vars)
             optimizer.apply_gradients(grads_and_vars)
             optimizer.apply_gradients(grads_and_vars)
-            optimizer.assign_average_vars([var_0, var_1])
+            
             
         self.assertAllClose(var_1.read_value(), [1.7, 1.7])
         self.assertAllClose(var_0.read_value(), [0.7, 0.7])
         
-        optimizer.assign_average_vars([var_0, var_1])
+        if not tf.executing_eagerly():
+            update = optimizer.assign_average_vars([var_0, var_1])
+            self.evaluate(update)
+        else:
+            optimizer.assign_average_vars([var_0, var_1])
         
         # self.assertEqual(True, False, msg='{} | {}'.format(var_0, expected_var_0))
-        self.assertAllClose(var_0.read_value(), [0.85, 0.85], msg='{}'.format(var_0.read_value()))
-        self.assertAllClose(var_1.read_value(), [1.85, 1.85])
+        self.assertAllClose(var_0.read_value(), [0.8, 0.8])
+        self.assertAllClose(var_1.read_value(), [1.8, 1.8])
 
     def test_fit_simple_linear_model(self):
         np.random.seed(0x2019)

--- a/tensorflow_addons/optimizers/stochastic_weight_averaging_test.py
+++ b/tensorflow_addons/optimizers/stochastic_weight_averaging_test.py
@@ -32,42 +32,26 @@ class SWATest(tf.test.TestCase):
 
     def test_averaging(self):
         
-        for start_averaging in [0, 1]:
-            for average_period in [1, 2]:
-                optimizer = SWA('adam', start_averaging, average_period)
+        start_averaging = 0
+        average_period = 1
+        optimizer = SWA('adam', start_averaging, average_period)
+              
+        val_0 = [1., 1.]
+        val_1 = [2., 2.]
+        var_0 = tf.Variable(val_0)
+        var_1 = tf.Variable(val_1)
+
+        grad_val_0 = [0.1, 0.1]
+        grad_val_1 = [0.1, 0.1]
+        grad_0 = tf.constant(grad_val_0)
+        grad_1 = tf.constant(grad_val_1)    
                 
-                val_0 = np.array([1., 1.])
-                val_1 = np.array([2., 2.])
-                
-                var_0 = tf.Variable(val_0)
-                var_1 = tf.Variable(val_1)
-                
-                grad_val_0 = np.array([0.1, 0.1])
-                grad_val_1 = np.array([0.1, 0.1])
-                
-                grad_0 = tf.constant(grad_val_0)
-                grad_1 = tf.constant(grad_val_1)
-                
-                for _ in range(start_averaging + 1):
-                    optimizer.apply_gradients(zip([grad_0, grad_1], [var_0, var_1]))
-                    
-                first_val_0 = val_0 - (grad_val_0 * (start_averaging + 1))
-                first_val_1 = val_1 - (grad_val_1 * (start_averaging + 1))
-                
-                for _ in range(average_period):
-                    optimizer.apply_gradients(zip([grad_0, grad_1], [var_0, var_1]))
-                
-                second_val_0 = first_val_0 - (grad_val_0 * average_period)
-                second_val_1 = first_val_1 - (grad_val_1 * average_period)
-                
-                optimizer.assign_average_vars([var_0, var_1])
-                
-                expected_val = [
-                    (first_val_0 + second_val_0) / 2.0,
-                    (first_val_1 + second_val_1) / 2.0
-                ]
-                msg = '{} | {}'.format([var_0, var_1], expected_val)
-                self.assertAllClose(expected_val, [var_0, var_1], msg=msg)
+        optimizer.apply_gradients(zip([grad_0, grad_1], [var_0, var_1]))
+        optimizer.apply_gradients(zip([grad_0, grad_1], [var_0, var_1]))
+
+        optimizer.assign_average_vars([var_0, var_1])
+        self.assertAllClose(var_0, [0.85, 0.85])
+        self.assertAllClose(var_1, [1.85, 1.85])
 
     def test_fit_simple_linear_model(self):
         np.random.seed(0x2019)

--- a/tensorflow_addons/optimizers/stochastic_weight_averaging_test.py
+++ b/tensorflow_addons/optimizers/stochastic_weight_averaging_test.py
@@ -22,9 +22,10 @@ from __future__ import print_function
 import numpy as np
 import tensorflow as tf
 
-from tensorflow_addons.optimizers import SWA
+from tensorflow_addons.optimizers import stochastic_weight_averaging
 from tensorflow_addons.utils import test_utils
 
+SWA = stochastic_weight_averaging.SWA
 
 @test_utils.run_all_in_graph_and_eager_modes
 class SWATest(tf.test.TestCase):

--- a/tensorflow_addons/optimizers/stochastic_weight_averaging_test.py
+++ b/tensorflow_addons/optimizers/stochastic_weight_averaging_test.py
@@ -72,6 +72,7 @@ class SWATest(tf.test.TestCase):
         self.assertAllClose(var_1.read_value(), [1.8, 1.8])
 
     def test_fit_simple_linear_model(self):
+        
         seed = 0x2019
         np.random.seed(seed)
         tf.random.set_seed(seed)

--- a/tensorflow_addons/optimizers/stochastic_weight_averaging_test.py
+++ b/tensorflow_addons/optimizers/stochastic_weight_averaging_test.py
@@ -105,7 +105,7 @@ class SWATest(tf.test.TestCase):
     def test_get_config(self):
         opt = SWAOptimizer('adam', average_period=10, start_averaging=0)
         opt = tf.keras.optimizers.deserialize(
-                tf.keras.optimizers.serialize(opt))
+            tf.keras.optimizers.serialize(opt))
         config = opt.get_config()
         self.assertEqual(config['average_period'], 10)
         self.assertEqual(config['start_averaging'], 0)

--- a/tensorflow_addons/optimizers/stochastic_weight_averaging_test.py
+++ b/tensorflow_addons/optimizers/stochastic_weight_averaging_test.py
@@ -50,7 +50,7 @@ class SWATest(tf.test.TestCase):
         optimizer.apply_gradients(zip([grad_0, grad_1], [var_0, var_1]))
 
         optimizer.assign_average_vars([var_0, var_1])
-        self.assertAllClose(var_0, [0.85, 0.85])
+        self.assertAllClose(var_0, [0.85, 0.85], msg='{}'.format(var_0))
         self.assertAllClose(var_1, [1.85, 1.85])
 
     def test_fit_simple_linear_model(self):

--- a/tensorflow_addons/optimizers/stochastic_weight_averaging_test.py
+++ b/tensorflow_addons/optimizers/stochastic_weight_averaging_test.py
@@ -53,8 +53,8 @@ class SWATest(tf.test.TestCase):
             for _ in range(iterations):
                 self.evaluate(update)
 
-        return [val_0, val_1], [grad_0, grad_1], [self.evaluate(var_0),
-                                                  self.evaluate(var_1)]
+        return [val_0, val_1], [grad_0, grad_1], [tf.Variable(self.evaluate(var_0)),
+                                                  tf.Variable(self.evaluate(var_1))]
 
     def test_averaging(self):
         for start_averaging in [0]:

--- a/tensorflow_addons/optimizers/stochastic_weight_averaging_test.py
+++ b/tensorflow_addons/optimizers/stochastic_weight_averaging_test.py
@@ -59,7 +59,7 @@ class SWATest(tf.test.TestCase):
     def test_averaging(self):
         for start_averaging in [0, 1, 2]:
             for average_period in [5, 10, 100]:
-                optimizer = SWA('adam', average_period, start_averaging)
+                optimizer = SWA('adam', start_averagin, average_period)
                 initial_vals, grads, final_vals = self.run_dense_sample(
                     start_averaging + average_period + 1, optimizer)
                 first_vals = [
@@ -82,8 +82,8 @@ class SWATest(tf.test.TestCase):
         model.add(tf.keras.layers.Dense(input_shape=(3,), units=1))
         # using num_examples - 1 since steps starts from 0.
         optimizer = SWA('adam',
-                                 start_averaging=num_examples - 1,
-                                 average_period=100)
+                        start_averaging=num_examples - 1,
+                        average_period=100)
         model.compile(optimizer, loss='mse')
         model.fit(x, y, epochs=3)
         optimizer.assign_average_vars(model.variables)

--- a/tensorflow_addons/optimizers/stochastic_weight_averaging_test.py
+++ b/tensorflow_addons/optimizers/stochastic_weight_averaging_test.py
@@ -72,7 +72,7 @@ class SWATest(tf.test.TestCase):
         self.assertAllClose(var_1.read_value(), [1.8, 1.8])
 
     def test_fit_simple_linear_model(self):
-        
+
         seed = 0x2019
         np.random.seed(seed)
         tf.random.set_seed(seed)

--- a/tensorflow_addons/optimizers/stochastic_weight_averaging_test.py
+++ b/tensorflow_addons/optimizers/stochastic_weight_averaging_test.py
@@ -51,8 +51,11 @@ class SWATest(tf.test.TestCase):
 
         optimizer.assign_average_vars([var_0, var_1])
         expected_var_0 = tf.constant([0.85, 0.85])
-        self.assertEqual(True, False, msg='{} | {}'.format(var_0, expected_var_0))
-        self.assertAllClose(var_0, tf.constant([0.85, 0.85]), msg='{}'.format(var_0))
+        
+        var_0 = self.evaluate(var_0)
+        var_1 = self.evaluate(var_1)
+        # self.assertEqual(True, False, msg='{} | {}'.format(var_0, expected_var_0))
+        self.assertAllClose(var_0, expected_var_0, msg='{}'.format(var_0))
         self.assertAllClose(var_1, [1.85, 1.85])
 
     def test_fit_simple_linear_model(self):

--- a/tensorflow_addons/optimizers/stochastic_weight_averaging_test.py
+++ b/tensorflow_addons/optimizers/stochastic_weight_averaging_test.py
@@ -22,7 +22,7 @@ from __future__ import print_function
 import numpy as np
 import tensorflow as tf
 
-from tensorflow_addons.optimizers import SWAOptimizer
+from tensorflow_addons.optimizers import SWA
 from tensorflow_addons.utils import test_utils
 
 
@@ -58,7 +58,7 @@ class SWATest(tf.test.TestCase):
     def test_averaging(self):
         for start_averaging in [0, 1, 2]:
             for average_period in [5, 10, 100]:
-                optimizer = SWAOptimizer('adam', average_period, start_averaging)
+                optimizer = SWA('adam', average_period, start_averaging)
                 initial_vals, grads, final_vals = self.run_dense_sample(
                     start_averaging + average_period + 1, optimizer)
                 first_vals = [
@@ -80,7 +80,7 @@ class SWATest(tf.test.TestCase):
         model = tf.keras.models.Sequential()
         model.add(tf.keras.layers.Dense(input_shape=(3,), units=1))
         # using num_examples - 1 since steps starts from 0.
-        optimizer = SWAOptimizer('adam',
+        optimizer = SWA('adam',
                                  start_averaging=num_examples - 1,
                                  average_period=100)
         model.compile(optimizer, loss='mse')
@@ -97,13 +97,13 @@ class SWATest(tf.test.TestCase):
 
     def test_optimizer_failure(self):
         with self.assertRaises(TypeError):
-            _ = SWAOptimizer(None, average_period=10)
+            _ = SWA(None, average_period=10)
 
     def test_optimizer_string(self):
-        _ = SWAOptimizer('adam', average_period=10)
+        _ = SWA('adam', average_period=10)
 
     def test_get_config(self):
-        opt = SWAOptimizer('adam', average_period=10, start_averaging=0)
+        opt = SWA('adam', average_period=10, start_averaging=0)
         opt = tf.keras.optimizers.deserialize(
             tf.keras.optimizers.serialize(opt))
         config = opt.get_config()

--- a/tensorflow_addons/optimizers/stochastic_weight_averaging_test.py
+++ b/tensorflow_addons/optimizers/stochastic_weight_averaging_test.py
@@ -85,7 +85,7 @@ class SWATest(tf.test.TestCase):
         optimizer = SWA(
             'adam', start_averaging=num_examples // 32 - 1, average_period=100)
         model.compile(optimizer, loss='mse')
-        model.fit(x, y, epochs=3)
+        model.fit(x, y, epochs=10)
         optimizer.assign_average_vars(model.variables)
 
         x = np.random.standard_normal((100, 3))
@@ -94,7 +94,7 @@ class SWATest(tf.test.TestCase):
         predicted = model.predict(x)
 
         max_abs_diff = np.max(np.abs(predicted - y))
-        self.assertLess(max_abs_diff, 1e-4)
+        self.assertLess(max_abs_diff, 2e-4)
 
     def test_optimizer_failure(self):
         with self.assertRaises(TypeError):

--- a/tensorflow_addons/optimizers/stochastic_weight_averaging_test.py
+++ b/tensorflow_addons/optimizers/stochastic_weight_averaging_test.py
@@ -42,22 +42,25 @@ class SWATest(tf.test.TestCase):
                 var_0 = tf.Variable(val_0)
                 var_1 = tf.Variable(val_1)
                 
-                grad_0 = tf.constant([0.1, 0.1])
-                grad_1 = tf.constant([0.1, 0.1])
+                grad_val_0 = [0.1, 0.1]
+                grad_val_1 = [0.1, 0.1]
+                grad_0 = tf.constant(grad_val_0)
+                grad_1 = tf.constant(grad_val_1)
                 
                 for _ in range(start_averaging + 1):
                     optimizer.apply_gradients(zip([grad_0, grad_1], [var_0, var_1]))
                     
-                first_val_0 = tf.identity(var_0)
-                first_val_1 = tf.identity(var_1)
+                first_val_0 = val_0 - (grad_val_0 * (start_averaging + 1))
+                first_val_1 = val_1 - (grad_val_1 * (start_averaging + 1))
                 
-                for _ in range(average_period + 1):
+                for _ in range(average_period):
                     optimizer.apply_gradients(zip([grad_0, grad_1], [var_0, var_1]))
                 
-                second_val_0 = tf.identity(var_0)
-                second_val_1 = tf.identity(var_1)
+                second_val_0 = first_val_0 - (grad_val_0 * average_period)
+                second_val_1 = first_val_1 - (grad_val_1 * average_period)
                 
                 optimizer.assign_average_vars([var_0, var_1])
+                
                 expected_val = [
                     (first_val_0 + second_val_0) / 2.0,
                     (first_val_1 + second_val_1) / 2.0

--- a/tensorflow_addons/optimizers/stochastic_weight_averaging_test.py
+++ b/tensorflow_addons/optimizers/stochastic_weight_averaging_test.py
@@ -30,47 +30,40 @@ SWA = stochastic_weight_averaging.SWA
 @test_utils.run_all_in_graph_and_eager_modes
 class SWATest(tf.test.TestCase):
 
-    def run_sample(self, iterations, optimizer, seed=0x2019):
-        np.random.seed(seed)
-
-        val_0 = np.random.random((2,))
-        val_1 = np.random.random((2,))
-
-        var_0 = tf.Variable(val_0, dtype=tf.dtypes.float32)
-        var_1 = tf.Variable(val_1, dtype=tf.dtypes.float32)
-
-        grad_0 = tf.constant([0.1, 0.1])
-        grad_1 = tf.constant([0.01, 0.01])
-
-        grads_and_vars = list(zip([grad_0, grad_1], [var_0, var_1]))
-
-        if tf.executing_eagerly():
-            for _ in range(iterations):
-                optimizer.apply_gradients(grads_and_vars)
-        else:
-            update = optimizer.apply_gradients(grads_and_vars)
-            self.evaluate(tf.compat.v1.global_variables_initializer())
-            for _ in range(iterations):
-                self.evaluate(update)
-
-        return [val_0, val_1], [grad_0, grad_1], [self.evaluate(var_0),
-                                                  self.evaluate(var_1)]
-
     def test_averaging(self):
-        for start_averaging in [0]:
-            for average_period in [5, 10, 100]:
+        
+        for start_averaging in [0, 1]:
+            for average_period in [1, 2]:
                 optimizer = SWA('adam', start_averaging, average_period)
-                initial_vals, grads, final_vals = self.run_sample(
-                    start_averaging + average_period + 1, 
-                    optimizer
-                )
-                first_vals = [
-                    initial_vals[0] - (start_averaging + 1) * grads[0],
-                    initial_vals[1] - (start_averaging + 1) * grads[1]
+                
+                val_0 = [1, 1]
+                val_1 = [2, 2]
+                
+                var_0 = tf.Variable(val_0)
+                var_1 = tf.Variable(val_1)
+                
+                grad_0 = tf.constant([0.1, 0.1])
+                grad_1 = tf.constant([0.1, 0.1])
+                
+                for _ in range(start_averaging + 1):
+                    optimizer.apply_gradients(zip([grad_0, grad_1], [var_0, var_1]))
+                    
+                first_val_0 = tf.identity(var_0)
+                first_val_1 = tf.identity(var_1)
+                
+                for _ in range(average_period + 1):
+                    optimizer.apply_gradients(zip([grad_0, grad_1], [var_0, var_1]))
+                
+                second_val_0 = tf.identity(var_0)
+                second_val_1 = tf.identity(var_1)
+                
+                optimizer.assign_average_vars([var_0, var_1])
+                expected_val = [
+                    (first_val_0 + second_val_0) / 2.0,
+                    (first_val_1 + second_val_1) / 2.0
                 ]
-                average_vals = [tf.Variable((first_vals[0] + final_vals[0]) / 2.0),
-                                tf.Variable((first_vals[1] + final_vals[1]) / 2.0)]
-                msg = '{}'.format(final_vals)
+                msg = '{} | {}'.format([var_0, var_1], expected_val)
+                
                 try:
                     optimizer.assign_average_vars(final_vals)
                 except:

--- a/tensorflow_addons/optimizers/stochastic_weight_averaging_test.py
+++ b/tensorflow_addons/optimizers/stochastic_weight_averaging_test.py
@@ -34,8 +34,8 @@ class SWATest(tf.test.TestCase):
         
         start_averaging = 0
         average_period = 1
-        adam = tf.keras.optimizers.Adam(learning_rate=1.)
-        optimizer = SWA(adam, start_averaging, average_period)
+        sgd = tf.keras.optimizers.SGD(lr=1.)
+        optimizer = SWA(sgd, start_averaging, average_period)
               
         val_0 = [1., 1.]
         val_1 = [2., 2.]
@@ -56,8 +56,9 @@ class SWATest(tf.test.TestCase):
         else:
             optimizer.apply_gradients(grads_and_vars)
             optimizer.apply_gradients(grads_and_vars)
-        self.assertAllClose(var_0.read_value(), [0.8, 0.8])
         self.assertAllClose(var_1.read_value(), [1.8, 1.8])
+        self.assertAllClose(var_0.read_value(), [0.8, 0.8])
+        
         optimizer.assign_average_vars([var_0, var_1])
         
         # self.assertEqual(True, False, msg='{} | {}'.format(var_0, expected_var_0))

--- a/tensorflow_addons/optimizers/stochastic_weight_averaging_test.py
+++ b/tensorflow_addons/optimizers/stochastic_weight_averaging_test.py
@@ -66,8 +66,8 @@ class SWATest(tf.test.TestCase):
                     initial_vals[0] - (start_averaging + 1) * grads[0],
                     initial_vals[1] - (start_averaging + 1) * grads[1]
                 ]
-                average_vals = [(first_vals[0] + final_vals[0]) / 2.0,
-                                (first_vals[1] + final_vals[1]) / 2.0]
+                average_vals = [tf.Variable((first_vals[0] + final_vals[0]) / 2.0),
+                                tf.Variable((first_vals[1] + final_vals[1]) / 2.0)]
                 optimizer.assign_average_vars(final_vals)
                 self.assertAllClose(average_vals, final_vals)
 
@@ -86,7 +86,7 @@ class SWATest(tf.test.TestCase):
                         average_period=100)
         model.compile(optimizer, loss='mse')
         model.fit(x, y, epochs=3)
-        optimizer.assign_average_vars(model.variables)
+        # optimizer.assign_average_vars(model.variables)
       
         x = np.random.standard_normal((100, 3))
         y = np.dot(x, w)

--- a/tensorflow_addons/optimizers/stochastic_weight_averaging_test.py
+++ b/tensorflow_addons/optimizers/stochastic_weight_averaging_test.py
@@ -34,7 +34,8 @@ class SWATest(tf.test.TestCase):
         
         start_averaging = 0
         average_period = 1
-        optimizer = SWA('adam', start_averaging, average_period)
+        adam = tf.keras.optimizers.Adam(learning_rate=1)
+        optimizer = SWA(adam, start_averaging, average_period)
               
         val_0 = [1., 1.]
         val_1 = [2., 2.]

--- a/tensorflow_addons/optimizers/stochastic_weight_averaging_test.py
+++ b/tensorflow_addons/optimizers/stochastic_weight_averaging_test.py
@@ -57,11 +57,13 @@ class SWATest(tf.test.TestCase):
                                                   self.evaluate(var_1)]
 
     def test_averaging(self):
-        for start_averaging in [0, 1, 2]:
+        for start_averaging in [0]:
             for average_period in [5, 10, 100]:
                 optimizer = SWA('adam', start_averaging, average_period)
                 initial_vals, grads, final_vals = self.run_sample(
-                    start_averaging + average_period + 1, optimizer)
+                    start_averaging + average_period + 1, 
+                    optimizer
+                )
                 first_vals = [
                     initial_vals[0] - (start_averaging + 1) * grads[0],
                     initial_vals[1] - (start_averaging + 1) * grads[1]
@@ -69,7 +71,8 @@ class SWATest(tf.test.TestCase):
                 average_vals = [tf.Variable((first_vals[0] + final_vals[0]) / 2.0),
                                 tf.Variable((first_vals[1] + final_vals[1]) / 2.0)]
                 optimizer.assign_average_vars(final_vals)
-                self.assertAllClose(average_vals, final_vals)
+                msg = '{}'.format(final_vals)
+                self.assertAllClose(average_vals, final_vals, msg=msg)
 
     def test_fit_simple_linear_model(self):
         np.random.seed(0x2019)

--- a/tensorflow_addons/optimizers/stochastic_weight_averaging_test.py
+++ b/tensorflow_addons/optimizers/stochastic_weight_averaging_test.py
@@ -53,8 +53,8 @@ class SWATest(tf.test.TestCase):
             for _ in range(iterations):
                 self.evaluate(update)
 
-        return [val_0, val_1], [grad_0, grad_1], [tf.Variable(self.evaluate(var_0)),
-                                                  tf.Variable(self.evaluate(var_1))]
+        return [val_0, val_1], [grad_0, grad_1], [self.evaluate(var_0)),
+                                                  self.evaluate(var_1)]
 
     def test_averaging(self):
         for start_averaging in [0]:
@@ -70,8 +70,12 @@ class SWATest(tf.test.TestCase):
                 ]
                 average_vals = [tf.Variable((first_vals[0] + final_vals[0]) / 2.0),
                                 tf.Variable((first_vals[1] + final_vals[1]) / 2.0)]
-                optimizer.assign_average_vars(final_vals)
                 msg = '{}'.format(final_vals)
+                try:
+                    optimizer.assign_average_vars(final_vals)
+                except:
+                    self.assertEqual(True, False, msg=msg)
+                
                 self.assertAllClose(average_vals, final_vals, msg=msg)
 
     def test_fit_simple_linear_model(self):

--- a/tensorflow_addons/optimizers/stochastic_weight_averaging_test.py
+++ b/tensorflow_addons/optimizers/stochastic_weight_averaging_test.py
@@ -59,7 +59,7 @@ class SWATest(tf.test.TestCase):
     def test_averaging(self):
         for start_averaging in [0, 1, 2]:
             for average_period in [5, 10, 100]:
-                optimizer = SWA('adam', start_averagin, average_period)
+                optimizer = SWA('adam', start_averaging, average_period)
                 initial_vals, grads, final_vals = self.run_dense_sample(
                     start_averaging + average_period + 1, optimizer)
                 first_vals = [

--- a/tensorflow_addons/optimizers/stochastic_weight_averaging_test.py
+++ b/tensorflow_addons/optimizers/stochastic_weight_averaging_test.py
@@ -63,13 +63,7 @@ class SWATest(tf.test.TestCase):
                     (first_val_1 + second_val_1) / 2.0
                 ]
                 msg = '{} | {}'.format([var_0, var_1], expected_val)
-                
-                try:
-                    optimizer.assign_average_vars(final_vals)
-                except:
-                    self.assertEqual(True, False, msg=msg)
-                
-                self.assertAllClose(average_vals, final_vals, msg=msg)
+                self.assertAllClose(expected_val, [var_0, var_1], msg=msg)
 
     def test_fit_simple_linear_model(self):
         np.random.seed(0x2019)

--- a/tensorflow_addons/optimizers/stochastic_weight_averaging_test.py
+++ b/tensorflow_addons/optimizers/stochastic_weight_averaging_test.py
@@ -1,4 +1,3 @@
-
 # Copyright 2019 The TensorFlow Authors. All Rights Reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -27,16 +26,16 @@ from tensorflow_addons.utils import test_utils
 
 SWA = stochastic_weight_averaging.SWA
 
+
 @test_utils.run_all_in_graph_and_eager_modes
 class SWATest(tf.test.TestCase):
-
     def test_averaging(self):
-        
+
         start_averaging = 0
         average_period = 1
         sgd = tf.keras.optimizers.SGD(lr=1.)
         optimizer = SWA(sgd, start_averaging, average_period)
-              
+
         val_0 = [1., 1.]
         val_1 = [2., 2.]
         var_0 = tf.Variable(val_0)
@@ -45,31 +44,30 @@ class SWATest(tf.test.TestCase):
         grad_val_0 = [0.1, 0.1]
         grad_val_1 = [0.1, 0.1]
         grad_0 = tf.constant(grad_val_0)
-        grad_1 = tf.constant(grad_val_1)    
+        grad_1 = tf.constant(grad_val_1)
         grads_and_vars = list(zip([grad_0, grad_1], [var_0, var_1]))
-       
+
         if not tf.executing_eagerly():
             update = optimizer.apply_gradients(grads_and_vars)
             self.evaluate(tf.compat.v1.global_variables_initializer())
             self.evaluate(update)
             self.evaluate(update)
             self.evaluate(update)
-            
+
         else:
             optimizer.apply_gradients(grads_and_vars)
             optimizer.apply_gradients(grads_and_vars)
             optimizer.apply_gradients(grads_and_vars)
-            
-            
+
         self.assertAllClose(var_1.read_value(), [1.7, 1.7])
         self.assertAllClose(var_0.read_value(), [0.7, 0.7])
-        
+
         if not tf.executing_eagerly():
             update = optimizer.assign_average_vars([var_0, var_1])
             self.evaluate(update)
         else:
             optimizer.assign_average_vars([var_0, var_1])
-        
+
         # self.assertEqual(True, False, msg='{} | {}'.format(var_0, expected_var_0))
         self.assertAllClose(var_0.read_value(), [0.8, 0.8])
         self.assertAllClose(var_1.read_value(), [1.8, 1.8])
@@ -84,13 +82,12 @@ class SWATest(tf.test.TestCase):
         model = tf.keras.models.Sequential()
         model.add(tf.keras.layers.Dense(input_shape=(3,), units=1))
         # using num_examples - 1 since steps starts from 0.
-        optimizer = SWA('adam',
-                        start_averaging=num_examples // 32 - 1,
-                        average_period=100)
+        optimizer = SWA(
+            'adam', start_averaging=num_examples // 32 - 1, average_period=100)
         model.compile(optimizer, loss='mse')
         model.fit(x, y, epochs=3)
         optimizer.assign_average_vars(model.variables)
-      
+
         x = np.random.standard_normal((100, 3))
         y = np.dot(x, w)
 

--- a/tensorflow_addons/optimizers/stochastic_weight_averaging_test.py
+++ b/tensorflow_addons/optimizers/stochastic_weight_averaging_test.py
@@ -82,11 +82,11 @@ class SWATest(tf.test.TestCase):
         model.add(tf.keras.layers.Dense(input_shape=(3,), units=1))
         # using num_examples - 1 since steps starts from 0.
         optimizer = SWA('adam',
-                        start_averaging=num_examples - 1,
+                        start_averaging=num_examples // 32 - 1,
                         average_period=100)
         model.compile(optimizer, loss='mse')
         model.fit(x, y, epochs=3)
-        # optimizer.assign_average_vars(model.variables)
+        optimizer.assign_average_vars(model.variables)
       
         x = np.random.standard_normal((100, 3))
         y = np.dot(x, w)

--- a/tensorflow_addons/optimizers/stochastic_weight_averaging_test.py
+++ b/tensorflow_addons/optimizers/stochastic_weight_averaging_test.py
@@ -75,7 +75,6 @@ class SWATest(tf.test.TestCase):
         seed = 0x2019
         np.random.seed(seed)
         tf.random.set_seed(seed)
-        
         num_examples = 100000
         x = np.random.standard_normal((num_examples, 3))
         w = np.random.standard_normal((3, 1))

--- a/tensorflow_addons/optimizers/stochastic_weight_averaging_test.py
+++ b/tensorflow_addons/optimizers/stochastic_weight_averaging_test.py
@@ -46,7 +46,7 @@ class SWATest(tf.test.TestCase):
         grad_val_1 = [0.1, 0.1]
         grad_0 = tf.constant(grad_val_0)
         grad_1 = tf.constant(grad_val_1)    
-        grads_and_vars = zip([grad_0, grad_1], [var_0, var_1])
+        grads_and_vars = list(zip([grad_0, grad_1], [var_0, var_1]))
        
         if not tf.executing_eagerly():
             update = optimizer.apply_gradients(grads_and_vars)

--- a/tensorflow_addons/optimizers/stochastic_weight_averaging_test.py
+++ b/tensorflow_addons/optimizers/stochastic_weight_averaging_test.py
@@ -54,16 +54,11 @@ class SWATest(tf.test.TestCase):
         else:
             optimizer.apply_gradients(grads_and_vars)
             optimizer.apply_gradients(grads_and_vars)
-       
-
         optimizer.assign_average_vars([var_0, var_1])
-        expected_var_0 = tf.constant([0.85, 0.85])
         
-        var_0 = self.evaluate(var_0)
-        var_1 = self.evaluate(var_1)
         # self.assertEqual(True, False, msg='{} | {}'.format(var_0, expected_var_0))
-        self.assertAllClose(var_0, expected_var_0, msg='{}'.format(var_0))
-        self.assertAllClose(var_1, [1.85, 1.85])
+        self.assertAllClose(var_0.read_value(), [0.85, 0.85], msg='{}'.format(var_0.read_value()))
+        self.assertAllClose(var_1.read_value(), [1.85, 1.85])
 
     def test_fit_simple_linear_model(self):
         np.random.seed(0x2019)

--- a/tensorflow_addons/optimizers/weight_decay_optimizers_test.py
+++ b/tensorflow_addons/optimizers/weight_decay_optimizers_test.py
@@ -4,7 +4,7 @@
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     http://www.apache.org/licenses/LICENSE-2.0
+#         http://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 # ==============================================================================
-"""Tests for optimizers with weight decay."""
+"""Tests for Stochastic Weight Averaging optimizer."""
 
 from __future__ import absolute_import
 from __future__ import division
@@ -21,264 +21,97 @@ from __future__ import print_function
 import numpy as np
 import tensorflow as tf
 
+from tensorflow_addons.optimizers import stochastic_weight_averaging
 from tensorflow_addons.utils import test_utils
-from tensorflow_addons.optimizers import weight_decay_optimizers
 
-WEIGHT_DECAY = 0.01
+SWA = stochastic_weight_averaging.SWA
 
 
-class OptimizerTestBase(tf.test.TestCase):
-    """Base class for optimizer tests.
+@test_utils.run_all_in_graph_and_eager_modes
+class SWATest(tf.test.TestCase):
+    def test_averaging(self):
 
-    Optimizer tests may inherit from this class and define test
-    functions using doTest. Usually this should include the functions
-    testSparse, testBasic, and testBasicCallableParams. See
-    weight_decay_optimizers_test for an example.
-    """
+        start_averaging = 0
+        average_period = 1
+        sgd = tf.keras.optimizers.SGD(lr=1.)
+        optimizer = SWA(sgd, start_averaging, average_period)
 
-    def doTest(self, optimizer, update_fn, do_sparse=False,
-               **optimizer_kwargs):
-        """The major test function.
+        val_0 = [1., 1.]
+        val_1 = [2., 2.]
+        var_0 = tf.Variable(val_0)
+        var_1 = tf.Variable(val_1)
 
-        Args:
-            optimizer: The tensorflow optimizer class to be tested.
-            update_fn: The numpy update function of the optimizer, the function
-                signature must be
-                update_fn(var: np.array,
-                          grad_t: np.array,
-                          slot_vars: dict,
-                          **kwargs) -> (updated_var, updated_slot_vars)
-                Note that slot_vars will be initialized to an empty dictionary
-                for each variable, initial values should be handled in the
-                update_fn.
-            do_sparse: If True, test sparse update. Defaults to False, i.e.,
-                dense update.
-            **optimizer_kwargs:The parameters to pass to the construcor of the
-                optimizer. Either a constant or a callable. This also passed to
-                the optimizer_params in the update_fn.
-        """
-        # TODO: Fix #347 issue
-        if do_sparse and tf.test.is_gpu_available():
-            self.skipTest('Wait #347 to be fixed')
+        grad_val_0 = [0.1, 0.1]
+        grad_val_1 = [0.1, 0.1]
+        grad_0 = tf.constant(grad_val_0)
+        grad_1 = tf.constant(grad_val_1)
+        grads_and_vars = list(zip([grad_0, grad_1], [var_0, var_1]))
 
-        for i, dtype in enumerate([tf.half, tf.float32, tf.float64]):
-            # Initialize variables for numpy implementation.
-            np_slot_vars0, np_slot_vars1 = {}, {}
-            var0_np = np.array([1.0, 2.0], dtype=dtype.as_numpy_dtype)
-            grads0_np = np.array([0.1, 0.1], dtype=dtype.as_numpy_dtype)
-            var1_np = np.array([3.0, 4.0], dtype=dtype.as_numpy_dtype)
-            grads1_np = np.array([0.01, 0.01], dtype=dtype.as_numpy_dtype)
-            # Create Tensorflow variables.
-            var0 = tf.Variable(var0_np, name="var0_%d" % i)
-            var1 = tf.Variable(var1_np, name="var1_%d" % i)
-            if do_sparse:
-                grads0_np_indices = np.array([0, 1], dtype=np.int32)
-                grads0 = tf.IndexedSlices(
-                    tf.constant(grads0_np), tf.constant(grads0_np_indices),
-                    tf.constant([2]))
-                grads1_np_indices = np.array([0, 1], dtype=np.int32)
-                grads1 = tf.IndexedSlices(
-                    tf.constant(grads1_np), tf.constant(grads1_np_indices),
-                    tf.constant([2]))
-            else:
-                grads0 = tf.constant(grads0_np)
-                grads1 = tf.constant(grads1_np)
-            opt = optimizer(**optimizer_kwargs)
-            # Validate initial values.
-            if not tf.executing_eagerly():
-                update = opt.apply_gradients(
-                    zip([grads0, grads1], [var0, var1]))
-                self.evaluate(tf.compat.v1.global_variables_initializer())
-                self.assertAllClose([1.0, 2.0], self.evaluate(var0))
-                self.assertAllClose([3.0, 4.0], self.evaluate(var1))
-            # Create the update op.
-            # Run 3 steps of the optimizer
-            for _ in range(3):
-                if tf.executing_eagerly():
-                    opt.apply_gradients(zip([grads0, grads1], [var0, var1]))
-                else:
-                    self.evaluate(update)
-                var0_np, np_slot_vars0 = update_fn(
-                    var0_np, grads0_np, np_slot_vars0, **optimizer_kwargs)
-                var1_np, np_slot_vars1 = update_fn(
-                    var1_np, grads1_np, np_slot_vars1, **optimizer_kwargs)
-                # Validate updated params
-                self.assertAllCloseAccordingToType(var0_np,
-                                                   self.evaluate(var0))
-                self.assertAllCloseAccordingToType(var1_np,
-                                                   self.evaluate(var1))
-
-    def doTestSparseRepeatedIndices(self, optimizer, **optimizer_kwargs):
-        """Test for repeated indices in sparse updates.
-
-        This test verifies that an update with repeated indices is the same as
-        an update with two times the gradient.
-
-        Args:
-            optimizer: The tensorflow optimizer class to be tested.
-            **optimizer_kwargs: The parameters to pass to the construcor of the
-                optimizer. Either a constant or a callable. This also passed to
-                the optimizer_params in the update_fn.
-        """
-        # TODO: Fix #347 issue
-        if tf.test.is_gpu_available():
-            self.skipTest('Wait #347 to be fixed')
-
-        for dtype in [tf.dtypes.half, tf.dtypes.float32, tf.dtypes.float64]:
-            repeated_index_update_var = tf.Variable([[1.0], [2.0]],
-                                                    dtype=dtype)
-            aggregated_update_var = tf.Variable([[1.0], [2.0]], dtype=dtype)
-            grad_repeated_index = tf.IndexedSlices(
-                tf.constant([0.1, 0.1], shape=[2, 1], dtype=dtype),
-                tf.constant([1, 1]), tf.constant([2, 1]))
-            grad_aggregated = tf.IndexedSlices(
-                tf.constant([0.2], shape=[1, 1], dtype=dtype),
-                tf.constant([1]), tf.constant([2, 1]))
-            opt_repeated = optimizer(**optimizer_kwargs)
-            repeated_update = opt_repeated.apply_gradients(
-                [(grad_repeated_index, repeated_index_update_var)])
-            opt_aggregated = optimizer(**optimizer_kwargs)
-            aggregated_update = opt_aggregated.apply_gradients(
-                [(grad_aggregated, aggregated_update_var)])
+        if not tf.executing_eagerly():
+            update = optimizer.apply_gradients(grads_and_vars)
             self.evaluate(tf.compat.v1.global_variables_initializer())
-            self.assertAllClose(
-                self.evaluate(aggregated_update_var),
-                self.evaluate(repeated_index_update_var))
-            for _ in range(3):
-                if not tf.executing_eagerly():
-                    self.evaluate(repeated_update)
-                    self.evaluate(aggregated_update)
-                else:
-                    opt_repeated.apply_gradients([(grad_repeated_index,
-                                                   repeated_index_update_var)])
-                    opt_aggregated.apply_gradients([(grad_aggregated,
-                                                     aggregated_update_var)])
-                self.assertAllClose(
-                    self.evaluate(aggregated_update_var),
-                    self.evaluate(repeated_index_update_var))
+            self.evaluate(update)
+            self.evaluate(update)
+            self.evaluate(update)
+
+        else:
+            optimizer.apply_gradients(grads_and_vars)
+            optimizer.apply_gradients(grads_and_vars)
+            optimizer.apply_gradients(grads_and_vars)
+
+        self.assertAllClose(var_1.read_value(), [1.7, 1.7])
+        self.assertAllClose(var_0.read_value(), [0.7, 0.7])
+
+        if not tf.executing_eagerly():
+            update = optimizer.assign_average_vars([var_0, var_1])
+            self.evaluate(update)
+        else:
+            optimizer.assign_average_vars([var_0, var_1])
+
+        # self.assertEqual(True, False, msg='{} | {}'.format(var_0, expected_var_0))
+        self.assertAllClose(var_0.read_value(), [0.8, 0.8])
+        self.assertAllClose(var_1.read_value(), [1.8, 1.8])
+
+    def test_fit_simple_linear_model(self):
+        np.random.seed(0x2019)
+        num_examples = 100000
+        x = np.random.standard_normal((num_examples, 3))
+        w = np.random.standard_normal((3, 1))
+        y = np.dot(x, w) + np.random.standard_normal((num_examples, 1)) * 1e-4
+
+        model = tf.keras.models.Sequential()
+        model.add(tf.keras.layers.Dense(input_shape=(3,), units=1))
+        # using num_examples - 1 since steps starts from 0.
+        optimizer = SWA(
+            'adam', start_averaging=num_examples // 32 - 1, average_period=100)
+        model.compile(optimizer, loss='mse')
+        model.fit(x, y, epochs=3)
+        optimizer.assign_average_vars(model.variables)
+
+        x = np.random.standard_normal((100, 3))
+        y = np.dot(x, w)
+
+        predicted = model.predict(x)
+
+        max_abs_diff = np.max(np.abs(predicted - y))
+        self.assertLess(max_abs_diff, 1e-4)
+
+    def test_optimizer_failure(self):
+        with self.assertRaises(TypeError):
+            _ = SWA(None, average_period=10)
+
+    def test_optimizer_string(self):
+        _ = SWA('adam', average_period=10)
+
+    def test_get_config(self):
+        self.skipTest('Wait #33614 to be fixed')
+        opt = SWA('adam', average_period=10, start_averaging=0)
+        opt = tf.keras.optimizers.deserialize(
+            tf.keras.optimizers.serialize(opt))
+        config = opt.get_config()
+        self.assertEqual(config['average_period'], 10)
+        self.assertEqual(config['start_averaging'], 0)
 
 
-def adamw_update_numpy(param, grad_t, slot_vars, learning_rate, beta_1, beta_2,
-                       epsilon, weight_decay):
-    """Numpy update function for AdamW."""
-    lr, beta1, beta2, eps, wd = (v() if callable(v) else v
-                                 for v in (learning_rate, beta_1, beta_2,
-                                           epsilon, weight_decay))
-    t = slot_vars.get("t", 0) + 1
-    lr_t = lr * np.sqrt(1 - beta2**t) / (1 - beta1**t)
-    slot_vars["m"] = beta1 * slot_vars.get("m", 0) + (1 - beta1) * grad_t
-    slot_vars["v"] = beta2 * slot_vars.get("v", 0) + (1 - beta2) * grad_t**2
-    param_t = (param * (1 - wd) -
-               lr_t * slot_vars["m"] / (np.sqrt(slot_vars["v"]) + eps))
-    slot_vars["t"] = t
-    return param_t, slot_vars
-
-
-def sgdw_update_numpy(param, grad_t, slot_vars, learning_rate, momentum,
-                      weight_decay):
-    """Numpy update function for SGDW."""
-    m = slot_vars.get("m", 0)
-    lr, momentum, wd = (v() if callable(v) else v
-                        for v in (learning_rate, momentum, weight_decay))
-    slot_vars["m"] = momentum * m + grad_t
-    param_t = param * (1 - wd) - lr * slot_vars["m"]
-    return param_t, slot_vars
-
-
-class AdamWTest(OptimizerTestBase):
-
-    optimizer = weight_decay_optimizers.AdamW
-
-    @test_utils.run_in_graph_and_eager_modes(reset_test=True)
-    def testSparse(self):
-        self.doTest(
-            self.optimizer,
-            adamw_update_numpy,
-            do_sparse=True,
-            learning_rate=0.001,
-            beta_1=0.9,
-            beta_2=0.999,
-            epsilon=1e-8,
-            weight_decay=WEIGHT_DECAY)
-
-    @test_utils.run_in_graph_and_eager_modes(reset_test=True)
-    def testSparseRepeatedIndices(self):
-        self.doTestSparseRepeatedIndices(
-            self.optimizer,
-            learning_rate=0.001,
-            beta_1=0.9,
-            beta_2=0.999,
-            epsilon=1e-8,
-            weight_decay=WEIGHT_DECAY)
-
-    @test_utils.run_in_graph_and_eager_modes(reset_test=True)
-    def testBasic(self):
-        self.doTest(
-            self.optimizer,
-            adamw_update_numpy,
-            learning_rate=0.001,
-            beta_1=0.9,
-            beta_2=0.999,
-            epsilon=1e-8,
-            weight_decay=WEIGHT_DECAY)
-
-    def testBasicCallableParams(self):
-        self.doTest(
-            self.optimizer,
-            adamw_update_numpy,
-            learning_rate=lambda: 0.001,
-            beta_1=lambda: 0.9,
-            beta_2=lambda: 0.999,
-            epsilon=1e-8,
-            weight_decay=lambda: WEIGHT_DECAY)
-
-
-class SGDWTest(OptimizerTestBase):
-
-    optimizer = weight_decay_optimizers.SGDW
-
-    @test_utils.run_in_graph_and_eager_modes(reset_test=True)
-    def testSparse(self):
-        self.doTest(
-            self.optimizer,
-            sgdw_update_numpy,
-            do_sparse=True,
-            learning_rate=0.001,
-            momentum=0.9,
-            weight_decay=WEIGHT_DECAY)
-
-    @test_utils.run_in_graph_and_eager_modes(reset_test=True)
-    def testSparseRepeatedIndices(self):
-        self.doTestSparseRepeatedIndices(
-            self.optimizer,
-            learning_rate=0.001,
-            momentum=0.9,
-            weight_decay=WEIGHT_DECAY)
-
-    @test_utils.run_in_graph_and_eager_modes(reset_test=True)
-    def testBasic(self):
-        self.doTest(
-            self.optimizer,
-            sgdw_update_numpy,
-            learning_rate=0.001,
-            momentum=0.9,
-            weight_decay=WEIGHT_DECAY)
-
-    def testBasicCallableParams(self):
-        self.doTest(
-            self.optimizer,
-            sgdw_update_numpy,
-            learning_rate=lambda: 0.001,
-            momentum=lambda: 0.9,
-            weight_decay=lambda: WEIGHT_DECAY)
-
-
-class ExtendWithWeightDecayTest(SGDWTest):
-    """Verify that the factory function SGDW is the same as SGDW."""
-
-    optimizer = weight_decay_optimizers.extend_with_decoupled_weight_decay(
-        tf.keras.optimizers.SGD)
-
-
-if __name__ == "__main__":
+if __name__ == '__main__':
     tf.test.main()

--- a/tensorflow_addons/optimizers/weight_decay_optimizers_test.py
+++ b/tensorflow_addons/optimizers/weight_decay_optimizers_test.py
@@ -4,7 +4,7 @@
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#         http://www.apache.org/licenses/LICENSE-2.0
+#     http://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 # ==============================================================================
-"""Tests for Stochastic Weight Averaging optimizer."""
+"""Tests for optimizers with weight decay."""
 
 from __future__ import absolute_import
 from __future__ import division
@@ -21,97 +21,264 @@ from __future__ import print_function
 import numpy as np
 import tensorflow as tf
 
-from tensorflow_addons.optimizers import stochastic_weight_averaging
 from tensorflow_addons.utils import test_utils
+from tensorflow_addons.optimizers import weight_decay_optimizers
 
-SWA = stochastic_weight_averaging.SWA
+WEIGHT_DECAY = 0.01
 
 
-@test_utils.run_all_in_graph_and_eager_modes
-class SWATest(tf.test.TestCase):
-    def test_averaging(self):
+class OptimizerTestBase(tf.test.TestCase):
+    """Base class for optimizer tests.
 
-        start_averaging = 0
-        average_period = 1
-        sgd = tf.keras.optimizers.SGD(lr=1.)
-        optimizer = SWA(sgd, start_averaging, average_period)
+    Optimizer tests may inherit from this class and define test
+    functions using doTest. Usually this should include the functions
+    testSparse, testBasic, and testBasicCallableParams. See
+    weight_decay_optimizers_test for an example.
+    """
 
-        val_0 = [1., 1.]
-        val_1 = [2., 2.]
-        var_0 = tf.Variable(val_0)
-        var_1 = tf.Variable(val_1)
+    def doTest(self, optimizer, update_fn, do_sparse=False,
+               **optimizer_kwargs):
+        """The major test function.
 
-        grad_val_0 = [0.1, 0.1]
-        grad_val_1 = [0.1, 0.1]
-        grad_0 = tf.constant(grad_val_0)
-        grad_1 = tf.constant(grad_val_1)
-        grads_and_vars = list(zip([grad_0, grad_1], [var_0, var_1]))
+        Args:
+            optimizer: The tensorflow optimizer class to be tested.
+            update_fn: The numpy update function of the optimizer, the function
+                signature must be
+                update_fn(var: np.array,
+                          grad_t: np.array,
+                          slot_vars: dict,
+                          **kwargs) -> (updated_var, updated_slot_vars)
+                Note that slot_vars will be initialized to an empty dictionary
+                for each variable, initial values should be handled in the
+                update_fn.
+            do_sparse: If True, test sparse update. Defaults to False, i.e.,
+                dense update.
+            **optimizer_kwargs:The parameters to pass to the construcor of the
+                optimizer. Either a constant or a callable. This also passed to
+                the optimizer_params in the update_fn.
+        """
+        # TODO: Fix #347 issue
+        if do_sparse and tf.test.is_gpu_available():
+            self.skipTest('Wait #347 to be fixed')
 
-        if not tf.executing_eagerly():
-            update = optimizer.apply_gradients(grads_and_vars)
+        for i, dtype in enumerate([tf.half, tf.float32, tf.float64]):
+            # Initialize variables for numpy implementation.
+            np_slot_vars0, np_slot_vars1 = {}, {}
+            var0_np = np.array([1.0, 2.0], dtype=dtype.as_numpy_dtype)
+            grads0_np = np.array([0.1, 0.1], dtype=dtype.as_numpy_dtype)
+            var1_np = np.array([3.0, 4.0], dtype=dtype.as_numpy_dtype)
+            grads1_np = np.array([0.01, 0.01], dtype=dtype.as_numpy_dtype)
+            # Create Tensorflow variables.
+            var0 = tf.Variable(var0_np, name="var0_%d" % i)
+            var1 = tf.Variable(var1_np, name="var1_%d" % i)
+            if do_sparse:
+                grads0_np_indices = np.array([0, 1], dtype=np.int32)
+                grads0 = tf.IndexedSlices(
+                    tf.constant(grads0_np), tf.constant(grads0_np_indices),
+                    tf.constant([2]))
+                grads1_np_indices = np.array([0, 1], dtype=np.int32)
+                grads1 = tf.IndexedSlices(
+                    tf.constant(grads1_np), tf.constant(grads1_np_indices),
+                    tf.constant([2]))
+            else:
+                grads0 = tf.constant(grads0_np)
+                grads1 = tf.constant(grads1_np)
+            opt = optimizer(**optimizer_kwargs)
+            # Validate initial values.
+            if not tf.executing_eagerly():
+                update = opt.apply_gradients(
+                    zip([grads0, grads1], [var0, var1]))
+                self.evaluate(tf.compat.v1.global_variables_initializer())
+                self.assertAllClose([1.0, 2.0], self.evaluate(var0))
+                self.assertAllClose([3.0, 4.0], self.evaluate(var1))
+            # Create the update op.
+            # Run 3 steps of the optimizer
+            for _ in range(3):
+                if tf.executing_eagerly():
+                    opt.apply_gradients(zip([grads0, grads1], [var0, var1]))
+                else:
+                    self.evaluate(update)
+                var0_np, np_slot_vars0 = update_fn(
+                    var0_np, grads0_np, np_slot_vars0, **optimizer_kwargs)
+                var1_np, np_slot_vars1 = update_fn(
+                    var1_np, grads1_np, np_slot_vars1, **optimizer_kwargs)
+                # Validate updated params
+                self.assertAllCloseAccordingToType(var0_np,
+                                                   self.evaluate(var0))
+                self.assertAllCloseAccordingToType(var1_np,
+                                                   self.evaluate(var1))
+
+    def doTestSparseRepeatedIndices(self, optimizer, **optimizer_kwargs):
+        """Test for repeated indices in sparse updates.
+
+        This test verifies that an update with repeated indices is the same as
+        an update with two times the gradient.
+
+        Args:
+            optimizer: The tensorflow optimizer class to be tested.
+            **optimizer_kwargs: The parameters to pass to the construcor of the
+                optimizer. Either a constant or a callable. This also passed to
+                the optimizer_params in the update_fn.
+        """
+        # TODO: Fix #347 issue
+        if tf.test.is_gpu_available():
+            self.skipTest('Wait #347 to be fixed')
+
+        for dtype in [tf.dtypes.half, tf.dtypes.float32, tf.dtypes.float64]:
+            repeated_index_update_var = tf.Variable([[1.0], [2.0]],
+                                                    dtype=dtype)
+            aggregated_update_var = tf.Variable([[1.0], [2.0]], dtype=dtype)
+            grad_repeated_index = tf.IndexedSlices(
+                tf.constant([0.1, 0.1], shape=[2, 1], dtype=dtype),
+                tf.constant([1, 1]), tf.constant([2, 1]))
+            grad_aggregated = tf.IndexedSlices(
+                tf.constant([0.2], shape=[1, 1], dtype=dtype),
+                tf.constant([1]), tf.constant([2, 1]))
+            opt_repeated = optimizer(**optimizer_kwargs)
+            repeated_update = opt_repeated.apply_gradients(
+                [(grad_repeated_index, repeated_index_update_var)])
+            opt_aggregated = optimizer(**optimizer_kwargs)
+            aggregated_update = opt_aggregated.apply_gradients(
+                [(grad_aggregated, aggregated_update_var)])
             self.evaluate(tf.compat.v1.global_variables_initializer())
-            self.evaluate(update)
-            self.evaluate(update)
-            self.evaluate(update)
-
-        else:
-            optimizer.apply_gradients(grads_and_vars)
-            optimizer.apply_gradients(grads_and_vars)
-            optimizer.apply_gradients(grads_and_vars)
-
-        self.assertAllClose(var_1.read_value(), [1.7, 1.7])
-        self.assertAllClose(var_0.read_value(), [0.7, 0.7])
-
-        if not tf.executing_eagerly():
-            update = optimizer.assign_average_vars([var_0, var_1])
-            self.evaluate(update)
-        else:
-            optimizer.assign_average_vars([var_0, var_1])
-
-        # self.assertEqual(True, False, msg='{} | {}'.format(var_0, expected_var_0))
-        self.assertAllClose(var_0.read_value(), [0.8, 0.8])
-        self.assertAllClose(var_1.read_value(), [1.8, 1.8])
-
-    def test_fit_simple_linear_model(self):
-        np.random.seed(0x2019)
-        num_examples = 100000
-        x = np.random.standard_normal((num_examples, 3))
-        w = np.random.standard_normal((3, 1))
-        y = np.dot(x, w) + np.random.standard_normal((num_examples, 1)) * 1e-4
-
-        model = tf.keras.models.Sequential()
-        model.add(tf.keras.layers.Dense(input_shape=(3,), units=1))
-        # using num_examples - 1 since steps starts from 0.
-        optimizer = SWA(
-            'adam', start_averaging=num_examples // 32 - 1, average_period=100)
-        model.compile(optimizer, loss='mse')
-        model.fit(x, y, epochs=3)
-        optimizer.assign_average_vars(model.variables)
-
-        x = np.random.standard_normal((100, 3))
-        y = np.dot(x, w)
-
-        predicted = model.predict(x)
-
-        max_abs_diff = np.max(np.abs(predicted - y))
-        self.assertLess(max_abs_diff, 1e-4)
-
-    def test_optimizer_failure(self):
-        with self.assertRaises(TypeError):
-            _ = SWA(None, average_period=10)
-
-    def test_optimizer_string(self):
-        _ = SWA('adam', average_period=10)
-
-    def test_get_config(self):
-        self.skipTest('Wait #33614 to be fixed')
-        opt = SWA('adam', average_period=10, start_averaging=0)
-        opt = tf.keras.optimizers.deserialize(
-            tf.keras.optimizers.serialize(opt))
-        config = opt.get_config()
-        self.assertEqual(config['average_period'], 10)
-        self.assertEqual(config['start_averaging'], 0)
+            self.assertAllClose(
+                self.evaluate(aggregated_update_var),
+                self.evaluate(repeated_index_update_var))
+            for _ in range(3):
+                if not tf.executing_eagerly():
+                    self.evaluate(repeated_update)
+                    self.evaluate(aggregated_update)
+                else:
+                    opt_repeated.apply_gradients([(grad_repeated_index,
+                                                   repeated_index_update_var)])
+                    opt_aggregated.apply_gradients([(grad_aggregated,
+                                                     aggregated_update_var)])
+                self.assertAllClose(
+                    self.evaluate(aggregated_update_var),
+                    self.evaluate(repeated_index_update_var))
 
 
-if __name__ == '__main__':
+def adamw_update_numpy(param, grad_t, slot_vars, learning_rate, beta_1, beta_2,
+                       epsilon, weight_decay):
+    """Numpy update function for AdamW."""
+    lr, beta1, beta2, eps, wd = (v() if callable(v) else v
+                                 for v in (learning_rate, beta_1, beta_2,
+                                           epsilon, weight_decay))
+    t = slot_vars.get("t", 0) + 1
+    lr_t = lr * np.sqrt(1 - beta2**t) / (1 - beta1**t)
+    slot_vars["m"] = beta1 * slot_vars.get("m", 0) + (1 - beta1) * grad_t
+    slot_vars["v"] = beta2 * slot_vars.get("v", 0) + (1 - beta2) * grad_t**2
+    param_t = (param * (1 - wd) -
+               lr_t * slot_vars["m"] / (np.sqrt(slot_vars["v"]) + eps))
+    slot_vars["t"] = t
+    return param_t, slot_vars
+
+
+def sgdw_update_numpy(param, grad_t, slot_vars, learning_rate, momentum,
+                      weight_decay):
+    """Numpy update function for SGDW."""
+    m = slot_vars.get("m", 0)
+    lr, momentum, wd = (v() if callable(v) else v
+                        for v in (learning_rate, momentum, weight_decay))
+    slot_vars["m"] = momentum * m + grad_t
+    param_t = param * (1 - wd) - lr * slot_vars["m"]
+    return param_t, slot_vars
+
+
+class AdamWTest(OptimizerTestBase):
+
+    optimizer = weight_decay_optimizers.AdamW
+
+    @test_utils.run_in_graph_and_eager_modes(reset_test=True)
+    def testSparse(self):
+        self.doTest(
+            self.optimizer,
+            adamw_update_numpy,
+            do_sparse=True,
+            learning_rate=0.001,
+            beta_1=0.9,
+            beta_2=0.999,
+            epsilon=1e-8,
+            weight_decay=WEIGHT_DECAY)
+
+    @test_utils.run_in_graph_and_eager_modes(reset_test=True)
+    def testSparseRepeatedIndices(self):
+        self.doTestSparseRepeatedIndices(
+            self.optimizer,
+            learning_rate=0.001,
+            beta_1=0.9,
+            beta_2=0.999,
+            epsilon=1e-8,
+            weight_decay=WEIGHT_DECAY)
+
+    @test_utils.run_in_graph_and_eager_modes(reset_test=True)
+    def testBasic(self):
+        self.doTest(
+            self.optimizer,
+            adamw_update_numpy,
+            learning_rate=0.001,
+            beta_1=0.9,
+            beta_2=0.999,
+            epsilon=1e-8,
+            weight_decay=WEIGHT_DECAY)
+
+    def testBasicCallableParams(self):
+        self.doTest(
+            self.optimizer,
+            adamw_update_numpy,
+            learning_rate=lambda: 0.001,
+            beta_1=lambda: 0.9,
+            beta_2=lambda: 0.999,
+            epsilon=1e-8,
+            weight_decay=lambda: WEIGHT_DECAY)
+
+
+class SGDWTest(OptimizerTestBase):
+
+    optimizer = weight_decay_optimizers.SGDW
+
+    @test_utils.run_in_graph_and_eager_modes(reset_test=True)
+    def testSparse(self):
+        self.doTest(
+            self.optimizer,
+            sgdw_update_numpy,
+            do_sparse=True,
+            learning_rate=0.001,
+            momentum=0.9,
+            weight_decay=WEIGHT_DECAY)
+
+    @test_utils.run_in_graph_and_eager_modes(reset_test=True)
+    def testSparseRepeatedIndices(self):
+        self.doTestSparseRepeatedIndices(
+            self.optimizer,
+            learning_rate=0.001,
+            momentum=0.9,
+            weight_decay=WEIGHT_DECAY)
+
+    @test_utils.run_in_graph_and_eager_modes(reset_test=True)
+    def testBasic(self):
+        self.doTest(
+            self.optimizer,
+            sgdw_update_numpy,
+            learning_rate=0.001,
+            momentum=0.9,
+            weight_decay=WEIGHT_DECAY)
+
+    def testBasicCallableParams(self):
+        self.doTest(
+            self.optimizer,
+            sgdw_update_numpy,
+            learning_rate=lambda: 0.001,
+            momentum=lambda: 0.9,
+            weight_decay=lambda: WEIGHT_DECAY)
+
+
+class ExtendWithWeightDecayTest(SGDWTest):
+    """Verify that the factory function SGDW is the same as SGDW."""
+
+    optimizer = weight_decay_optimizers.extend_with_decoupled_weight_decay(
+        tf.keras.optimizers.SGD)
+
+
+if __name__ == "__main__":
     tf.test.main()


### PR DESCRIPTION
Adding Stochastic Weight Averaging Optimizer.

Notes:

* The optimizer needs the calling of the `assign_average_vars()` at the end of training to assign the averaged values to the model variables. Docstring for `assign_average_vars()` contains an example on how to do this.

* Averaging starts happening at step `start_averaging` and then happens at every `average_period` steps.

Closes #592 