### PR TITLE
Test in eager model

### DIFF
--- a/tensorflow_addons/image/transform_ops_test.py
+++ b/tensorflow_addons/image/transform_ops_test.py
@@ -69,9 +69,7 @@ class ImageOpsTest(tf.test.TestCase):
     def test_transform_static_output_shape(self):
         image = tf.constant([[1., 2.], [3., 4.]])
         result = transform_ops.transform(
-            image,
-            tf.random.uniform([8], -1, 1),
-            output_shape=[3, 5])
+            image, tf.random.uniform([8], -1, 1), output_shape=[3, 5])
         self.assertAllEqual([3, 5], result.shape)
 
     def test_transform_unknown_shape(self):

--- a/tensorflow_addons/image/transform_ops_test.py
+++ b/tensorflow_addons/image/transform_ops_test.py
@@ -30,8 +30,8 @@ _DTYPES = set([
 ])
 
 
+@test_utils.run_all_in_graph_and_eager_modes
 class ImageOpsTest(tf.test.TestCase):
-    @test_utils.run_in_graph_and_eager_modes
     def test_compose(self):
         for dtype in _DTYPES:
             with test_utils.use_gpu():
@@ -52,7 +52,6 @@ class ImageOpsTest(tf.test.TestCase):
                     [[0, 0, 0, 0], [0, 1, 0, 1], [0, 1, 0, 1], [0, 1, 1, 1]],
                     image_transformed)
 
-    @test_utils.run_in_graph_and_eager_modes
     def test_extreme_projective_transform(self):
         for dtype in _DTYPES:
             with test_utils.use_gpu():
@@ -72,10 +71,9 @@ class ImageOpsTest(tf.test.TestCase):
         result = transform_ops.transform(
             image,
             tf.random.uniform([8], -1, 1),
-            output_shape=tf.constant([3, 5]))
+            output_shape=[3, 5])
         self.assertAllEqual([3, 5], result.shape)
 
-    @test_utils.run_in_graph_and_eager_modes
     def test_transform_unknown_shape(self):
         fn = transform_ops.transform.get_concrete_function(
             tf.TensorSpec(shape=None, dtype=tf.float32),
@@ -113,7 +111,6 @@ class ImageOpsTest(tf.test.TestCase):
 
         self.assertAllClose(theoretical[0], numerical[0])
 
-    @test_utils.run_in_graph_and_eager_modes
     def test_grad(self):
         self._test_grad([16, 16])
         self._test_grad([4, 12, 12])
@@ -122,7 +119,6 @@ class ImageOpsTest(tf.test.TestCase):
         self._test_grad([4, 12, 3], [8, 24, 3])
         self._test_grad([3, 4, 12, 3], [3, 8, 24, 3])
 
-    @test_utils.run_in_graph_and_eager_modes
     def test_transform_data_types(self):
         for dtype in _DTYPES:
             image = tf.constant([[1, 2], [3, 4]], dtype=dtype)
@@ -130,7 +126,6 @@ class ImageOpsTest(tf.test.TestCase):
                 np.array([[4, 4], [4, 4]]).astype(dtype.as_numpy_dtype()),
                 transform_ops.transform(image, [1] * 8))
 
