### PR TITLE
Update logging to warning since warn is deprecated

### DIFF
--- a/tensorflow_addons/layers/wrappers.py
+++ b/tensorflow_addons/layers/wrappers.py
@@ -64,7 +64,7 @@ class WeightNormalization(tf.keras.layers.Wrapper):
         self.is_rnn = isinstance(self.layer, tf.keras.layers.RNN)
 
         if self.data_init and self.is_rnn:
-            logging.warn(
+            logging.warning(
                 "WeightNormalization: Using `data_init=True` with RNNs "
                 "is advised against by the paper. Use `data_init=False`.")
 


### PR DESCRIPTION
Minor fix:
https://stackoverflow.com/questions/15539937/whats-the-difference-between-logging-warn-and-logging-warning-in-python