### PR TITLE
Hotfix: fix brew setup

### DIFF
--- a/tools/ci_build/builds/release_macos.sh
+++ b/tools/ci_build/builds/release_macos.sh
@@ -27,7 +27,7 @@ export PATH="$PATH:$HOME/bin"
 # Install delocate
 python3 -m pip install -q delocate
 
-brew update && brew upgrade pyenv
+brew update && brew outdated | grep -q pyenv && brew upgrade pyenv
 eval "$(pyenv init -)"
 
 for version in ${PYTHON_VERSIONS}; do


### PR DESCRIPTION
Nightly macos build is currently failing while trying to upgrade an up-to-date pyenv:
https://travis-ci.org/tensorflow/addons/jobs/616260135

Small fix to correct this:
https://travis-ci.org/seanpmorgan/addons/jobs/616425666

Reference: https://github.com/Homebrew/legacy-homebrew/issues/27897

Just a note: Plan on doing some upgrades to the build later this week (e.g. Bazel 1.0 / CUDA 10.1)