-    @test_utils.run_in_graph_and_eager_modes
     def test_transform_eager(self):
         image = tf.constant([[1., 2.], [3., 4.]])
         self.assertAllEqual(

--- a/tensorflow_addons/layers/BUILD
+++ b/tensorflow_addons/layers/BUILD
@@ -77,7 +77,7 @@ py_test(
 )
 
 py_test(
-    name = "layers_normalizations_test",
+    name = "normalizations_test",
     size = "small",
     srcs = [
         "normalizations_test.py",

--- a/tensorflow_addons/layers/normalizations_test.py
+++ b/tensorflow_addons/layers/normalizations_test.py
@@ -52,7 +52,9 @@ class NormalizationTest(tf.test.TestCase):
             reshaped_inputs, group_shape = group_layer._reshape_into_groups(
                 inputs, (10, 10, 10), tensor_input_shape)
             for i in range(len(expected_shape)):
-                tf.assertEqual(tf.cast(group_shape[i],tf.int32), tf.cast(expected_shape[i], tf.int32))
+                tf.assertEqual(
+                    tf.cast(group_shape[i], tf.int32),
+                    tf.cast(expected_shape[i], tf.int32))
 
         input_shape = (10, 10, 10)
         expected_shape = [10, 5, 10, 2]

--- a/tensorflow_addons/layers/normalizations_test.py
+++ b/tensorflow_addons/layers/normalizations_test.py
@@ -24,6 +24,7 @@ from tensorflow_addons.layers.normalizations import InstanceNormalization
 from tensorflow_addons.utils import test_utils
 
 
+@test_utils.run_all_in_graph_and_eager_modes
 class NormalizationTest(tf.test.TestCase):
 
     # ------------Tests to ensure proper inheritance. If these suceed you can
@@ -50,7 +51,8 @@ class NormalizationTest(tf.test.TestCase):
             reshaped_inputs, group_shape = group_layer._reshape_into_groups(
                 inputs, (10, 10, 10), tensor_input_shape)
             for i in range(len(expected_shape)):
-                self.assertEqual(int(group_shape[i]), expected_shape[i])
+                self.assertEqual(
+                    self.evaluate(group_shape[i]), expected_shape[i])
 
         input_shape = (10, 10, 10)
         expected_shape = [10, 5, 10, 2]
@@ -99,13 +101,13 @@ class NormalizationTest(tf.test.TestCase):
             axis=axis, groups=groups, center=center, scale=scale)
         model = tf.keras.models.Sequential()
         model.add(layer)
-        outputs = model.predict(inputs)
+        outputs = model.predict(inputs, steps=1)
         self.assertFalse(np.isnan(outputs).any())
 
         # Create shapes
         if groups is -1:
             groups = input_shape[axis]
-        np_inputs = inputs.numpy()
+        np_inputs = self.evaluate(inputs)
         reshaped_dims = list(np_inputs.shape)
         reshaped_dims[axis] = reshaped_dims[axis] // groups
         reshaped_dims.insert(1, groups)
@@ -134,8 +136,9 @@ class NormalizationTest(tf.test.TestCase):
         output_test = gamma * zeroed * rsqrt + beta
 
         # compare outputs
-        output_test = np.reshape(output_test, input_shape.as_list())
-        self.assertAlmostEqual(np.mean(output_test - outputs), 0, places=7)
+        output_test = tf.reshape(output_test, input_shape)
+        self.assertAlmostEqual(
+            self.evaluate(tf.reduce_mean(output_test - outputs)), 0, places=7)
 
     def _create_and_fit_Sequential_model(self, layer, shape):
         # Helperfunction for quick evaluation
@@ -153,7 +156,6 @@ class NormalizationTest(tf.test.TestCase):
         model.fit(x=input_batch, y=output_batch, epochs=1, batch_size=1)
         return model
 
-    @test_utils.run_in_graph_and_eager_modes
     def test_weights(self):
         # Check if weights get initialized correctly
         layer = GroupNormalization(groups=1, scale=False, center=False)
@@ -174,15 +176,15 @@ class NormalizationTest(tf.test.TestCase):
         normalized_input = layer._apply_normalization(reshaped_inputs,
                                                       input_shape)
         self.assertTrue(
-            tf.reduce_all(
-                tf.equal(normalized_input,
-                         tf.constant([[[0.0, 0.0], [0.0, 0.0]]]))))
+            np.all(
+                np.equal(
+                    self.evaluate(normalized_input),
+                    np.array([[[0.0, 0.0], [0.0, 0.0]]]))))
 
     def test_axis_error(self):
         with self.assertRaises(ValueError):
             GroupNormalization(axis=0)
 
-    @test_utils.run_in_graph_and_eager_modes
     def test_groupnorm_flat(self):
         # Check basic usage of groupnorm_flat
         # Testing for 1 == LayerNorm, 16 == GroupNorm, -1 == InstanceNorm
@@ -195,7 +197,6 @@ class NormalizationTest(tf.test.TestCase):
             self.assertTrue(hasattr(model.layers[0], 'gamma'))
             self.assertTrue(hasattr(model.layers[0], 'beta'))
 
-    @test_utils.run_in_graph_and_eager_modes
     def test_instancenorm_flat(self):
         # Check basic usage of instancenorm
         model = self._create_and_fit_Sequential_model(InstanceNormalization(),
@@ -203,7 +204,6 @@ class NormalizationTest(tf.test.TestCase):
         self.assertTrue(hasattr(model.layers[0], 'gamma'))
         self.assertTrue(hasattr(model.layers[0], 'beta'))
 
-    @test_utils.run_in_graph_and_eager_modes
     def test_initializer(self):
         # Check if the initializer for gamma and beta is working correctly
         layer = GroupNormalization(
@@ -219,7 +219,6 @@ class NormalizationTest(tf.test.TestCase):
         negativ = weights[weights < 0.0]
         self.assertTrue(len(negativ) == 0)
 
-    @test_utils.run_in_graph_and_eager_modes
     def test_regularizations(self):
         layer = GroupNormalization(
             gamma_regularizer='l1', beta_regularizer='l1', groups=4, axis=2)
@@ -232,7 +231,6 @@ class NormalizationTest(tf.test.TestCase):
         self.assertEqual(layer.gamma.constraint, max_norm)
         self.assertEqual(layer.beta.constraint, max_norm)
 
-    @test_utils.run_in_graph_and_eager_modes
     def test_groupnorm_conv(self):
         # Check if Axis is working for CONV nets
         # Testing for 1 == LayerNorm, 5 == GroupNorm, -1 == InstanceNorm

--- a/tensorflow_addons/layers/normalizations_test.py
+++ b/tensorflow_addons/layers/normalizations_test.py
@@ -24,6 +24,8 @@ from tensorflow_addons.layers.normalizations import InstanceNormalization
 from tensorflow_addons.utils import test_utils
 
 
+@test_utils.run_all_in_graph_and_eager_modes
+@tf.function
 class NormalizationTest(tf.test.TestCase):
 
     # ------------Tests to ensure proper inheritance. If these suceed you can
@@ -50,7 +52,8 @@ class NormalizationTest(tf.test.TestCase):
             reshaped_inputs, group_shape = group_layer._reshape_into_groups(
                 inputs, (10, 10, 10), tensor_input_shape)
             for i in range(len(expected_shape)):
-                self.assertEqual(int(group_shape[i]), expected_shape[i])
+                # self.assertEqual(int(group_shape[i]), expected_shape[i])
+                tf.assertEqual(tf.cast(group_shape[i],tf.int32), tf.cast(expected_shape[i], tf.int32))
 
         input_shape = (10, 10, 10)
         expected_shape = [10, 5, 10, 2]
@@ -153,7 +156,6 @@ class NormalizationTest(tf.test.TestCase):
         model.fit(x=input_batch, y=output_batch, epochs=1, batch_size=1)
         return model
 
-    @test_utils.run_in_graph_and_eager_modes
     def test_weights(self):
         # Check if weights get initialized correctly
         layer = GroupNormalization(groups=1, scale=False, center=False)
@@ -184,7 +186,7 @@ class NormalizationTest(tf.test.TestCase):
         with self.assertRaises(ValueError):
             GroupNormalization(axis=0)
 
-    @test_utils.run_in_graph_and_eager_modes
+    # @test_utils.run_in_graph_and_eager_modes
     def test_groupnorm_flat(self):
         # Check basic usage of groupnorm_flat
         # Testing for 1 == LayerNorm, 16 == GroupNorm, -1 == InstanceNorm
@@ -197,7 +199,7 @@ class NormalizationTest(tf.test.TestCase):
             self.assertTrue(hasattr(model.layers[0], 'gamma'))
             self.assertTrue(hasattr(model.layers[0], 'beta'))
 
-    @test_utils.run_in_graph_and_eager_modes
+    # @test_utils.run_in_graph_and_eager_modes
     def test_instancenorm_flat(self):
         # Check basic usage of instancenorm
 
@@ -206,7 +208,7 @@ class NormalizationTest(tf.test.TestCase):
         self.assertTrue(hasattr(model.layers[0], 'gamma'))
         self.assertTrue(hasattr(model.layers[0], 'beta'))
 
-    @test_utils.run_in_graph_and_eager_modes
+    # @test_utils.run_in_graph_and_eager_modes
     def test_initializer(self):
         # Check if the initializer for gamma and beta is working correctly
 
@@ -223,7 +225,7 @@ class NormalizationTest(tf.test.TestCase):
         negativ = weights[weights < 0.0]
         self.assertTrue(len(negativ) == 0)
 
-    @test_utils.run_in_graph_and_eager_modes
+    # @test_utils.run_in_graph_and_eager_modes
     def test_regularizations(self):
 
         layer = GroupNormalization(
@@ -237,7 +239,7 @@ class NormalizationTest(tf.test.TestCase):
         self.assertEqual(layer.gamma.constraint, max_norm)
         self.assertEqual(layer.beta.constraint, max_norm)
 
-    @test_utils.run_in_graph_and_eager_modes
+    # @test_utils.run_in_graph_and_eager_modes
     def test_groupnorm_conv(self):
         # Check if Axis is working for CONV nets
         # Testing for 1 == LayerNorm, 5 == GroupNorm, -1 == InstanceNorm

--- a/tensorflow_addons/layers/normalizations_test.py
+++ b/tensorflow_addons/layers/normalizations_test.py
@@ -187,7 +187,6 @@ class NormalizationTest(tf.test.TestCase):
         with self.assertRaises(ValueError):
             GroupNormalization(axis=0)
 
-    # @test_utils.run_in_graph_and_eager_modes
     def test_groupnorm_flat(self):
         # Check basic usage of groupnorm_flat
         # Testing for 1 == LayerNorm, 16 == GroupNorm, -1 == InstanceNorm
@@ -200,7 +199,6 @@ class NormalizationTest(tf.test.TestCase):
             self.assertTrue(hasattr(model.layers[0], 'gamma'))
             self.assertTrue(hasattr(model.layers[0], 'beta'))
 
-    # @test_utils.run_in_graph_and_eager_modes
     def test_instancenorm_flat(self):
         # Check basic usage of instancenorm
 
@@ -209,7 +207,6 @@ class NormalizationTest(tf.test.TestCase):
         self.assertTrue(hasattr(model.layers[0], 'gamma'))
         self.assertTrue(hasattr(model.layers[0], 'beta'))
 
-    # @test_utils.run_in_graph_and_eager_modes
     def test_initializer(self):
         # Check if the initializer for gamma and beta is working correctly
 
@@ -226,7 +223,6 @@ class NormalizationTest(tf.test.TestCase):
         negativ = weights[weights < 0.0]
         self.assertTrue(len(negativ) == 0)
 
-    # @test_utils.run_in_graph_and_eager_modes
     def test_regularizations(self):
 
         layer = GroupNormalization(
@@ -240,7 +236,6 @@ class NormalizationTest(tf.test.TestCase):
         self.assertEqual(layer.gamma.constraint, max_norm)
         self.assertEqual(layer.beta.constraint, max_norm)
 
-    # @test_utils.run_in_graph_and_eager_modes
     def test_groupnorm_conv(self):
         # Check if Axis is working for CONV nets
         # Testing for 1 == LayerNorm, 5 == GroupNorm, -1 == InstanceNorm

--- a/tensorflow_addons/layers/normalizations_test.py
+++ b/tensorflow_addons/layers/normalizations_test.py
@@ -52,7 +52,6 @@ class NormalizationTest(tf.test.TestCase):
             reshaped_inputs, group_shape = group_layer._reshape_into_groups(
                 inputs, (10, 10, 10), tensor_input_shape)
             for i in range(len(expected_shape)):
-                # self.assertEqual(int(group_shape[i]), expected_shape[i])
                 tf.assertEqual(tf.cast(group_shape[i],tf.int32), tf.cast(expected_shape[i], tf.int32))
 
         input_shape = (10, 10, 10)

--- a/tensorflow_addons/layers/normalizations_test.py
+++ b/tensorflow_addons/layers/normalizations_test.py
@@ -24,8 +24,6 @@ from tensorflow_addons.layers.normalizations import InstanceNormalization
 from tensorflow_addons.utils import test_utils
 
 
-@test_utils.run_all_in_graph_and_eager_modes
-@tf.function
 class NormalizationTest(tf.test.TestCase):
 
     # ------------Tests to ensure proper inheritance. If these suceed you can
@@ -52,9 +50,7 @@ class NormalizationTest(tf.test.TestCase):
             reshaped_inputs, group_shape = group_layer._reshape_into_groups(
                 inputs, (10, 10, 10), tensor_input_shape)
             for i in range(len(expected_shape)):
-                tf.assertEqual(
-                    tf.cast(group_shape[i], tf.int32),
-                    tf.cast(expected_shape[i], tf.int32))
+                self.assertEqual(int(group_shape[i]), expected_shape[i])
 
         input_shape = (10, 10, 10)
         expected_shape = [10, 5, 10, 2]
@@ -157,6 +153,7 @@ class NormalizationTest(tf.test.TestCase):
         model.fit(x=input_batch, y=output_batch, epochs=1, batch_size=1)
         return model
 
+    @test_utils.run_in_graph_and_eager_modes
     def test_weights(self):
         # Check if weights get initialized correctly
         layer = GroupNormalization(groups=1, scale=False, center=False)
@@ -170,7 +167,6 @@ class NormalizationTest(tf.test.TestCase):
         self.assertEqual(len(layer.weights), 2)
 
     def test_apply_normalization(self):
-
         input_shape = (1, 4)
         expected_shape = (1, 2, 2)
         reshaped_inputs = tf.constant([[[2.0, 2.0], [3.0, 3.0]]])
@@ -183,10 +179,10 @@ class NormalizationTest(tf.test.TestCase):
                          tf.constant([[[0.0, 0.0], [0.0, 0.0]]]))))
 
     def test_axis_error(self):
-
         with self.assertRaises(ValueError):
             GroupNormalization(axis=0)
 
+    @test_utils.run_in_graph_and_eager_modes
     def test_groupnorm_flat(self):
         # Check basic usage of groupnorm_flat
         # Testing for 1 == LayerNorm, 16 == GroupNorm, -1 == InstanceNorm
@@ -199,17 +195,17 @@ class NormalizationTest(tf.test.TestCase):
             self.assertTrue(hasattr(model.layers[0], 'gamma'))
             self.assertTrue(hasattr(model.layers[0], 'beta'))
 
+    @test_utils.run_in_graph_and_eager_modes
     def test_instancenorm_flat(self):
         # Check basic usage of instancenorm
-
         model = self._create_and_fit_Sequential_model(InstanceNormalization(),
                                                       (64,))
         self.assertTrue(hasattr(model.layers[0], 'gamma'))
         self.assertTrue(hasattr(model.layers[0], 'beta'))
 
+    @test_utils.run_in_graph_and_eager_modes
     def test_initializer(self):
         # Check if the initializer for gamma and beta is working correctly
-
         layer = GroupNormalization(
             groups=32,
             beta_initializer='random_normal',
@@ -223,8 +219,8 @@ class NormalizationTest(tf.test.TestCase):
         negativ = weights[weights < 0.0]
         self.assertTrue(len(negativ) == 0)
 
+    @test_utils.run_in_graph_and_eager_modes
     def test_regularizations(self):
-
         layer = GroupNormalization(
             gamma_regularizer='l1', beta_regularizer='l1', groups=4, axis=2)
         layer.build((None, 4, 4))
@@ -236,10 +232,10 @@ class NormalizationTest(tf.test.TestCase):
         self.assertEqual(layer.gamma.constraint, max_norm)
         self.assertEqual(layer.beta.constraint, max_norm)
 
+    @test_utils.run_in_graph_and_eager_modes
     def test_groupnorm_conv(self):
         # Check if Axis is working for CONV nets
         # Testing for 1 == LayerNorm, 5 == GroupNorm, -1 == InstanceNorm
-
         groups = [-1, 5, 1]
         for i in groups:
             model = tf.keras.models.Sequential()

--- a/tensorflow_addons/metrics/r_square_test.py
+++ b/tensorflow_addons/metrics/r_square_test.py
@@ -24,7 +24,6 @@ from tensorflow_addons.utils import test_utils
 
 
 @test_utils.run_all_in_graph_and_eager_modes
-@tf.function
 class RSquareTest(tf.test.TestCase):
     def test_config(self):
         r2_obj = RSquare(name='r_square')
@@ -50,8 +49,8 @@ class RSquareTest(tf.test.TestCase):
     def test_r2_perfect_score(self):
         actuals = tf.constant([100, 700, 40, 5.7], dtype=tf.float32)
         preds = tf.constant([100, 700, 40, 5.7], dtype=tf.float32)
-        actuals = tf.constant(actuals, dtype=tf.float32)
-        preds = tf.constant(preds, dtype=tf.float32)
+        actuals = tf.cast(actuals, dtype=tf.float32)
+        preds = tf.cast(preds, dtype=tf.float32)
         # Initialize
         r2_obj = self.initialize_vars()
         # Update
@@ -62,8 +61,8 @@ class RSquareTest(tf.test.TestCase):
     def test_r2_worst_score(self):
         actuals = tf.constant([10, 600, 4, 9.77], dtype=tf.float32)
         preds = tf.constant([1, 70, 40, 5.7], dtype=tf.float32)
-        actuals = tf.constant(actuals, dtype=tf.float32)
-        preds = tf.constant(preds, dtype=tf.float32)
+        actuals = tf.cast(actuals, dtype=tf.float32)
+        preds = tf.cast(preds, dtype=tf.float32)
         # Initialize
         r2_obj = self.initialize_vars()
         # Update
@@ -74,8 +73,8 @@ class RSquareTest(tf.test.TestCase):
     def test_r2_random_score(self):
         actuals = tf.constant([10, 600, 3, 9.77], dtype=tf.float32)
         preds = tf.constant([1, 340, 40, 5.7], dtype=tf.float32)
-        actuals = tf.constant(actuals, dtype=tf.float32)
-        preds = tf.constant(preds, dtype=tf.float32)
+        actuals = tf.cast(actuals, dtype=tf.float32)
+        preds = tf.cast(preds, dtype=tf.float32)
         # Initialize
         r2_obj = self.initialize_vars()
         # Update

--- a/tensorflow_addons/metrics/r_square_test.py
+++ b/tensorflow_addons/metrics/r_square_test.py
@@ -20,8 +20,11 @@ from __future__ import print_function
 
 import tensorflow as tf
 from tensorflow_addons.metrics import RSquare
+from tensorflow_addons.utils import test_utils
 
 
+@test_utils.run_all_in_graph_and_eager_modes
+@tf.function
 class RSquareTest(tf.test.TestCase):
     def test_config(self):
         r2_obj = RSquare(name='r_square')

--- a/tensorflow_addons/optimizers/conditional_gradient_test.py
+++ b/tensorflow_addons/optimizers/conditional_gradient_test.py
@@ -25,6 +25,7 @@ from six.moves import xrange  # pylint: disable=redefined-builtin
 import conditional_gradient as cg_lib
 
 
+@test_utils.run_all_in_graph_and_eager_modes
 class ConditionalGradientTest(tf.test.TestCase):
     def _update_conditional_gradient_numpy(self, var, norm, g, lr, lambda_):
         var = var * lr - (1 - lr) * lambda_ * g / norm
@@ -104,20 +105,16 @@ class ConditionalGradientTest(tf.test.TestCase):
                           - (1 - 0.5) * 0.01 * 0.01 / norm1]),
                 self.evaluate(var1))
 
