### PR TITLE
Add cyclical learning rate schedulers

### DIFF
--- a/tensorflow_addons/optimizers/BUILD
+++ b/tensorflow_addons/optimizers/BUILD
@@ -7,6 +7,7 @@ py_library(
     srcs = [
         "__init__.py",
         "conditional_gradient.py",
+        "cyclical_learning_rate.py",
         "lamb.py",
         "lazy_adam.py",
         "lookahead.py",
@@ -105,6 +106,19 @@ py_test(
         "weight_decay_optimizers_test.py",
     ],
     main = "weight_decay_optimizers_test.py",
+    srcs_version = "PY2AND3",
+    deps = [
+        ":optimizers",
+    ],
+)
+
+py_test(
+    name = "cyclical_learning_rate_test",
+    size = "small",
+    srcs = [
+        "cyclical_learning_rate_test.py",
+    ],
+    main = "cyclical_learning_rate_test.py",
     srcs_version = "PY2AND3",
     deps = [
         ":optimizers",

--- a/tensorflow_addons/optimizers/README.md
+++ b/tensorflow_addons/optimizers/README.md
@@ -10,6 +10,7 @@
 | moving_average | Dheeraj R. Reddy | dheeraj98reddy@gmail.com |
 | rectified_adam | Zhao Hanguang | cyberzhg@gmail.com |
 | weight_decay_optimizers |  Phil Jund | ijund.phil@googlemail.com   |
+| cyclical_learning_rate | Raphael Meudec | raphael.meudec@gmail.com |
 
 
 ## Components
@@ -22,6 +23,7 @@
 | moving_average | MovingAverage | |
 | rectified_adam | RectifiedAdam | https://arxiv.org/pdf/1908.03265v1.pdf |
 | weight_decay_optimizers | SGDW, AdamW, extend_with_decoupled_weight_decay | https://arxiv.org/pdf/1711.05101.pdf |
+| cyclical_learning_rate | Cyclical Learning Rate | https://arxiv.org/abs/1506.01186 |
 
 
 ## Contribution Guidelines

--- a/tensorflow_addons/optimizers/README.md
+++ b/tensorflow_addons/optimizers/README.md
@@ -4,26 +4,26 @@
 | Submodule  | Maintainers  | Contact Info   |
 |:---------- |:------------- |:--------------|
 | conditional_gradient | Pengyu Kan, Vishnu Lokhande | pkan2@wisc.edu, lokhande@cs.wisc.edu |
+| cyclical_learning_rate | Raphael Meudec | raphael.meudec@gmail.com |
 | lamb | Jing Li, Junjie Ke | jingli@google.com, junjiek@google.com |
 | lazy_adam | Saishruthi Swaminathan  | saishruthi.tn@gmail.com  |
 | lookahead | Zhao Hanguang | cyberzhg@gmail.com |
 | moving_average | Dheeraj R. Reddy | dheeraj98reddy@gmail.com |
 | rectified_adam | Zhao Hanguang | cyberzhg@gmail.com |
 | weight_decay_optimizers |  Phil Jund | ijund.phil@googlemail.com   |
-| cyclical_learning_rate | Raphael Meudec | raphael.meudec@gmail.com |
 
 
 ## Components
 | Submodule | Optimizer  | Reference                                   |
 |:--------- |:---------- |:---------|
 | conditional_gradient | ConditionalGradient | https://arxiv.org/pdf/1803.06453.pdf |
+| cyclical_learning_rate | Cyclical Learning Rate | https://arxiv.org/abs/1506.01186 |
 | lamb | LAMB | https://arxiv.org/abs/1904.00962      |
 | lazy_adam | LazyAdam | https://arxiv.org/abs/1412.6980      |
 | lookahead | Lookahead | https://arxiv.org/abs/1907.08610v1 |
 | moving_average | MovingAverage | |
 | rectified_adam | RectifiedAdam | https://arxiv.org/pdf/1908.03265v1.pdf |
 | weight_decay_optimizers | SGDW, AdamW, extend_with_decoupled_weight_decay | https://arxiv.org/pdf/1711.05101.pdf |
-| cyclical_learning_rate | Cyclical Learning Rate | https://arxiv.org/abs/1506.01186 |
 
 
 ## Contribution Guidelines

--- a/tensorflow_addons/optimizers/__init__.py
+++ b/tensorflow_addons/optimizers/__init__.py
@@ -19,6 +19,14 @@ from __future__ import division
 from __future__ import print_function
 
 from tensorflow_addons.optimizers.conditional_gradient import ConditionalGradient
+from tensorflow_addons.optimizers.cyclical_learning_rate import (
+    CyclicalLearningRate)
+from tensorflow_addons.optimizers.cyclical_learning_rate import (
+    TriangularCyclicalLearningRate)
+from tensorflow_addons.optimizers.cyclical_learning_rate import (
+    Triangular2CyclicalLearningRate)
+from tensorflow_addons.optimizers.cyclical_learning_rate import (
+    ExponentialCyclicalLearningRate)
 from tensorflow_addons.optimizers.lamb import LAMB
 from tensorflow_addons.optimizers.lazy_adam import LazyAdam
 from tensorflow_addons.optimizers.lookahead import Lookahead

--- a/tensorflow_addons/optimizers/cyclical_learning_rate.py
+++ b/tensorflow_addons/optimizers/cyclical_learning_rate.py
@@ -18,10 +18,9 @@ from __future__ import division
 from __future__ import print_function
 
 import tensorflow as tf
-from tensorflow_addons.utils import keras_utils
 
 
-@keras_utils.register_keras_custom_object
+@tf.keras.utils.register_keras_serializable(package='Addons')
 class CyclicalLearningRate(tf.keras.optimizers.schedules.LearningRateSchedule):
     """A LearningRateSchedule that uses cyclical schedule."""
 
@@ -110,7 +109,7 @@ class CyclicalLearningRate(tf.keras.optimizers.schedules.LearningRateSchedule):
         }
 
 
-@keras_utils.register_keras_custom_object
+@tf.keras.utils.register_keras_serializable(package='Addons')
 class TriangularCyclicalLearningRate(CyclicalLearningRate):
     def __init__(
             self,
@@ -174,7 +173,7 @@ class TriangularCyclicalLearningRate(CyclicalLearningRate):
         )
 
 
-@keras_utils.register_keras_custom_object
+@tf.keras.utils.register_keras_serializable(package='Addons')
 class Triangular2CyclicalLearningRate(CyclicalLearningRate):
     def __init__(
             self,
@@ -238,7 +237,7 @@ class Triangular2CyclicalLearningRate(CyclicalLearningRate):
         )
 
 
-@keras_utils.register_keras_custom_object
+@tf.keras.utils.register_keras_serializable(package='Addons')
 class ExponentialCyclicalLearningRate(CyclicalLearningRate):
     def __init__(
             self,

--- a/tensorflow_addons/optimizers/cyclical_learning_rate.py
+++ b/tensorflow_addons/optimizers/cyclical_learning_rate.py
@@ -56,10 +56,7 @@ class CyclicalLearningRate(tf.keras.optimizers.schedules.LearningRateSchedule):
         ```
 
         You can pass this schedule directly into a
-        `tf.keras.optimizers.Optimizer` as the learning rate. The learning rate
-        schedule is also serializable and deserializable using
-        `tf.keras.optimizers.schedules.serialize` and
-        `tf.keras.optimizers.schedules.deserialize`.
+        `tf.keras.optimizers.Optimizer` as the learning rate.
 
         Args:
             initial_learning_rate: A scalar `float32` or `float64` `Tensor` or
@@ -143,10 +140,7 @@ class TriangularCyclicalLearningRate(CyclicalLearningRate):
         ```
 
         You can pass this schedule directly into a
-        `tf.keras.optimizers.Optimizer` as the learning rate. The learning rate
-        schedule is also serializable and deserializable using
-        `tf.keras.optimizers.schedules.serialize` and
-        `tf.keras.optimizers.schedules.deserialize`.
+        `tf.keras.optimizers.Optimizer` as the learning rate.
 
         Args:
             initial_learning_rate: A scalar `float32` or `float64` `Tensor` or
@@ -207,10 +201,7 @@ class Triangular2CyclicalLearningRate(CyclicalLearningRate):
         ```
 
         You can pass this schedule directly into a
-        `tf.keras.optimizers.Optimizer` as the learning rate. The learning rate
-        schedule is also serializable and deserializable using
-        `tf.keras.optimizers.schedules.serialize` and
-        `tf.keras.optimizers.schedules.deserialize`.
+        `tf.keras.optimizers.Optimizer` as the learning rate.
 
         Args:
             initial_learning_rate: A scalar `float32` or `float64` `Tensor` or
@@ -273,10 +264,7 @@ class ExponentialCyclicalLearningRate(CyclicalLearningRate):
         ```
 
         You can pass this schedule directly into a
-        `tf.keras.optimizers.Optimizer` as the learning rate. The learning rate
-        schedule is also serializable and deserializable using
-        `tf.keras.optimizers.schedules.serialize` and
-        `tf.keras.optimizers.schedules.deserialize`.
+        `tf.keras.optimizers.Optimizer` as the learning rate.
 
         Args:
             initial_learning_rate: A scalar `float32` or `float64` `Tensor` or

--- a/tensorflow_addons/optimizers/cyclical_learning_rate.py
+++ b/tensorflow_addons/optimizers/cyclical_learning_rate.py
@@ -48,23 +48,25 @@ class CyclicalLearningRate(tf.keras.optimizers.schedules.LearningRateSchedule):
             scale_mode="cycle",
             name="MyCyclicScheduler")
 
-        model.compile(optimizer=tf.keras.optimizers.SGD(learning_rate=lr_schedule),
+        model.compile(optimizer=tf.keras.optimizers.SGD(
+                                                    learning_rate=lr_schedule),
                       loss='sparse_categorical_crossentropy',
                       metrics=['accuracy'])
 
         model.fit(data, labels, epochs=5)
         ```
 
-        You can pass this schedule directly into a `tf.keras.optimizers.Optimizer`
-        as the learning rate. The learning rate schedule is also serializable and
-        deserializable using `tf.keras.optimizers.schedules.serialize` and
+        You can pass this schedule directly into a
+        `tf.keras.optimizers.Optimizer` as the learning rate. The learning rate
+        schedule is also serializable and deserializable using
+        `tf.keras.optimizers.schedules.serialize` and
         `tf.keras.optimizers.schedules.deserialize`.
 
         Args:
-            initial_learning_rate: A scalar `float32` or `float64` `Tensor` or a
-                Python number.  The initial learning rate.
-            maximal_learning_rate: A scalar `float32` or `float64` `Tensor` or a
-                Python number.  The maximum learning rate.
+            initial_learning_rate: A scalar `float32` or `float64` `Tensor` or
+                a Python number.  The initial learning rate.
+            maximal_learning_rate: A scalar `float32` or `float64` `Tensor` or
+                a Python number.  The maximum learning rate.
             step_size: A scalar `float32` or `float64` `Tensor` or a
                 Python number. Step size.
             scale_fn: A function. Scheduling function applied in cycle
@@ -124,30 +126,34 @@ class TriangularCyclicalLearningRate(CyclicalLearningRate):
 
 
         ```python
-        lr_schedule = tf.keras.optimizers.schedules.TriangularCyclicalLearningRate(
+        from tf.keras.optimizers import schedules
+
+        lr_schedule = schedules.TriangularCyclicalLearningRate(
             initial_learning_rate=1e-4,
             maximal_learning_rate=1e-2,
             step_size=2000,
             scale_mode="cycle",
             name="MyCyclicScheduler")
 
-        model.compile(optimizer=tf.keras.optimizers.SGD(learning_rate=lr_schedule),
+        model.compile(optimizer=tf.keras.optimizers.SGD(
+                                                    learning_rate=lr_schedule),
                       loss='sparse_categorical_crossentropy',
                       metrics=['accuracy'])
 
         model.fit(data, labels, epochs=5)
         ```
 
-        You can pass this schedule directly into a `tf.keras.optimizers.Optimizer`
-        as the learning rate. The learning rate schedule is also serializable and
-        deserializable using `tf.keras.optimizers.schedules.serialize` and
+        You can pass this schedule directly into a
+        `tf.keras.optimizers.Optimizer` as the learning rate. The learning rate
+        schedule is also serializable and deserializable using
+        `tf.keras.optimizers.schedules.serialize` and
         `tf.keras.optimizers.schedules.deserialize`.
 
         Args:
-            initial_learning_rate: A scalar `float32` or `float64` `Tensor` or a
-                Python number.  The initial learning rate.
-            maximal_learning_rate: A scalar `float32` or `float64` `Tensor` or a
-                Python number.  The maximum learning rate.
+            initial_learning_rate: A scalar `float32` or `float64` `Tensor` or
+                a Python number.  The initial learning rate.
+            maximal_learning_rate: A scalar `float32` or `float64` `Tensor` or
+                a Python number.  The maximum learning rate.
             step_size: A scalar `float32` or `float64` `Tensor` or a
                 Python number. Step size.
             scale_fn: A function. Scheduling function applied in cycle
@@ -184,30 +190,34 @@ class Triangular2CyclicalLearningRate(CyclicalLearningRate):
 
 
         ```python
-        lr_schedule = tf.keras.optimizers.schedules.Triangular2CyclicalLearningRate(
+        from tf.keras.optimizers import schedules
+
+        lr_schedule = schedules.Triangular2CyclicalLearningRate(
             initial_learning_rate=1e-4,
             maximal_learning_rate=1e-2,
             step_size=2000,
             scale_mode="cycle",
             name="MyCyclicScheduler")
 
-        model.compile(optimizer=tf.keras.optimizers.SGD(learning_rate=lr_schedule),
+        model.compile(optimizer=tf.keras.optimizers.SGD(
+                                                    learning_rate=lr_schedule),
                       loss='sparse_categorical_crossentropy',
                       metrics=['accuracy'])
 
         model.fit(data, labels, epochs=5)
         ```
 
-        You can pass this schedule directly into a `tf.keras.optimizers.Optimizer`
-        as the learning rate. The learning rate schedule is also serializable and
-        deserializable using `tf.keras.optimizers.schedules.serialize` and
+        You can pass this schedule directly into a
+        `tf.keras.optimizers.Optimizer` as the learning rate. The learning rate
+        schedule is also serializable and deserializable using
+        `tf.keras.optimizers.schedules.serialize` and
         `tf.keras.optimizers.schedules.deserialize`.
 
         Args:
-            initial_learning_rate: A scalar `float32` or `float64` `Tensor` or a
-                Python number.  The initial learning rate.
-            maximal_learning_rate: A scalar `float32` or `float64` `Tensor` or a
-                Python number.  The maximum learning rate.
+            initial_learning_rate: A scalar `float32` or `float64` `Tensor` or
+                a Python number.  The initial learning rate.
+            maximal_learning_rate: A scalar `float32` or `float64` `Tensor` or
+                a Python number.  The maximum learning rate.
             step_size: A scalar `float32` or `float64` `Tensor` or a
                 Python number. Step size.
             scale_fn: A function. Scheduling function applied in cycle
@@ -245,7 +255,9 @@ class ExponentialCyclicalLearningRate(CyclicalLearningRate):
 
 
         ```python
-        lr_schedule = tf.keras.optimizers.schedules.ExponentialCyclicalLearningRate(
+        from tf.keras.optimizers import schedules
+
+        lr_schedule = ExponentialCyclicalLearningRate(
             initial_learning_rate=1e-4,
             maximal_learning_rate=1e-2,
             step_size=2000,
@@ -253,23 +265,25 @@ class ExponentialCyclicalLearningRate(CyclicalLearningRate):
             gamma=0.96,
             name="MyCyclicScheduler")
 
-        model.compile(optimizer=tf.keras.optimizers.SGD(learning_rate=lr_schedule),
+        model.compile(optimizer=tf.keras.optimizers.SGD(
+                                                    learning_rate=lr_schedule),
                       loss='sparse_categorical_crossentropy',
                       metrics=['accuracy'])
 
         model.fit(data, labels, epochs=5)
         ```
 
-        You can pass this schedule directly into a `tf.keras.optimizers.Optimizer`
-        as the learning rate. The learning rate schedule is also serializable and
-        deserializable using `tf.keras.optimizers.schedules.serialize` and
+        You can pass this schedule directly into a
+        `tf.keras.optimizers.Optimizer` as the learning rate. The learning rate
+        schedule is also serializable and deserializable using
+        `tf.keras.optimizers.schedules.serialize` and
         `tf.keras.optimizers.schedules.deserialize`.
 
         Args:
-            initial_learning_rate: A scalar `float32` or `float64` `Tensor` or a
-                Python number.  The initial learning rate.
-            maximal_learning_rate: A scalar `float32` or `float64` `Tensor` or a
-                Python number.  The maximum learning rate.
+            initial_learning_rate: A scalar `float32` or `float64` `Tensor` or
+                a Python number.  The initial learning rate.
+            maximal_learning_rate: A scalar `float32` or `float64` `Tensor` or
+                a Python number.  The maximum learning rate.
             step_size: A scalar `float32` or `float64` `Tensor` or a
                 Python number. Step size.
             scale_fn: A function. Scheduling function applied in cycle

--- a/tensorflow_addons/optimizers/cyclical_learning_rate.py
+++ b/tensorflow_addons/optimizers/cyclical_learning_rate.py
@@ -23,16 +23,16 @@ from tensorflow_addons.utils import keras_utils
 
 @keras_utils.register_keras_custom_object
 class CyclicalLearningRate(tf.keras.optimizers.schedules.LearningRateSchedule):
-    """A LearningRateSchedule that uses cyclical schedule"""
+    """A LearningRateSchedule that uses cyclical schedule."""
 
     def __init__(
-        self,
-        initial_learning_rate,
-        maximal_learning_rate,
-        step_size,
-        scale_fn,
-        scale_mode="cycle",
-        name=None,
+            self,
+            initial_learning_rate,
+            maximal_learning_rate,
+            step_size,
+            scale_fn,
+            scale_mode="cycle",
+            name=None,
     ):
         """Applies cyclical schedule to the learning rate.
 
@@ -86,8 +86,7 @@ class CyclicalLearningRate(tf.keras.optimizers.schedules.LearningRateSchedule):
     def __call__(self, step):
         with tf.name_scope(self.name or "CyclicalLearningRate"):
             initial_learning_rate = tf.convert_to_tensor(
-                self.initial_learning_rate, name="initial_learning_rate"
-            )
+                self.initial_learning_rate, name="initial_learning_rate")
             dtype = initial_learning_rate.dtype
             maximal_learning_rate = tf.cast(self.maximal_learning_rate, dtype)
             step_size = tf.cast(self.step_size, dtype)
@@ -97,8 +96,8 @@ class CyclicalLearningRate(tf.keras.optimizers.schedules.LearningRateSchedule):
             mode_step = cycle if self.scale_mode == "cycle" else step
 
             return initial_learning_rate + (
-                maximal_learning_rate - initial_learning_rate
-            ) * tf.maximum(tf.cast(0, dtype), (1 - x)) * self.scale_fn(mode_step)
+                maximal_learning_rate - initial_learning_rate) * tf.maximum(
+                    tf.cast(0, dtype), (1 - x)) * self.scale_fn(mode_step)
 
     def get_config(self):
         return {
@@ -112,12 +111,12 @@ class CyclicalLearningRate(tf.keras.optimizers.schedules.LearningRateSchedule):
 @keras_utils.register_keras_custom_object
 class TriangularCyclicalLearningRate(CyclicalLearningRate):
     def __init__(
-        self,
-        initial_learning_rate,
-        maximal_learning_rate,
-        step_size,
-        scale_mode="cycle",
-        name="TriangularCyclicalLearningRate",
+            self,
+            initial_learning_rate,
+            maximal_learning_rate,
+            step_size,
+            scale_mode="cycle",
+            name="TriangularCyclicalLearningRate",
     ):
         """Applies triangular cyclical schedule to the learning rate.
 
@@ -172,12 +171,12 @@ class TriangularCyclicalLearningRate(CyclicalLearningRate):
 @keras_utils.register_keras_custom_object
 class Triangular2CyclicalLearningRate(CyclicalLearningRate):
     def __init__(
-        self,
-        initial_learning_rate,
-        maximal_learning_rate,
-        step_size,
-        scale_mode="cycle",
-        name="Triangular2CyclicalLearningRate",
+            self,
+            initial_learning_rate,
+            maximal_learning_rate,
+            step_size,
+            scale_mode="cycle",
+            name="Triangular2CyclicalLearningRate",
     ):
         """Applies triangular2 cyclical schedule to the learning rate.
 
@@ -223,7 +222,7 @@ class Triangular2CyclicalLearningRate(CyclicalLearningRate):
             initial_learning_rate=initial_learning_rate,
             maximal_learning_rate=maximal_learning_rate,
             step_size=step_size,
-            scale_fn=lambda x: 1 / (2. ** (x - 1)),
+            scale_fn=lambda x: 1 / (2.**(x - 1)),
             scale_mode=scale_mode,
             name=name,
         )
@@ -232,13 +231,13 @@ class Triangular2CyclicalLearningRate(CyclicalLearningRate):
 @keras_utils.register_keras_custom_object
 class ExponentialCyclicalLearningRate(CyclicalLearningRate):
     def __init__(
-        self,
-        initial_learning_rate,
-        maximal_learning_rate,
-        step_size,
-        scale_mode="iterations",
-        gamma=1.,
-        name="ExponentialCyclicalLearningRate",
+            self,
+            initial_learning_rate,
+            maximal_learning_rate,
+            step_size,
+            scale_mode="iterations",
+            gamma=1.,
+            name="ExponentialCyclicalLearningRate",
     ):
         """Applies exponential cyclical schedule to the learning rate.
 
@@ -287,7 +286,7 @@ class ExponentialCyclicalLearningRate(CyclicalLearningRate):
             initial_learning_rate=initial_learning_rate,
             maximal_learning_rate=maximal_learning_rate,
             step_size=step_size,
-            scale_fn=lambda x: gamma ** x,
+            scale_fn=lambda x: gamma**x,
             scale_mode=scale_mode,
             name=name,
         )

--- a/tensorflow_addons/optimizers/cyclical_learning_rate.py
+++ b/tensorflow_addons/optimizers/cyclical_learning_rate.py
@@ -1,0 +1,293 @@
+# Copyright 2019 The TensorFlow Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ==============================================================================
+"""Cyclical Learning Rate Schedule policies for TensorFlow."""
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+
+import tensorflow as tf
+from tensorflow_addons.utils import keras_utils
+
+
+@keras_utils.register_keras_custom_object
+class CyclicalLearningRate(tf.keras.optimizers.schedules.LearningRateSchedule):
+    """A LearningRateSchedule that uses cyclical schedule"""
+
+    def __init__(
+        self,
+        initial_learning_rate,
+        maximal_learning_rate,
+        step_size,
+        scale_fn,
+        scale_mode="cycle",
+        name=None,
+    ):
+        """Applies cyclical schedule to the learning rate.
+
+        See Cyclical Learning Rates for Training Neural Networks. https://arxiv.org/abs/1506.01186
+
+
+        ```python
+        lr_schedule = tf.keras.optimizers.schedules.CyclicalLearningRate(
+            initial_learning_rate=1e-4,
+            maximal_learning_rate=1e-2,
+            step_size=2000,
+            scale_fn=lambda x: 1.,
+            scale_mode="cycle",
+            name="MyCyclicScheduler")
+
+        model.compile(optimizer=tf.keras.optimizers.SGD(learning_rate=lr_schedule),
+                      loss='sparse_categorical_crossentropy',
+                      metrics=['accuracy'])
+
+        model.fit(data, labels, epochs=5)
+        ```
+
+        You can pass this schedule directly into a `tf.keras.optimizers.Optimizer`
+        as the learning rate. The learning rate schedule is also serializable and
+        deserializable using `tf.keras.optimizers.schedules.serialize` and
+        `tf.keras.optimizers.schedules.deserialize`.
+
+        Args:
+            initial_learning_rate: A scalar `float32` or `float64` `Tensor` or a
+                Python number.  The initial learning rate.
+            maximal_learning_rate: A scalar `float32` or `float64` `Tensor` or a
+                Python number.  The maximum learning rate.
+            step_size: A scalar `float32` or `float64` `Tensor` or a
+                Python number. Step size.
+            scale_fn: A function. Scheduling function applied in cycle
+            scale_mode: ['cycle', 'iterations']. Mode to apply during cyclic
+                schedule
+            name: (Optional) Name for the operation.
+
+        Returns:
+            Updated learning rate value.
+        """
+        super(CyclicalLearningRate, self).__init__()
+        self.initial_learning_rate = initial_learning_rate
+        self.maximal_learning_rate = maximal_learning_rate
+        self.step_size = step_size
+        self.scale_fn = scale_fn
+        self.scale_mode = scale_mode
+        self.name = name
+
+    def __call__(self, step):
+        with tf.name_scope(self.name or "CyclicalLearningRate"):
+            initial_learning_rate = tf.convert_to_tensor(
+                self.initial_learning_rate, name="initial_learning_rate"
+            )
+            dtype = initial_learning_rate.dtype
+            maximal_learning_rate = tf.cast(self.maximal_learning_rate, dtype)
+            step_size = tf.cast(self.step_size, dtype)
+            cycle = tf.floor(1 + step / (2 * step_size))
+            x = tf.abs(step / step_size - 2 * cycle + 1)
+
+            mode_step = cycle if self.scale_mode == "cycle" else step
+
+            return initial_learning_rate + (
+                maximal_learning_rate - initial_learning_rate
+            ) * tf.maximum(tf.cast(0, dtype), (1 - x)) * self.scale_fn(mode_step)
+
+    def get_config(self):
+        return {
+            "initial_learning_rate": self.initial_learning_rate,
+            "maximal_learning_rate": self.maximal_learning_rate,
+            "step_size": self.step_size,
+            "scale_mode": self.scale_mode,
+        }
+
+
+@keras_utils.register_keras_custom_object
+class TriangularCyclicalLearningRate(CyclicalLearningRate):
+    def __init__(
+        self,
+        initial_learning_rate,
+        maximal_learning_rate,
+        step_size,
+        scale_mode="cycle",
+        name="TriangularCyclicalLearningRate",
+    ):
+        """Applies triangular cyclical schedule to the learning rate.
+
+        See Cyclical Learning Rates for Training Neural Networks. https://arxiv.org/abs/1506.01186
+
+
+        ```python
+        lr_schedule = tf.keras.optimizers.schedules.TriangularCyclicalLearningRate(
+            initial_learning_rate=1e-4,
+            maximal_learning_rate=1e-2,
+            step_size=2000,
+            scale_mode="cycle",
+            name="MyCyclicScheduler")
+
+        model.compile(optimizer=tf.keras.optimizers.SGD(learning_rate=lr_schedule),
+                      loss='sparse_categorical_crossentropy',
+                      metrics=['accuracy'])
+
+        model.fit(data, labels, epochs=5)
+        ```
+
+        You can pass this schedule directly into a `tf.keras.optimizers.Optimizer`
+        as the learning rate. The learning rate schedule is also serializable and
+        deserializable using `tf.keras.optimizers.schedules.serialize` and
+        `tf.keras.optimizers.schedules.deserialize`.
+
+        Args:
+            initial_learning_rate: A scalar `float32` or `float64` `Tensor` or a
+                Python number.  The initial learning rate.
+            maximal_learning_rate: A scalar `float32` or `float64` `Tensor` or a
+                Python number.  The maximum learning rate.
+            step_size: A scalar `float32` or `float64` `Tensor` or a
+                Python number. Step size.
+            scale_fn: A function. Scheduling function applied in cycle
+            scale_mode: ['cycle', 'iterations']. Mode to apply during cyclic
+                schedule
+            name: (Optional) Name for the operation.
+
+        Returns:
+            Updated learning rate value.
+        """
+        super(TriangularCyclicalLearningRate, self).__init__(
+            initial_learning_rate=initial_learning_rate,
+            maximal_learning_rate=maximal_learning_rate,
+            step_size=step_size,
+            scale_fn=lambda x: 1.,
+            scale_mode=scale_mode,
+            name=name,
+        )
+
+
+@keras_utils.register_keras_custom_object
+class Triangular2CyclicalLearningRate(CyclicalLearningRate):
+    def __init__(
+        self,
+        initial_learning_rate,
+        maximal_learning_rate,
+        step_size,
+        scale_mode="cycle",
+        name="Triangular2CyclicalLearningRate",
+    ):
+        """Applies triangular2 cyclical schedule to the learning rate.
+
+        See Cyclical Learning Rates for Training Neural Networks. https://arxiv.org/abs/1506.01186
+
+
+        ```python
+        lr_schedule = tf.keras.optimizers.schedules.Triangular2CyclicalLearningRate(
+            initial_learning_rate=1e-4,
+            maximal_learning_rate=1e-2,
+            step_size=2000,
+            scale_mode="cycle",
+            name="MyCyclicScheduler")
+
+        model.compile(optimizer=tf.keras.optimizers.SGD(learning_rate=lr_schedule),
+                      loss='sparse_categorical_crossentropy',
+                      metrics=['accuracy'])
+
+        model.fit(data, labels, epochs=5)
+        ```
+
+        You can pass this schedule directly into a `tf.keras.optimizers.Optimizer`
+        as the learning rate. The learning rate schedule is also serializable and
+        deserializable using `tf.keras.optimizers.schedules.serialize` and
+        `tf.keras.optimizers.schedules.deserialize`.
+
+        Args:
+            initial_learning_rate: A scalar `float32` or `float64` `Tensor` or a
+                Python number.  The initial learning rate.
+            maximal_learning_rate: A scalar `float32` or `float64` `Tensor` or a
+                Python number.  The maximum learning rate.
+            step_size: A scalar `float32` or `float64` `Tensor` or a
+                Python number. Step size.
+            scale_fn: A function. Scheduling function applied in cycle
+            scale_mode: ['cycle', 'iterations']. Mode to apply during cyclic
+                schedule
+            name: (Optional) Name for the operation.
+
+        Returns:
+            Updated learning rate value.
+        """
+        super(Triangular2CyclicalLearningRate, self).__init__(
+            initial_learning_rate=initial_learning_rate,
+            maximal_learning_rate=maximal_learning_rate,
+            step_size=step_size,
+            scale_fn=lambda x: 1 / (2. ** (x - 1)),
+            scale_mode=scale_mode,
+            name=name,
+        )
+
+
+@keras_utils.register_keras_custom_object
+class ExponentialCyclicalLearningRate(CyclicalLearningRate):
+    def __init__(
+        self,
+        initial_learning_rate,
+        maximal_learning_rate,
+        step_size,
+        scale_mode="iterations",
+        gamma=1.,
+        name="ExponentialCyclicalLearningRate",
+    ):
+        """Applies exponential cyclical schedule to the learning rate.
+
+        See Cyclical Learning Rates for Training Neural Networks. https://arxiv.org/abs/1506.01186
+
+
+        ```python
+        lr_schedule = tf.keras.optimizers.schedules.ExponentialCyclicalLearningRate(
+            initial_learning_rate=1e-4,
+            maximal_learning_rate=1e-2,
+            step_size=2000,
+            scale_mode="cycle",
+            gamma=0.96,
+            name="MyCyclicScheduler")
+
+        model.compile(optimizer=tf.keras.optimizers.SGD(learning_rate=lr_schedule),
+                      loss='sparse_categorical_crossentropy',
+                      metrics=['accuracy'])
+
+        model.fit(data, labels, epochs=5)
+        ```
+
+        You can pass this schedule directly into a `tf.keras.optimizers.Optimizer`
+        as the learning rate. The learning rate schedule is also serializable and
+        deserializable using `tf.keras.optimizers.schedules.serialize` and
+        `tf.keras.optimizers.schedules.deserialize`.
+
+        Args:
+            initial_learning_rate: A scalar `float32` or `float64` `Tensor` or a
+                Python number.  The initial learning rate.
+            maximal_learning_rate: A scalar `float32` or `float64` `Tensor` or a
+                Python number.  The maximum learning rate.
+            step_size: A scalar `float32` or `float64` `Tensor` or a
+                Python number. Step size.
+            scale_fn: A function. Scheduling function applied in cycle
+            scale_mode: ['cycle', 'iterations']. Mode to apply during cyclic
+                schedule
+            gamma: A scalar `float32` or `float64` `Tensor` or a
+                Python number.  Gamma value.
+            name: (Optional) Name for the operation.
+
+        Returns:
+            Updated learning rate value.
+        """
+        super(ExponentialCyclicalLearningRate, self).__init__(
+            initial_learning_rate=initial_learning_rate,
+            maximal_learning_rate=maximal_learning_rate,
+            step_size=step_size,
+            scale_fn=lambda x: gamma ** x,
+            scale_mode=scale_mode,
+            name=name,
+        )

--- a/tensorflow_addons/optimizers/cyclical_learning_rate_test.py
+++ b/tensorflow_addons/optimizers/cyclical_learning_rate_test.py
@@ -46,11 +46,12 @@ class CyclicalLearningRateTest(tf.test.TestCase, parameterized.TestCase):
         maximal_learning_rate = 1
         step_size = 4000
         step = tf.resource_variable_ops.ResourceVariable(0)
-        triangular_cyclical_lr = cyclical_learning_rate.TriangularCyclicalLearningRate(
-            initial_learning_rate=initial_learning_rate,
-            maximal_learning_rate=maximal_learning_rate,
-            step_size=step_size,
-        )
+        triangular_cyclical_lr = (
+            cyclical_learning_rate.TriangularCyclicalLearningRate(
+                initial_learning_rate=initial_learning_rate,
+                maximal_learning_rate=maximal_learning_rate,
+                step_size=step_size,
+            ))
         triangular_cyclical_lr = _maybe_serialized(triangular_cyclical_lr,
                                                    serialize)
 
@@ -74,11 +75,12 @@ class CyclicalLearningRateTest(tf.test.TestCase, parameterized.TestCase):
         maximal_learning_rate = 1
         step_size = 4000
         step = tf.resource_variable_ops.ResourceVariable(0)
-        triangular2_cyclical_lr = cyclical_learning_rate.Triangular2CyclicalLearningRate(
-            initial_learning_rate=initial_learning_rate,
-            maximal_learning_rate=maximal_learning_rate,
-            step_size=step_size,
-        )
+        triangular2_cyclical_lr = (
+            cyclical_learning_rate.Triangular2CyclicalLearningRate(
+                initial_learning_rate=initial_learning_rate,
+                maximal_learning_rate=maximal_learning_rate,
+                step_size=step_size,
+            ))
         triangular2_cyclical_lr = _maybe_serialized(triangular2_cyclical_lr,
                                                     serialize)
 
@@ -110,12 +112,13 @@ class CyclicalLearningRateTest(tf.test.TestCase, parameterized.TestCase):
         gamma = 0.996
 
         step = tf.resource_variable_ops.ResourceVariable(0)
-        exponential_cyclical_lr = cyclical_learning_rate.ExponentialCyclicalLearningRate(
-            initial_learning_rate=initial_learning_rate,
-            maximal_learning_rate=maximal_learning_rate,
-            step_size=step_size,
-            gamma=gamma,
-        )
+        exponential_cyclical_lr = (
+            cyclical_learning_rate.ExponentialCyclicalLearningRate(
+                initial_learning_rate=initial_learning_rate,
+                maximal_learning_rate=maximal_learning_rate,
+                step_size=step_size,
+                gamma=gamma,
+            ))
         exponential_cyclical_lr = _maybe_serialized(exponential_cyclical_lr,
                                                     serialize)
 

--- a/tensorflow_addons/optimizers/cyclical_learning_rate_test.py
+++ b/tensorflow_addons/optimizers/cyclical_learning_rate_test.py
@@ -23,8 +23,7 @@ from absl.testing import parameterized
 import tensorflow as tf
 from tensorflow_addons.utils import test_utils
 import numpy as np
-# from six.moves import xrange  # pylint: disable=redefined-builtin
-# import conditional_gradient as cg_lib
+
 import cyclical_learning_rate
 
 

--- a/tensorflow_addons/optimizers/cyclical_learning_rate_test.py
+++ b/tensorflow_addons/optimizers/cyclical_learning_rate_test.py
@@ -29,16 +29,16 @@ import cyclical_learning_rate
 
 
 def _maybe_serialized(lr_decay, serialize_and_deserialize):
-  if serialize_and_deserialize:
-    serialized = tf.keras.optimizers.learning_rate_schedule.serialize(lr_decay)
-    return tf.keras.optimizers.learning_rate_schedule.deserialize(serialized)
-  else:
-    return lr_decay
+    if serialize_and_deserialize:
+        serialized = tf.keras.optimizers.learning_rate_schedule.serialize(
+            lr_decay)
+        return tf.keras.optimizers.learning_rate_schedule.deserialize(
+            serialized)
+    else:
+        return lr_decay
 
 
-@parameterized.named_parameters(
-    ("NotSerialized", False),
-    ("Serialized", True))
+@parameterized.named_parameters(("NotSerialized", False), ("Serialized", True))
 class CyclicalLearningRateTest(tf.test.TestCase, parameterized.TestCase):
     @test_utils.run_in_graph_and_eager_modes(reset_test=True)
     def testTriangularCyclicalLearningRate(self, serialize):
@@ -51,16 +51,21 @@ class CyclicalLearningRateTest(tf.test.TestCase, parameterized.TestCase):
             maximal_learning_rate=maximal_learning_rate,
             step_size=step_size,
         )
-        triangular_cyclical_lr = _maybe_serialized(triangular_cyclical_lr, serialize)
+        triangular_cyclical_lr = _maybe_serialized(triangular_cyclical_lr,
+                                                   serialize)
 
         self.evaluate(tf.compat.v1.global_variables_initializer())
         expected = np.concatenate([
-            np.linspace(initial_learning_rate, maximal_learning_rate, num=2001)[1:],
-            np.linspace(maximal_learning_rate, initial_learning_rate, num=2001)[1:]
+            np.linspace(
+                initial_learning_rate, maximal_learning_rate, num=2001)[1:],
+            np.linspace(
+                maximal_learning_rate, initial_learning_rate, num=2001)[1:]
         ])
 
         for expected_value in expected:
-            self.assertAllClose(self.evaluate(triangular_cyclical_lr(step)), expected_value, 1e-6)
+            self.assertAllClose(
+                self.evaluate(triangular_cyclical_lr(step)), expected_value,
+                1e-6)
             self.evaluate(step.assign_add(1))
 
     @test_utils.run_in_graph_and_eager_modes(reset_test=True)
@@ -69,21 +74,32 @@ class CyclicalLearningRateTest(tf.test.TestCase, parameterized.TestCase):
         maximal_learning_rate = 1
         step_size = 4000
         step = tf.resource_variable_ops.ResourceVariable(0)
-        triangular_cyclical_lr = cyclical_learning_rate.TriangularCyclicalLearningRate(
+        triangular2_cyclical_lr = cyclical_learning_rate.Triangular2CyclicalLearningRate(
             initial_learning_rate=initial_learning_rate,
             maximal_learning_rate=maximal_learning_rate,
             step_size=step_size,
         )
-        triangular_cyclical_lr = _maybe_serialized(triangular_cyclical_lr, serialize)
+        triangular2_cyclical_lr = _maybe_serialized(triangular2_cyclical_lr,
+                                                    serialize)
 
         self.evaluate(tf.compat.v1.global_variables_initializer())
+        middle_learning_rate = (
+            maximal_learning_rate + initial_learning_rate) / 2
         expected = np.concatenate([
-            np.linspace(initial_learning_rate, maximal_learning_rate, num=2001)[1:],
-            np.linspace(maximal_learning_rate, initial_learning_rate, num=2001)[1:]
+            np.linspace(
+                initial_learning_rate, maximal_learning_rate, num=2001)[1:],
+            np.linspace(
+                maximal_learning_rate, initial_learning_rate, num=2001)[1:],
+            np.linspace(initial_learning_rate, middle_learning_rate,
+                        num=2001)[1:],
+            np.linspace(middle_learning_rate, initial_learning_rate,
+                        num=2001)[1:],
         ])
 
         for expected_value in expected:
-            self.assertAllClose(self.evaluate(triangular_cyclical_lr(step)), expected_value, 1e-6)
+            self.assertAllClose(
+                self.evaluate(triangular2_cyclical_lr(step)), expected_value,
+                1e-6)
             self.evaluate(step.assign_add(1))
 
     @test_utils.run_in_graph_and_eager_modes(reset_test=True)
@@ -94,17 +110,23 @@ class CyclicalLearningRateTest(tf.test.TestCase, parameterized.TestCase):
         gamma = 0.996
 
         step = tf.resource_variable_ops.ResourceVariable(0)
-        triangular2_cyclical_lr = cyclical_learning_rate.ExponentialCyclicalLearningRate(
+        exponential_cyclical_lr = cyclical_learning_rate.ExponentialCyclicalLearningRate(
             initial_learning_rate=initial_learning_rate,
             maximal_learning_rate=maximal_learning_rate,
             step_size=step_size,
             gamma=gamma,
         )
-        triangular2_cyclical_lr = _maybe_serialized(triangular2_cyclical_lr, serialize)
+        exponential_cyclical_lr = _maybe_serialized(exponential_cyclical_lr,
+                                                    serialize)
 
         self.evaluate(tf.compat.v1.global_variables_initializer())
 
-        for _ in range(8000):
-            expected = 0  # TODO
-            self.assertAllClose(self.evaluate(triangular2_cyclical_lr(step)), expected, 1e-6)
+        for i in range(1, 8001):
+            non_bounded_value = np.abs(i / 2000. -
+                                       2 * np.floor(1 + i / (2 * 2000)) + 1)
+            expected = initial_learning_rate + (
+                maximal_learning_rate - initial_learning_rate) * np.maximum(
+                    0, (1 - non_bounded_value)) * (gamma**i)
+            self.assertAllClose(
+                self.evaluate(exponential_cyclical_lr(step)), expected, 1e-6)
             self.evaluate(step.assign_add(1))

--- a/tensorflow_addons/optimizers/cyclical_learning_rate_test.py
+++ b/tensorflow_addons/optimizers/cyclical_learning_rate_test.py
@@ -1,0 +1,41 @@
+# Copyright 2019 The TensorFlow Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ==============================================================================
+"""Tests for Cyclical Learning Rate."""
+
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+
+from absl.testing import parameterized
+
+import tensorflow as tf
+from tensorflow_addons.utils import test_utils
+import numpy as np
+# from six.moves import xrange  # pylint: disable=redefined-builtin
+# import conditional_gradient as cg_lib
+import cyclical_learning_rate
+
+
+@parameterized.named_parameters(
+    ("NotSerialized", False),
+    ("Serialized", True))
+class CyclicalLearningRateTest(tf.test.TestCase):
+    def testCycleMode(self, serialize):
+        with self.cached_session():
+            self.assertEqual(cyclical_learning_rate.CyclicalLearningRate(name="toto").name, "toto")
+
+    def testNonCycleMode(self, serialize):
+        with self.cached_session():
+            self.assertEqual()


### PR DESCRIPTION
Migrating CyclicLR from keras-team/keras-contrib as discussed in https://github.com/keras-team/keras-contrib/issues/519.

- @gabrieldemarmiesse & @seanpmorgan would love some feedback on implementation
- @seanpmorgan is there any recommendations regarding tests? I plan on taking inspiration from [tf core schedulers](https://github.com/tensorflow/tensorflow/blob/master/tensorflow/python/keras/optimizer_v2/learning_rate_schedule_test.py), does it seem ok to you?