### PR TITLE
Temporarily remove stale ppa until image can be updated

### DIFF
--- a/tools/ci_build/builds/release_linux.sh
+++ b/tools/ci_build/builds/release_linux.sh
@@ -15,6 +15,10 @@
 # ==============================================================================
 set -e -x
 
+# Remove the now private ppa. This can be removed after the docker image removes the
+# pre-installed python packages from this ppa.
+rm -f /etc/apt/sources.list.d/jonathonf-ubuntu-python-3_6-xenial.list
+
 PYTHON_VERSIONS="python2.7 python3.5 python3.6 python3.7"
 ln -sf /usr/bin/python3.5 /usr/bin/python3 # Py36 has issues with add-apt
 curl -sSOL https://bootstrap.pypa.io/get-pip.py

--- a/tools/ci_build/install/install_ci_dependency.sh
+++ b/tools/ci_build/install/install_ci_dependency.sh
@@ -50,6 +50,10 @@ wget ${QUIET_FLAG} https://github.com/bazelbuild/buildtools/releases/download/0.
 chmod +x buildozer
 sudo mv buildozer /usr/local/bin/.
 
+# Remove the now private ppa. This can be removed after the docker image removes the
+# pre-installed python packages from this ppa.
+rm -f /etc/apt/sources.list.d/jonathonf-ubuntu-python-3_6-xenial.list
+
 # Install clang-format
 apt-get update -qq && apt-get install -y clang-format-3.8
 


### PR DESCRIPTION
Current CI and nightly build fail to run `apt-get update` since this ppa is now stale. Some context:
https://launchpad.net/~jonathonf

Tested the build scripts as well and it should fix our nightly. 

