### PR TITLE
Don't build parse_time till TF r2.1

### DIFF
--- a/tensorflow_addons/custom_ops/text/BUILD
+++ b/tensorflow_addons/custom_ops/text/BUILD
@@ -12,7 +12,7 @@ custom_op_library(
     ],
 )
 
-# TODO: https://github.com/tensorflow/addons/pull/658
+# TODO: https://github.com/tensorflow/addons/issues/663
 # custom_op_library(
 #     name = "_parse_time_op.so",
 #     srcs = [

--- a/tensorflow_addons/custom_ops/text/BUILD
+++ b/tensorflow_addons/custom_ops/text/BUILD
@@ -12,10 +12,11 @@ custom_op_library(
     ],
 )
 
-custom_op_library(
-    name = "_parse_time_op.so",
-    srcs = [
-        "cc/kernels/parse_time_kernel.cc",
-        "cc/ops/parse_time_op.cc",
-    ],
-)
+# TODO: https://github.com/tensorflow/addons/pull/658
+# custom_op_library(
+#     name = "_parse_time_op.so",
+#     srcs = [
+#         "cc/kernels/parse_time_kernel.cc",
+#         "cc/ops/parse_time_op.cc",
+#     ],
+# )

--- a/tensorflow_addons/text/BUILD
+++ b/tensorflow_addons/text/BUILD
@@ -2,21 +2,22 @@ licenses(["notice"])  # Apache 2.0
 
 package(default_visibility = ["//visibility:public"])
 
-py_library(
-    name = "text",
-    srcs = ([
-        "__init__.py",
-        "crf.py",
-        "parse_time_op.py",
-        "skip_gram_ops.py",
-    ]),
-    data = [
-        "//tensorflow_addons/custom_ops/text:_parse_time_op.so",
-        "//tensorflow_addons/custom_ops/text:_skip_gram_ops.so",
-        "//tensorflow_addons/utils",
-    ],
-    srcs_version = "PY2AND3",
-)
+# TODO: https://github.com/tensorflow/addons/pull/658
+# py_library(
+#     name = "text",
+#     srcs = ([
+#         "__init__.py",
+#         "crf.py",
+#         "parse_time_op.py",
+#         "skip_gram_ops.py",
+#     ]),
+#     data = [
+#         "//tensorflow_addons/custom_ops/text:_parse_time_op.so",
+#         "//tensorflow_addons/custom_ops/text:_skip_gram_ops.so",
+#         "//tensorflow_addons/utils",
+#     ],
+#     srcs_version = "PY2AND3",
+# )
 
 py_test(
     name = "crf_test",
@@ -44,15 +45,16 @@ py_test(
     ],
 )
 
-py_test(
-    name = "parse_time_op_test",
-    size = "small",
-    srcs = [
-        "parse_time_op_test.py",
-    ],
-    main = "parse_time_op_test.py",
-    srcs_version = "PY2AND3",
-    deps = [
-        ":text",
-    ],
-)
+# TODO: https://github.com/tensorflow/addons/pull/658
+# py_test(
+#     name = "parse_time_op_test",
+#     size = "small",
+#     srcs = [
+#         "parse_time_op_test.py",
+#     ],
+#     main = "parse_time_op_test.py",
+#     srcs_version = "PY2AND3",
+#     deps = [
+#         ":text",
+#     ],
+# )

--- a/tensorflow_addons/text/BUILD
+++ b/tensorflow_addons/text/BUILD
@@ -2,22 +2,22 @@ licenses(["notice"])  # Apache 2.0
 
 package(default_visibility = ["//visibility:public"])
 
-# TODO: https://github.com/tensorflow/addons/pull/658
-# py_library(
-#     name = "text",
-#     srcs = ([
-#         "__init__.py",
-#         "crf.py",
-#         "parse_time_op.py",
-#         "skip_gram_ops.py",
-#     ]),
-#     data = [
-#         "//tensorflow_addons/custom_ops/text:_parse_time_op.so",
-#         "//tensorflow_addons/custom_ops/text:_skip_gram_ops.so",
-#         "//tensorflow_addons/utils",
-#     ],
-#     srcs_version = "PY2AND3",
-# )
+py_library(
+    name = "text",
+    srcs = ([
+        "__init__.py",
+        "crf.py",
+        "parse_time_op.py",
+        "skip_gram_ops.py",
+    ]),
+    data = [
+        # TODO: https://github.com/tensorflow/addons/issues/663
+        # "//tensorflow_addons/custom_ops/text:_parse_time_op.so",
+        "//tensorflow_addons/custom_ops/text:_skip_gram_ops.so",
+        "//tensorflow_addons/utils",
+    ],
+    srcs_version = "PY2AND3",
+)
 
 py_test(
     name = "crf_test",
@@ -45,7 +45,7 @@ py_test(
     ],
 )
 
-# TODO: https://github.com/tensorflow/addons/pull/658
+# TODO: https://github.com/tensorflow/addons/issues/663
 # py_test(
 #     name = "parse_time_op_test",
 #     size = "small",

--- a/tensorflow_addons/text/BUILD
+++ b/tensorflow_addons/text/BUILD
@@ -2,16 +2,16 @@ licenses(["notice"])  # Apache 2.0
 
 package(default_visibility = ["//visibility:public"])
 
+# TODO: https://github.com/tensorflow/addons/issues/663
 py_library(
     name = "text",
     srcs = ([
         "__init__.py",
         "crf.py",
-        "parse_time_op.py",
+        # "parse_time_op.py",
         "skip_gram_ops.py",
     ]),
     data = [
-        # TODO: https://github.com/tensorflow/addons/issues/663
         # "//tensorflow_addons/custom_ops/text:_parse_time_op.so",
         "//tensorflow_addons/custom_ops/text:_skip_gram_ops.so",
         "//tensorflow_addons/utils",

--- a/tensorflow_addons/text/__init__.py
+++ b/tensorflow_addons/text/__init__.py
@@ -34,5 +34,6 @@ from tensorflow_addons.text.crf import viterbi_decode
 from tensorflow_addons.text.skip_gram_ops import skip_gram_sample
 from tensorflow_addons.text.skip_gram_ops import skip_gram_sample_with_text_vocab
 
+# TODO: https://github.com/tensorflow/addons/pull/658
 # Parse Time
-from tensorflow_addons.text.parse_time_op import parse_time
+# from tensorflow_addons.text.parse_time_op import parse_time

--- a/tensorflow_addons/text/__init__.py
+++ b/tensorflow_addons/text/__init__.py
@@ -34,6 +34,6 @@ from tensorflow_addons.text.crf import viterbi_decode
 from tensorflow_addons.text.skip_gram_ops import skip_gram_sample
 from tensorflow_addons.text.skip_gram_ops import skip_gram_sample_with_text_vocab
 
-# TODO: https://github.com/tensorflow/addons/pull/658
+# TODO: https://github.com/tensorflow/addons/issues/663
 # Parse Time
 # from tensorflow_addons.text.parse_time_op import parse_time


### PR DESCRIPTION
As discussed, we won't build `parse_time` till #663 is completely resolved in r2.1