### PR TITLE
FIX: RNN support for weight norm and `remove()`

### DIFF
--- a/tensorflow_addons/layers/wrappers.py
+++ b/tensorflow_addons/layers/wrappers.py
@@ -63,7 +63,7 @@ class WeightNormalization(tf.keras.layers.Wrapper):
 
         if self.data_init and self.is_rnn:
             print(
-                "WeightNormalization: Using data dependent initialization with RNNs is not advised"
+                "WeightNormalization: Using `data_init=True` with RNNs is not advised"
             )
 
     def build(self, input_shape):
@@ -206,3 +206,15 @@ class WeightNormalization(tf.keras.layers.Wrapper):
         config = {'data_init': self.data_init}
         base_config = super(WeightNormalization, self).get_config()
         return dict(list(base_config.items()) + list(config.items()))
+
+    def remove(self):
+        kernel = tf.Variable(
+            tf.nn.l2_normalize(self.v, axis=self.kernel_norm_axes) * self.g,
+            name='recurrent_kernel' if self.is_rnn else 'kernel')
+
+        if self.is_rnn:
+            self.layer.cell.recurrent_kernel = kernel
+        else:
+            self.layer.kernel = kernel
+
+        return self.layer

--- a/tensorflow_addons/layers/wrappers.py
+++ b/tensorflow_addons/layers/wrappers.py
@@ -16,6 +16,8 @@ from __future__ import absolute_import
 from __future__ import division
 from __future__ import print_function
 
+import logging
+
 import tensorflow as tf
 
 
@@ -62,9 +64,9 @@ class WeightNormalization(tf.keras.layers.Wrapper):
         self.is_rnn = isinstance(self.layer, tf.keras.layers.RNN)
 
         if self.data_init and self.is_rnn:
-            print(
-                "WeightNormalization: Using `data_init=True` with RNNs is not advised"
-            )
+            logging.warn(
+                "WeightNormalization: Using `data_init=True` with RNNs "
+                "is advised against by the paper. Use `data_init=False`.")
 
     def build(self, input_shape):
         """Build `Layer`"""
@@ -81,7 +83,10 @@ class WeightNormalization(tf.keras.layers.Wrapper):
             raise ValueError('`WeightNormalization` must wrap a layer that'
                              ' contains a `kernel` for weights')
 
-        kernel = self.layer.cell.recurrent_kernel if self.is_rnn else self.layer.kernel
+        if self.is_rnn:
+            kernel = kernel_layer.recurrent_kernel
+        else:
+            kernel = kernel_layer.kernel
 
         # The kernel's filter or unit dimension is -1
         self.layer_depth = int(kernel.shape[-1])

--- a/tensorflow_addons/layers/wrappers_test.py
+++ b/tensorflow_addons/layers/wrappers_test.py
@@ -95,6 +95,9 @@ class WeightNormalizationTest(tf.test.TestCase):
         wt_rnn = wrappers.WeightNormalization(rnn_layer)
         dense = tf.keras.layers.Dense(1)
         model = tf.keras.models.Sequential(layers=[inputs, wt_rnn, dense])
+        model.build()
+        sample_data = np.ones((1, 5, 3), dtype=np.float32)
+        model(sample_data)
 
     def test_save_file_h5(self):
         self.create_tempfile('wrapper_test_model.h5')

--- a/tensorflow_addons/layers/wrappers_test.py
+++ b/tensorflow_addons/layers/wrappers_test.py
@@ -17,6 +17,8 @@ from __future__ import absolute_import
 from __future__ import division
 from __future__ import print_function
 
+from absl.testing import parameterized
+
 import numpy as np
 import tensorflow as tf
 
@@ -25,8 +27,8 @@ from tensorflow_addons.utils import test_utils
 
 
 @test_utils.run_all_in_graph_and_eager_modes
-class WeightNormalizationTest(tf.test.TestCase):
-    def test_weightnorm(self):
+class WeightNormalizationTest(tf.test.TestCase, parameterized.TestCase):
+    def test_basic(self):
         test_utils.layer_test(
             wrappers.WeightNormalization,
             kwargs={
@@ -34,7 +36,7 @@ class WeightNormalizationTest(tf.test.TestCase):
             },
             input_shape=(2, 4, 4, 3))
 
