### PR TITLE
Pin tf-nightly in setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -73,7 +73,7 @@ if project_name == TFA_RELEASE:
     else:
         REQUIRED_PACKAGES.append('tensorflow >= 2.0.0')
 elif project_name == TFA_NIGHTLY:
-    REQUIRED_PACKAGES.append('tf-nightly')
+    REQUIRED_PACKAGES.append('tf-nightly==2.1.0.dev20191029')
 
 
 class BinaryDistribution(Distribution):


### PR DESCRIPTION
Currently, the following sequence of steps fails:

* Create and activate fresh virtualenv
* install tfa-nightly
* import tensorflow_addons

This raises an op not found error.

I believe this change should fix at least this behavior.