### PR TITLE
Make interpolate_bilinear compatible with TF Dataset (#332)

### DIFF
--- a/tensorflow_addons/image/dense_image_warp.py
+++ b/tensorflow_addons/image/dense_image_warp.py
@@ -21,6 +21,7 @@ import numpy as np
 import tensorflow as tf
 
 
+@tf.function
 def interpolate_bilinear(grid, query_points, indexing="ij", name=None):
     """Similar to Matlab's interp2 function.
 
@@ -48,62 +49,76 @@ def interpolate_bilinear(grid, query_points, indexing="ij", name=None):
         grid = tf.convert_to_tensor(grid)
         query_points = tf.convert_to_tensor(query_points)
 
-        if len(grid.shape) != 4:
-            msg = "Grid must be 4 dimensional. Received size: "
-            raise ValueError(msg + str(grid.shape))
-
-        if len(query_points.shape) != 3:
-            raise ValueError("Query points must be 3 dimensional.")
-
-        if query_points.shape[2] is not None and query_points.shape[2] != 2:
-            raise ValueError("Query points must be size 2 in dim 2.")
-
-        if grid.shape[1] is not None and grid.shape[1] < 2:
-            raise ValueError("Grid height must be at least 2.")
-
-        if grid.shape[2] is not None and grid.shape[2] < 2:
-            raise ValueError("Grid width must be at least 2.")
-
+        # grid shape checks
+        grid_static_shape = grid.shape
         grid_shape = tf.shape(grid)
+        if grid_static_shape.dims is not None:
+            if len(grid_static_shape) != 4:
+                raise ValueError("Grid must be 4D Tensor")
+            if grid_static_shape[1] is not None and grid_static_shape[1] < 2:
+                raise ValueError("Grid height must be at least 2.")
+            if grid_static_shape[2] is not None and grid_static_shape[2] < 2:
+                raise ValueError("Grid width must be at least 2.")
+        else:
+            # pylint: disable=bad-continuation
+            with tf.control_dependencies([
+                    tf.debugging.assert_greater_equal(
+                        grid_shape[1],
+                        2,
+                        message="Grid height must be at least 2."),
+                    tf.debugging.assert_greater_equal(
+                        grid_shape[2],
+                        2,
+                        message="Grid width must be at least 2."),
+                    tf.debugging.assert_less_equal(
+                        tf.cast(
+                            grid_shape[0] * grid_shape[1] * grid_shape[2],
+                            dtype=tf.dtypes.float32),
+                        np.iinfo(np.int32).max / 8.0,
+                        message="The image size or batch size is sufficiently "
+                        "large that the linearized addresses used by "
+                        "tf.gather may exceed the int32 limit.")
+            ]):
+                # pylint: enable=bad-continuation
+                pass
+
+        # query_points shape checks
+        query_static_shape = query_points.shape
         query_shape = tf.shape(query_points)
+        if query_static_shape.dims is not None:
+            if len(query_static_shape) != 3:
+                raise ValueError("Query points must be 3 dimensional.")
+            query_hw = query_static_shape[2]
+            if query_hw is not None and query_hw != 2:
+                raise ValueError("Query points last dimension must be 2.")
+        else:
+            with tf.control_dependencies([
+                    tf.debugging.assert_equal(
+                        query_shape[2],
+                        2,
+                        message="Query points last dimension must be 2.")
+            ]):
+                pass
 
         batch_size, height, width, channels = (grid_shape[0], grid_shape[1],
                                                grid_shape[2], grid_shape[3])
 
-        shape = [batch_size, height, width, channels]
-
-        # pylint: disable=bad-continuation
-        with tf.control_dependencies([
-                tf.debugging.assert_equal(
-                    query_shape[2],
-                    2,
-                    message="Query points must be size 2 in dim 2.")
-        ]):
-            num_queries = query_shape[1]
-        # pylint: enable=bad-continuation
+        num_queries = query_shape[1]
 
         query_type = query_points.dtype
         grid_type = grid.dtype
 
-        # pylint: disable=bad-continuation
-        with tf.control_dependencies([
-                tf.debugging.assert_greater_equal(
-                    height, 2, message="Grid height must be at least 2."),
-                tf.debugging.assert_greater_equal(
-                    width, 2, message="Grid width must be at least 2."),
-        ]):
-            alphas = []
-            floors = []
-            ceils = []
-            index_order = [0, 1] if indexing == "ij" else [1, 0]
-            unstacked_query_points = tf.unstack(query_points, axis=2)
-        # pylint: enable=bad-continuation
+        alphas = []
+        floors = []
+        ceils = []
+        index_order = [0, 1] if indexing == "ij" else [1, 0]
+        unstacked_query_points = tf.unstack(query_points, axis=2, num=2)
 
         for dim in index_order:
             with tf.name_scope("dim-" + str(dim)):
                 queries = unstacked_query_points[dim]
 
-                size_in_indexing_dimension = shape[dim + 1]
+                size_in_indexing_dimension = grid_shape[dim + 1]
 
                 # max_floor is size_in_indexing_dimension - 2 so that max_floor + 1
                 # is still a valid index into the grid.
@@ -130,16 +145,6 @@ def interpolate_bilinear(grid, query_points, indexing="ij", name=None):
                 alpha = tf.expand_dims(alpha, 2)
                 alphas.append(alpha)
 
-        # pylint: disable=bad-continuation
-        with tf.control_dependencies([
-                tf.debugging.assert_less_equal(
-                    tf.cast(
-                        batch_size * height * width, dtype=tf.dtypes.float32),
-                    np.iinfo(np.int32).max / 8.0,
-                    message="The image size or batch size is sufficiently "
-                    "large that the linearized addresses used by tf.gather "
-                    "may exceed the int32 limit.")
-        ]):
             flattened_grid = tf.reshape(
                 grid, [batch_size * height * width, channels])
             batch_offsets = tf.reshape(

--- a/tensorflow_addons/image/dense_image_warp.py
+++ b/tensorflow_addons/image/dense_image_warp.py
@@ -79,8 +79,8 @@ def interpolate_bilinear(grid, query_points, indexing="ij", name=None):
                         "large that the linearized addresses used by "
                         "tf.gather may exceed the int32 limit.")
             ]):
-                # pylint: enable=bad-continuation
                 pass
+            # pylint: enable=bad-continuation
 
         # query_points shape checks
         query_static_shape = query_points.shape
@@ -92,6 +92,7 @@ def interpolate_bilinear(grid, query_points, indexing="ij", name=None):
             if query_hw is not None and query_hw != 2:
                 raise ValueError("Query points last dimension must be 2.")
         else:
+            # pylint: disable=bad-continuation
             with tf.control_dependencies([
                     tf.debugging.assert_equal(
                         query_shape[2],
@@ -99,6 +100,7 @@ def interpolate_bilinear(grid, query_points, indexing="ij", name=None):
                         message="Query points last dimension must be 2.")
             ]):
                 pass
+            # pylint: enable=bad-continuation
 
         batch_size, height, width, channels = (grid_shape[0], grid_shape[1],
                                                grid_shape[2], grid_shape[3])

--- a/tensorflow_addons/image/dense_image_warp_test.py
+++ b/tensorflow_addons/image/dense_image_warp_test.py
@@ -28,7 +28,7 @@ from tensorflow_addons.utils import test_utils
 
 
 @test_utils.run_all_in_graph_and_eager_modes
-class DenseImageWarpTest(tf.test.TestCase):
+class InterpolateBilinearTest(tf.test.TestCase):
     def test_interpolate_small_grid_ij(self):
         grid = tf.constant([[0., 1., 2.], [3., 4., 5.], [6., 7., 8.]],
                            shape=[1, 3, 3, 1])
@@ -63,6 +63,20 @@ class DenseImageWarpTest(tf.test.TestCase):
 
         self.assertAllClose(expected_results, interp)
 
+    def test_unknown_shape(self):
+        query_points = tf.constant(
+            [[0., 0.], [0., 1.], [0.5, 2.0], [1.5, 1.5]], shape=[1, 4, 2])
+        fn = interpolate_bilinear.get_concrete_function(
+            tf.TensorSpec(shape=None, dtype=tf.float32),
+            tf.TensorSpec(shape=None, dtype=tf.float32))
+        for shape in (2, 4, 3, 6), (6, 2, 4, 3), (1, 2, 4, 3):
+            image = tf.ones(shape=shape)
+            res = fn(image, query_points)
+            self.assertAllEqual(res.shape, (shape[0], 4, shape[3]))
+
+
+@test_utils.run_all_in_graph_and_eager_modes
+class DenseImageWarpTest(tf.test.TestCase):
     def _get_random_image_and_flows(self, shape, image_type, flow_type):
         batch_size, height, width, num_channels = shape
         image_shape = [batch_size, height, width, num_channels]


### PR DESCRIPTION
* Make interpolate_bilinear compatible with TF Dataset

* Split InterpolateBilinearTest from DenseImageWarpTest

* Add InterpolateBilinearTest::test_unknown_shape