### PR TITLE
Add github workflow labeler

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -1,0 +1,47 @@
+# Subpackages
+activations:
+  /tensorflow_addons/activations/**/*
+
+callbacks:
+  /tensorflow_addons/callbacks/**/*
+
+image:
+  /tensorflow_addons/image/**/*
+
+layers:
+  /tensorflow_addons/layers/**/*
+
+losses:
+  /tensorflow_addons/losses/**/*
+
+metrics:
+  /tensorflow_addons/metrics/**/*
+
+optimizers:
+  /tensorflow_addons/optimizers/**/*
+
+seq2seq:
+  /tensorflow_addons/seq2seq/**/*
+
+text:
+  /tensorflow_addons/text/**/*
+
+# Other labels
+build:
+  /build_deps/**/*
+  /tools/ci_build/**/*
+
+documentation:
+  /docs/**/*
+
+tutorials:
+  /docs/tutorials/**/*
+
+testing:
+  /tools/ci_testing/**/
+
+style:
+  STYLE_GUIDE.md
+
+github:
+  /.github/**/*

--- a/.github/workflows/label.yml
+++ b/.github/workflows/label.yml
@@ -1,0 +1,23 @@
+# This workflow will triage pull requests and apply a label based on the
+# paths that are modified in the pull request.
+#
+# To use this workflow, you will need to set up a .github/labeler.yml
+# file with configuration.  For more information, see:
+# https://github.com/actions/labeler/blob/master/README.md
+
+name: Labeler
+on:
+  issues:
+    types: [opened]
+  pull_request:
+    types: [opened]
+
+jobs:
+  label:
+
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/labeler@v2
+        with:
+          repo-token: "${{ secrets.GITHUB_TOKEN }}"


### PR DESCRIPTION
GitHub actions are now available for TF repos. We'll be making a push to automate as much maintainer burden as possible. 