### PR TITLE
Build data_init layer under name_scope

### DIFF
--- a/tensorflow_addons/layers/wrappers.py
+++ b/tensorflow_addons/layers/wrappers.py
@@ -93,12 +93,13 @@ class WeightNormalization(tf.keras.layers.Wrapper):
 
         if self.data_init:
             # Used for data initialization in self._data_dep_init.
-            layer_config = tf.keras.layers.serialize(self.layer)
-            layer_config['config']['trainable'] = False
-            self._naked_clone_layer = tf.keras.layers.deserialize(layer_config)
-            self._naked_clone_layer.build(input_shape)
-            self._naked_clone_layer.set_weights(self.layer.get_weights())
-            self._naked_clone_layer.activation = None
+            with tf.name_scope('data_dep_init'):
+                layer_config = tf.keras.layers.serialize(self.layer)
+                layer_config['config']['trainable'] = False
+                self._naked_clone_layer = tf.keras.layers.deserialize(layer_config)
+                self._naked_clone_layer.build(input_shape)
+                self._naked_clone_layer.set_weights(self.layer.get_weights())
+                self._naked_clone_layer.activation = None
 
         self.built = True
 

--- a/tensorflow_addons/layers/wrappers.py
+++ b/tensorflow_addons/layers/wrappers.py
@@ -96,7 +96,8 @@ class WeightNormalization(tf.keras.layers.Wrapper):
             with tf.name_scope('data_dep_init'):
                 layer_config = tf.keras.layers.serialize(self.layer)
                 layer_config['config']['trainable'] = False
-                self._naked_clone_layer = tf.keras.layers.deserialize(layer_config)
+                self._naked_clone_layer = tf.keras.layers.deserialize(
+                    layer_config)
                 self._naked_clone_layer.build(input_shape)
                 self._naked_clone_layer.set_weights(self.layer.get_weights())
                 self._naked_clone_layer.activation = None

--- a/tensorflow_addons/layers/wrappers_test.py
+++ b/tensorflow_addons/layers/wrappers_test.py
@@ -82,15 +82,12 @@ class WeightNormalizationTest(tf.test.TestCase):
         model = tf.keras.Model(inputs, out)
 
     def test_save_file_h5(self):
+        self.create_tempfile('wrapper_test_model.h5')
         conv = tf.keras.layers.Conv1D(1, 1)
         wn_conv = wrappers.WeightNormalization(conv)
         model = tf.keras.Sequential(layers=[wn_conv])
         model.build([1, 2, 3])
-        model.save_weights('/tmp/model.h5')
-
-        import os
-        os.remove('/tmp/model.h5')
-        # TODO: Find a better way to test this
+        model.save_weights('wrapper_test_model.h5')
 
 
 if __name__ == "__main__":

--- a/tensorflow_addons/layers/wrappers_test.py
+++ b/tensorflow_addons/layers/wrappers_test.py
@@ -81,6 +81,17 @@ class WeightNormalizationTest(tf.test.TestCase):
         out = tf.keras.layers.TimeDistributed(b)(inputs)
         model = tf.keras.Model(inputs, out)
 
+    def test_save_file_h5(self):
+        conv = tf.keras.layers.Conv1D(1, 1)
+        wn_conv = wrappers.WeightNormalization(conv)
+        model = tf.keras.Sequential(layers=[wn_conv])
+        model.build([1, 2, 3])
+        model.save_weights('/tmp/model.h5')
+
+        import os
+        os.remove('/tmp/model.h5')
+        # TODO: Find a better way to test this
+
 
 if __name__ == "__main__":
     tf.test.main()


### PR DESCRIPTION
The original wrapped layer and the non-trainable layer created for data-dependent initialization had a clash in their namespaces. Creating the second layer under a name scope of 'data_dep_init' fixes the issue.

Fixes #624 