### PR TITLE
Migrate from std::string to tensorflow::tstring.

### DIFF
--- a/tensorflow_addons/custom_ops/text/cc/kernels/skip_gram_kernels.cc
+++ b/tensorflow_addons/custom_ops/text/cc/kernels/skip_gram_kernels.cc
@@ -133,7 +133,7 @@ class SkipGramGenerateCandidatesOp : public OpKernel {
                               .TypeConstraint<type>("T"),           \
                           SkipGramGenerateCandidatesOp<type>)
 
-REGISTER_KERNEL(string);
+REGISTER_KERNEL(tstring);
 REGISTER_KERNEL(int64);
 REGISTER_KERNEL(int32);
 REGISTER_KERNEL(int16);


### PR DESCRIPTION
Note that during the transition period tstring is typedef'ed to
std::string.

See: https://github.com/tensorflow/community/pull/91