-    @test_utils.run_in_graph_and_eager_modes(reset_test=True)
     def testBasic(self):
         with self.cached_session():
             self.doTestBasic(use_resource=False)
 
-    @test_utils.run_in_graph_and_eager_modes(reset_test=True)
     def testResourceBasic(self):
         self.doTestBasic(use_resource=True)
 
-    @test_utils.run_in_graph_and_eager_modes(reset_test=True)
     def testBasicCallableParams(self):
         self.doTestBasic(use_resource=True, use_callable_params=True)
 
-    @test_utils.run_in_graph_and_eager_modes(reset_test=True)
     def testVariablesAcrossGraphs(self):
         optimizer = cg_lib.ConditionalGradient(0.01, 0.5)
         with tf.Graph().as_default():
@@ -148,7 +145,6 @@ class ConditionalGradientTest(tf.test.TestCase):
         else:
             return [tf.half, tf.float32, tf.float64]
 
-    @test_utils.run_in_graph_and_eager_modes(reset_test=True)
     def testMinimizeSparseResourceVariable(self):
         # This test invokes the ResourceSparseApplyConditionalGradient
         # operation. And it will call the 'ResourceScatterUpdate' OpKernel
@@ -194,7 +190,6 @@ class ConditionalGradientTest(tf.test.TestCase):
                 (1 - learning_rate) * lambda_ * grads0_1 / norm0
             ]], self.evaluate(var0))
 
