### PR TITLE
fixes bugs when using fit generator

### DIFF
--- a/tensorflow_addons/callbacks/tqdm_progress_bar.py
+++ b/tensorflow_addons/callbacks/tqdm_progress_bar.py
@@ -126,8 +126,9 @@ class TQDMProgressBar(Callback):
                 dynamic_ncols=True,
                 unit=self.mode)
 
-        self.seen = 0
+        self.num_samples_seen = 0
         self.steps_to_update = 0
+        self.steps_so_far = 0
         self.logs = defaultdict(float)
 
     def on_epoch_end(self, epoch, logs={}):
@@ -154,10 +155,11 @@ class TQDMProgressBar(Callback):
         else:
             batch_size = 1
 
-        self.seen += batch_size
-        self.steps_to_update += batch_size
+        self.num_samples_seen += batch_size
+        self.steps_to_update += 1
+        self.steps_so_far += 1
 
-        if self.seen < self.total_steps:
+        if self.steps_so_far < self.total_steps:
 
             for metric, value in logs.items():
                 self.logs[metric] += value * batch_size
@@ -167,7 +169,7 @@ class TQDMProgressBar(Callback):
             if self.show_epoch_progress and time_diff >= self.update_interval:
 
                 # update the epoch progress bar
-                metrics = self.format_metrics(self.logs, self.seen)
+                metrics = self.format_metrics(self.logs, self.num_samples_seen)
                 self.epoch_progress_tqdm.desc = metrics
                 self.epoch_progress_tqdm.update(self.steps_to_update)
 


### PR DESCRIPTION
Quick fix to a bug when using `fit_generator`
It turns out that when using `fit_generator` the progress bar is updating by 1 (instead of by `batch_size`) after each batch, but we still need to keep the number of samples seen to accuracy compute and display the metrics. Therefore I add another field to keep track of steps so far and rename `self.seen` to `self.num_samples_seen` for clarity.

Edit: Link to Issue
https://github.com/tensorflow/addons/issues/812