### PR TITLE
Add SWA in optimizers.__init__

### DIFF
--- a/tensorflow_addons/optimizers/__init__.py
+++ b/tensorflow_addons/optimizers/__init__.py
@@ -32,6 +32,7 @@ from tensorflow_addons.optimizers.lazy_adam import LazyAdam
 from tensorflow_addons.optimizers.lookahead import Lookahead
 from tensorflow_addons.optimizers.moving_average import MovingAverage
 from tensorflow_addons.optimizers.rectified_adam import RectifiedAdam
+from tensorflow_addons.optimizers.stochastic_weight_averaging import SWA
 from tensorflow_addons.optimizers.weight_decay_optimizers import AdamW
 from tensorflow_addons.optimizers.weight_decay_optimizers import SGDW
 from tensorflow_addons.optimizers.weight_decay_optimizers import (


### PR DESCRIPTION
to fix the following error when `tfa.optimizers.SWA` is used:
`AttributeError: module 'tensorflow_addons.optimizers' has no attribute 'SWA'`