-    @test_utils.run_in_graph_and_eager_modes(reset_test=True)
     def testMinimizeWith2DIndiciesForEmbeddingLookup(self):
         # This test invokes the ResourceSparseApplyConditionalGradient
         # operation.
@@ -224,7 +219,6 @@ class ConditionalGradientTest(tf.test.TestCase):
                  learning_rate * 1 - (1 - learning_rate) * lambda_ * 1 / norm0
              ]], self.evaluate(var0))
 
-    @test_utils.run_in_graph_and_eager_modes(reset_test=True)
     def testTensorLearningRateAndConditionalGradient(self):
         for dtype in [tf.half, tf.float32, tf.float64]:
             with self.cached_session():
@@ -397,7 +391,6 @@ class ConditionalGradientTest(tf.test.TestCase):
         # pylint: enable=line-too-long
         return db_grad, db_out
 
-    @test_utils.run_in_graph_and_eager_modes(reset_test=True)
     def testLikeDistBeliefCG01(self):
         with self.cached_session():
             db_grad, db_out = self._dbParamsCG01()
@@ -417,7 +410,6 @@ class ConditionalGradientTest(tf.test.TestCase):
                     cg_update.run(feed_dict={grads0: db_grad[i]})
                 self.assertAllClose(np.array(db_out[i]), self.evaluate(var0))
 
