### PR TITLE
Fix WeightNormalization wrapped layer has use_biase=False

### DIFF
--- a/tensorflow_addons/layers/wrappers.py
+++ b/tensorflow_addons/layers/wrappers.py
@@ -168,7 +168,7 @@ class WeightNormalization(tf.keras.layers.Wrapper):
 
             # Assign data dependent init values
             g_tensor = self.g.assign(self.g * scale_init)
-            if hasattr(self.layer, 'bias'):
+            if hasattr(self.layer, 'bias') and self.layer.bias is not None:
                 bias_tensor = self.layer.bias.assign(-m_init * scale_init)
                 return [g_tensor, bias_tensor]
             else:

--- a/tensorflow_addons/layers/wrappers_test.py
+++ b/tensorflow_addons/layers/wrappers_test.py
@@ -34,6 +34,14 @@ class WeightNormalizationTest(tf.test.TestCase):
             },
             input_shape=(2, 4, 4, 3))
 
+    def test_weightnorm_no_bias(self):
+        test_utils.layer_test(
+            wrappers.WeightNormalization,
+            kwargs={
+                'layer': tf.keras.layers.Dense(5, use_bias=False),
+            },
+            input_shape=(2, 4))
+
     def _check_data_init(self, data_init, input_data, expected_output):
         layer = tf.keras.layers.Dense(
             input_data.shape[-1],


### PR DESCRIPTION
When using WeightNormalization wrapper layer on a layer which set use_bias=False we get an exception. 

Make sure to check that a bias exists before trying to assign to it.