### PR TITLE
Bugfix: correct input shape handling for CorrelationCost Keras layer

### DIFF
--- a/tensorflow_addons/layers/optical_flow.py
+++ b/tensorflow_addons/layers/optical_flow.py
@@ -202,20 +202,29 @@ class CorrelationCost(tf.keras.layers.Layer):
 
     def compute_output_shape(self, input_shape):
         assert isinstance(input_shape, list)
+
+        #  Input validation
+        if len(input_shape) != 2:
+            raise ValueError("Input must be a list of two shapes")
+
+        for idx in range(4):
+            if input_shape[0][idx] != input_shape[1][idx]:
+                raise ValueError("Input shapes must match")
+
         n = input_shape[0][0]
-        r = self.max_displacement / self.stride_2
-        bd = self.max_displacement + (self.kernel_size - 1) / 2
+        r = self.max_displacement // self.stride_2
+        bd = self.max_displacement + (self.kernel_size - 1) // 2
         output_c = (2 * r + 1)**2
 
         if self.data_format == "channels_first":
-            output_h = input_shape[0][1] + 2 * (self.pad - bd) / self.stride_1
-            output_w = input_shape[0][2] + 2 * (self.pad - bd) / self.stride_1
-            return [int(n), int(output_c), int(output_h), int(output_w)]
+            output_h = input_shape[0][2] + 2 * (self.pad - bd) // self.stride_1
+            output_w = input_shape[0][3] + 2 * (self.pad - bd) // self.stride_1
+            return [(n, output_c, output_h, output_w)]
 
         elif self.data_format == "channels_last":
-            output_h = input_shape[0][0] + 2 * (self.pad - bd) / self.stride_1
-            output_w = input_shape[0][1] + 2 * (self.pad - bd) / self.stride_1
-            return [int(n), int(output_h), int(output_w), int(output_c)]
+            output_h = input_shape[0][1] + 2 * (self.pad - bd) // self.stride_1
+            output_w = input_shape[0][2] + 2 * (self.pad - bd) // self.stride_1
+            return [(n, output_h, output_w, output_c)]
         else:
             raise ValueError("`data_format` must be either `channels_last` or"
                              "`channels_first`")

--- a/tensorflow_addons/layers/optical_flow_test.py
+++ b/tensorflow_addons/layers/optical_flow_test.py
@@ -41,23 +41,31 @@ class CorrelationCostTest(tf.test.TestCase):
 
         return output
 
+    def _create_test_data(self, data_format):
+        # Produce test data for _forward_simple and _keras methods
+        val_a = np.array(
+            [[[[0, -6, 9, 5], [1, -5, 10, 3], [2, -4, 11, 1]],
+              [[3, -3, 12, -1], [4, -2, 13, -3], [5, -1, 14, -5]]],
+             [[[6, 0, 15, -7], [7, 1, 16, -9], [8, 2, 17, -11]],
+              [[9, 3, 18, -13], [10, 4, 19, -15], [11, 5, 20, -17]]]],
+            dtype=np.float32)
+
+        # pylint: disable=too-many-function-args
+        val_b = val_a.transpose(2, 3, 0, 1).reshape(2, 2, 3, 4)
+        # pylint: enable=too-many-function-args
+
+        if data_format == 'channels_last':
+            val_a = np.moveaxis(val_a, 1, -1)
+            val_b = np.moveaxis(val_b, 1, -1)
+
+        return val_a, val_b
+
     def _forward_simple(self, data_format):
         # We are just testing where the output has vanishing values.
         with test_utils.use_gpu():
-            val = [[[[0, -6, 9, 5], [1, -5, 10, 3], [2, -4, 11, 1]],
-                    [[3, -3, 12, -1], [4, -2, 13, -3], [5, -1, 14, -5]]],
-                   [[[6, 0, 15, -7], [7, 1, 16, -9], [8, 2, 17, -11]],
-                    [[9, 3, 18, -13], [10, 4, 19, -15], [11, 5, 20, -17]]]]
-
-            input_a = tf.constant(np.array(val), dtype=tf.float32)
-            # pylint: disable=too-many-function-args
-            valb = np.array(val).transpose(2, 3, 0, 1).reshape(2, 2, 3, 4)
-            # pylint: enable=too-many-function-args
-            input_b = tf.constant(valb, dtype=tf.float32)
-
-            if data_format == 'channels_last':
-                input_a = tf.transpose(input_a, [0, 2, 3, 1])
-                input_b = tf.transpose(input_b, [0, 2, 3, 1])
+            val_a, val_b = self._create_test_data(data_format)
+            input_a = tf.constant(val_a, dtype=tf.float32)
+            input_b = tf.constant(val_b, dtype=tf.float32)
 
             input_a_tensor = tf.convert_to_tensor(input_a, dtype=tf.float32)
             input_b_tensor = tf.convert_to_tensor(input_b, dtype=tf.float32)
@@ -133,19 +141,11 @@ class CorrelationCostTest(tf.test.TestCase):
     def _keras(self, data_format):
         # Unable to use `layer_test` as this layer has multiple inputs.
         with test_utils.use_gpu():
-            val_a = np.array(
-                [[[[0, -6, 9, 5], [1, -5, 10, 3], [2, -4, 11, 1]],
-                  [[3, -3, 12, -1], [4, -2, 13, -3], [5, -1, 14, -5]]],
-                 [[[6, 0, 15, -7], [7, 1, 16, -9], [8, 2, 17, -11]],
-                  [[9, 3, 18, -13], [10, 4, 19, -15], [11, 5, 20, -17]]]],
-                dtype=np.float32)
-            # pylint: disable=too-many-function-args
-            val_b = val_a.transpose(2, 3, 0, 1).reshape(2, 2, 3, 4)
-            # pylint: enable=too-many-function-args
+            val_a, val_b = self._create_test_data(data_format)
 
             # yapf: disable
-            input_a = tf.keras.Input(shape=(2, 3, 4,))
-            input_b = tf.keras.Input(shape=(2, 3, 4,))
+            input_a = tf.keras.Input(shape=val_a.shape[1:])
+            input_b = tf.keras.Input(shape=val_b.shape[1:])
 
             layer = CorrelationCost(
                 kernel_size=1,
@@ -156,7 +156,7 @@ class CorrelationCostTest(tf.test.TestCase):
                 data_format=data_format)
 
             expected_output_shape = tuple(
-                layer.compute_output_shape([(2, 3, 4,), (2, 3, 4,)]))[1:]
+                layer.compute_output_shape([input_a.shape, input_b.shape]))
             # yapf: enable
 
             x = [input_a, input_b]
@@ -171,10 +171,10 @@ class CorrelationCostTest(tf.test.TestCase):
                     "expected output type %s" % (tf.keras.backend.dtype(y[0]),
                                                  expected_output_type))
 
-            if actual_output[0].shape != expected_output_shape:
+            if actual_output.shape[1:] != expected_output_shape[0][1:]:
                 raise AssertionError(
                     "Expected shape %s does not equal output shape"
-                    "%s" % (actual_output[0].shape, expected_output_shape))
+                    "%s" % (actual_output.shape, expected_output_shape[0]))
 
     def testForwardNCHW(self):
         self._forward_simple(data_format='channels_first')


### PR DESCRIPTION
* Fixes in CorrelationCost::compute_output_shape: integer division and channel indexing
* Cleanup in CorrelationCostTest for duplicated code