-    @test_utils.run_in_graph_and_eager_modes(reset_test=True)
     def testSparse(self):
         # TODO:
         #       To address the issue #347.
@@ -516,7 +508,6 @@ class ConditionalGradientTest(tf.test.TestCase):
                               (1 - learning_rate) * lambda_ * 0.01 / norm1]),
                     self.evaluate(var1)[2])
 
-    @test_utils.run_in_graph_and_eager_modes(reset_test=True)
     def testSharing(self):
         for dtype in [tf.half, tf.float32, tf.float64]:
             with self.cached_session():

--- a/tensorflow_addons/optimizers/cyclical_learning_rate_test.py
+++ b/tensorflow_addons/optimizers/cyclical_learning_rate_test.py
@@ -36,6 +36,7 @@ def _maybe_serialized(lr_decay, serialize_and_deserialize):
     else:
         return lr_decay
 
+
 @test_utils.run_all_in_graph_and_eager_modes
 @parameterized.named_parameters(("NotSerialized", False), ("Serialized", True))
 class CyclicalLearningRateTest(tf.test.TestCase, parameterized.TestCase):

--- a/tensorflow_addons/optimizers/cyclical_learning_rate_test.py
+++ b/tensorflow_addons/optimizers/cyclical_learning_rate_test.py
@@ -36,10 +36,9 @@ def _maybe_serialized(lr_decay, serialize_and_deserialize):
     else:
         return lr_decay
 
