### PR TITLE
Pin tf-nightly==2.1.0.dev20191119

### DIFF
--- a/build_deps/requirements.txt
+++ b/build_deps/requirements.txt
@@ -1,2 +1,2 @@
 # TensorFlow greater than this date is manylinux2010 compliant
-tf-nightly>=2.1.0.dev20191004
+tf-nightly==2.1.0.dev20191119


### PR DESCRIPTION
Pinning to a newer `tf-nightly` version. 

Undoes #658 

See https://github.com/tensorflow/addons/issues/663#issuecomment-556253136