### PR TITLE
Use PEP 508 environment markers to select dependencies

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -67,11 +67,11 @@ REQUIRED_PACKAGES = [
 ]
 
 if project_name == TFA_RELEASE:
-    # TODO: remove if-else condition when tf supports package consolidation.
-    if platform.system() == 'Linux':
-        REQUIRED_PACKAGES.append('tensorflow-gpu >= 2.0.0')
-    else:
-        REQUIRED_PACKAGES.append('tensorflow >= 2.0.0')
+    # TODO: remove environment markers when tf supports package consolidation.
+    REQUIRED_PACKAGES += [
+        'tensorflow-gpu;sys_platform=="linux"',
+        'tensorflow;sys_platform!="linux"',
+    ]
 elif project_name == TFA_NIGHTLY:
     REQUIRED_PACKAGES.append('tf-nightly')
 


### PR DESCRIPTION
Similar to https://github.com/tensorflow/tensorflow/pull/30255, if using Poetry or other such package managers, resolving dependencies fail on MacOS:

```
❯ poetry add tensorflow-addons
Using version ^0.6.0 for tensorflow-addons

Updating dependencies
Resolving dependencies... (0.1s)

[SolverProblemError]
Because tensorflow-addons (0.6.0) depends on tensorflow-gpu (2.0.0)
 and no versions of tensorflow-addons match >0.6.0,<0.7.0, tensorflow-addons (>=0.6.0,<0.7.0) requires tensorflow-gpu (2.0.0).
So, because core depends on both tensorflow-gpu (2.1.0-rc0) and tensorflow-addons (^0.6.0), version solving failed.
```

The fix is to use PEP 508 environment markers instead of if/else statements in `setup.py`