-
+@test_utils.run_all_in_graph_and_eager_modes
 @parameterized.named_parameters(("NotSerialized", False), ("Serialized", True))
 class CyclicalLearningRateTest(tf.test.TestCase, parameterized.TestCase):
-    @test_utils.run_in_graph_and_eager_modes(reset_test=True)
     def testTriangularCyclicalLearningRate(self, serialize):
         initial_learning_rate = 0.1
         maximal_learning_rate = 1
@@ -68,7 +67,6 @@ class CyclicalLearningRateTest(tf.test.TestCase, parameterized.TestCase):
                 1e-6)
             self.evaluate(step.assign_add(1))
 
-    @test_utils.run_in_graph_and_eager_modes(reset_test=True)
     def testTriangular2CyclicalLearningRate(self, serialize):
         initial_learning_rate = 0.1
         maximal_learning_rate = 1
@@ -103,7 +101,6 @@ class CyclicalLearningRateTest(tf.test.TestCase, parameterized.TestCase):
                 1e-6)
             self.evaluate(step.assign_add(1))
 
-    @test_utils.run_in_graph_and_eager_modes(reset_test=True)
     def testExponentialCyclicalLearningRate(self, serialize):
         initial_learning_rate = 0.1
         maximal_learning_rate = 1
@@ -133,7 +130,6 @@ class CyclicalLearningRateTest(tf.test.TestCase, parameterized.TestCase):
                 self.evaluate(exponential_cyclical_lr(step)), expected, 1e-6)
             self.evaluate(step.assign_add(1))
 