-    def test_weightnorm_no_bias(self):
+    def test_no_bias(self):
         test_utils.layer_test(
             wrappers.WeightNormalization,
             kwargs={
@@ -57,31 +59,31 @@ class WeightNormalizationTest(tf.test.TestCase):
             input_data=input_data,
             expected_output=expected_output)
 
-    def test_weightnorm_with_data_init_is_false(self):
+    def test_with_data_init_is_false(self):
         input_data = np.array([[[-4, -4], [4, 4]]], dtype=np.float32)
         self._check_data_init(
             data_init=False, input_data=input_data, expected_output=input_data)
 
-    def test_weightnorm_with_data_init_is_true(self):
+    def test_with_data_init_is_true(self):
         input_data = np.array([[[-4, -4], [4, 4]]], dtype=np.float32)
         self._check_data_init(
             data_init=True,
             input_data=input_data,
             expected_output=input_data / 4)
 
-    def test_weightnorm_non_layer(self):
+    def test_non_layer(self):
         images = tf.random.uniform((2, 4, 43))
         with self.assertRaises(AssertionError):
             wrappers.WeightNormalization(images)
 
-    def test_weightnorm_non_kernel_layer(self):
+    def test_non_kernel_layer(self):
         images = tf.random.uniform((2, 2, 2))
         with self.assertRaisesRegexp(ValueError, 'contains a `kernel`'):
             non_kernel_layer = tf.keras.layers.MaxPooling2D(2, 2)
             wn_wrapper = wrappers.WeightNormalization(non_kernel_layer)
             wn_wrapper(images)
 
-    def test_weightnorm_with_time_dist(self):
+    def test_with_time_dist(self):
         batch_shape = (32, 16, 64, 64, 3)
         inputs = tf.keras.layers.Input(batch_shape=batch_shape)
         a = tf.keras.layers.Conv2D(3, 5)
@@ -89,23 +91,66 @@ class WeightNormalizationTest(tf.test.TestCase):
         out = tf.keras.layers.TimeDistributed(b)(inputs)
         model = tf.keras.Model(inputs, out)
 
-    def test_weightnorm_with_rnn(self):
-        inputs = tf.keras.layers.Input(shape=(None, 3))
-        rnn_layer = tf.keras.layers.SimpleRNN(4)
-        wt_rnn = wrappers.WeightNormalization(rnn_layer)
-        dense = tf.keras.layers.Dense(1)
-        model = tf.keras.models.Sequential(layers=[inputs, wt_rnn, dense])
-        model.build()
-        sample_data = np.ones((1, 5, 3), dtype=np.float32)
-        model(sample_data)
+    @parameterized.named_parameters(
+        ["Dense", lambda: tf.keras.layers.Dense(1), False],
+        ["SimpleRNN", lambda: tf.keras.layers.SimpleRNN(1), True],
+        ["Conv2D", lambda: tf.keras.layers.Conv2D(3, 1), False],
+        ["LSTM", lambda: tf.keras.layers.LSTM(1), True])
+    def test_serialization(self, base_layer, rnn):
+        base_layer = base_layer()
+        wn_layer = wrappers.WeightNormalization(base_layer, not rnn)
+        new_wn_layer = tf.keras.layers.deserialize(
+            tf.keras.layers.serialize(wn_layer))
+        self.assertEqual(wn_layer.data_init, new_wn_layer.data_init)
+        self.assertEqual(wn_layer.is_rnn, new_wn_layer.is_rnn)
+        self.assertEqual(wn_layer.is_rnn, rnn)
+        if not isinstance(base_layer, tf.keras.layers.LSTM):
+            # Issue with LSTM serialization, check with TF-core
+            # Before serialization: tensorflow.python.keras.layers.recurrent_v2.LSTM
+            # After serialization: tensorflow.python.keras.layers.recurrent.LSTM
+            self.assertTrue(
+                isinstance(new_wn_layer.layer, base_layer.__class__))
 
-    def test_save_file_h5(self):
+    @parameterized.named_parameters(
+        ["Dense", lambda: tf.keras.layers.Dense(1), [25]],
+        ["SimpleRNN", lambda: tf.keras.layers.SimpleRNN(1), [None, 10]],
+        ["Conv2D", lambda: tf.keras.layers.Conv2D(3, 1), [3, 3, 1]],
+        ["LSTM", lambda: tf.keras.layers.LSTM(1), [10, 10]])
+    def test_model_build(self, base_layer, input_shape):
+        inputs = tf.keras.layers.Input(shape=input_shape)
+        base_layer = base_layer()
+        for data_init in [True, False]:
+            wt_layer = wrappers.WeightNormalization(base_layer, data_init)
+            model = tf.keras.models.Sequential(layers=[inputs, wt_layer])
+            model.build()
+
+    @parameterized.named_parameters(
+        ["Dense", lambda: tf.keras.layers.Dense(1), [25]],
+        ["SimpleRNN", lambda: tf.keras.layers.SimpleRNN(1), [10, 10]],
+        ["Conv2D", lambda: tf.keras.layers.Conv2D(3, 1), [3, 3, 1]],
+        ["LSTM", lambda: tf.keras.layers.LSTM(1), [10, 10]])
+    def test_save_file_h5(self, base_layer, input_shape):
         self.create_tempfile('wrapper_test_model.h5')
-        conv = tf.keras.layers.Conv1D(1, 1)
-        wn_conv = wrappers.WeightNormalization(conv)
+        base_layer = base_layer()
+        wn_conv = wrappers.WeightNormalization(base_layer)
         model = tf.keras.Sequential(layers=[wn_conv])
-        model.build([1, 2, 3])
+        model.build([None] + input_shape)
         model.save_weights('wrapper_test_model.h5')
+
+    @parameterized.named_parameters(
+        ["Dense", lambda: tf.keras.layers.Dense(1), [25]],
+        ["SimpleRNN", lambda: tf.keras.layers.SimpleRNN(1), [10, 10]],
+        ["Conv2D", lambda: tf.keras.layers.Conv2D(3, 1), [3, 3, 1]],
+        ["LSTM", lambda: tf.keras.layers.LSTM(1), [10, 10]])
+    def test_forward_pass(self, base_layer, input_shape):
+        sample_data = np.ones([1] + input_shape, dtype=np.float32)
+        base_layer = base_layer()
+        base_output = base_layer(sample_data)
+        wn_layer = wrappers.WeightNormalization(base_layer, False)
+        wn_output = wn_layer(sample_data)
+        self.evaluate(tf.compat.v1.global_variables_initializer())
+        self.assertAllClose(
+            self.evaluate(base_output), self.evaluate(wn_output))
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
* Use `recurrent_kernel` for RNNs
* Add more test cases
* Add warning for RNN + data-dependent initialization 
* Add `remove()`, fixes #763 

Continuation of #769 