### PR TITLE
Temporarily set rrelu_test as flaky

### DIFF
--- a/tensorflow_addons/activations/BUILD
+++ b/tensorflow_addons/activations/BUILD
@@ -123,6 +123,7 @@ py_test(
     srcs = [
         "rrelu_test.py",
     ],
+    flaky = True,
     main = "rrelu_test.py",
     deps = [
         ":activations",


### PR DESCRIPTION
Temporary until #802 is resolved.

Example:
https://source.cloud.google.com/results/invocations/2490d700-0837-4468-916a-0306b1714d87/targets/tensorflow_addons%2Fubuntu%2Fgpu%2Fpy3%2Fpresubmit/log