-    @test_utils.run_in_graph_and_eager_modes(reset_test=True)
     def testCustomCyclicalLearningRate(self, serialize):
         initial_learning_rate = 0.1
         maximal_learning_rate = 1

--- a/tensorflow_addons/optimizers/weight_decay_optimizers_test.py
+++ b/tensorflow_addons/optimizers/weight_decay_optimizers_test.py
@@ -27,6 +27,7 @@ from tensorflow_addons.optimizers import weight_decay_optimizers
 WEIGHT_DECAY = 0.01
 
 
+@test_utils.run_all_in_graph_and_eager_modes
 class OptimizerTestBase(tf.test.TestCase):
     """Base class for optimizer tests.
 

--- a/tensorflow_addons/optimizers/weight_decay_optimizers_test.py
+++ b/tensorflow_addons/optimizers/weight_decay_optimizers_test.py
@@ -27,7 +27,6 @@ from tensorflow_addons.optimizers import weight_decay_optimizers
 WEIGHT_DECAY = 0.01
 
 
-@test_utils.run_all_in_graph_and_eager_modes
 class OptimizerTestBase(tf.test.TestCase):
     """Base class for optimizer tests.
 
@@ -186,11 +185,11 @@ def sgdw_update_numpy(param, grad_t, slot_vars, learning_rate, momentum,
     return param_t, slot_vars
 
 
+@test_utils.run_all_in_graph_and_eager_modes
 class AdamWTest(OptimizerTestBase):
 
     optimizer = weight_decay_optimizers.AdamW
 
-    @test_utils.run_in_graph_and_eager_modes(reset_test=True)
     def testSparse(self):
         self.doTest(
             self.optimizer,
@@ -202,7 +201,6 @@ class AdamWTest(OptimizerTestBase):
             epsilon=1e-8,
             weight_decay=WEIGHT_DECAY)
 
-    @test_utils.run_in_graph_and_eager_modes(reset_test=True)
     def testSparseRepeatedIndices(self):
         self.doTestSparseRepeatedIndices(
             self.optimizer,
@@ -212,7 +210,6 @@ class AdamWTest(OptimizerTestBase):
             epsilon=1e-8,
             weight_decay=WEIGHT_DECAY)
 
-    @test_utils.run_in_graph_and_eager_modes(reset_test=True)
     def testBasic(self):
         self.doTest(
             self.optimizer,
@@ -234,11 +231,11 @@ class AdamWTest(OptimizerTestBase):
             weight_decay=lambda: WEIGHT_DECAY)
 
 
+@test_utils.run_all_in_graph_and_eager_modes
 class SGDWTest(OptimizerTestBase):
 
     optimizer = weight_decay_optimizers.SGDW
 
-    @test_utils.run_in_graph_and_eager_modes(reset_test=True)
     def testSparse(self):
         self.doTest(
             self.optimizer,
@@ -248,7 +245,6 @@ class SGDWTest(OptimizerTestBase):
             momentum=0.9,
             weight_decay=WEIGHT_DECAY)
 
-    @test_utils.run_in_graph_and_eager_modes(reset_test=True)
     def testSparseRepeatedIndices(self):
         self.doTestSparseRepeatedIndices(
             self.optimizer,
@@ -256,7 +252,6 @@ class SGDWTest(OptimizerTestBase):
             momentum=0.9,
             weight_decay=WEIGHT_DECAY)
 
-    @test_utils.run_in_graph_and_eager_modes(reset_test=True)
     def testBasic(self):
         self.doTest(
             self.optimizer,


### PR DESCRIPTION
To be consistent with all tests in optimizers, layers, etc; replacing `run_in_graph_and_eager_modes` (only supports test methods) by `run_all_in_graph_and_eager_modes`. 