### PR TITLE
Mark filters_test as flaky

### DIFF
--- a/tensorflow_addons/image/BUILD
+++ b/tensorflow_addons/image/BUILD
@@ -78,6 +78,7 @@ py_test(
     deps = [
         ":image",
     ],
+    flaky=True,
 )
 
 py_test(

--- a/tensorflow_addons/image/BUILD
+++ b/tensorflow_addons/image/BUILD
@@ -74,11 +74,11 @@ py_test(
     srcs = [
         "filters_test.py",
     ],
+    flaky = True,
     main = "filters_test.py",
     deps = [
         ":image",
     ],
-    flaky=True,
 )
 
 py_test(


### PR DESCRIPTION
This test occasionally fails just outside of tolerance. Marking as flaky:
https://docs.bazel.build/versions/master/be/common-definitions.html#test.flaky

