### PR TITLE
BLD: Only install twine to user path for linux builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -37,7 +37,7 @@ jobs:
       script:
         - bash -x -e tools/ci_build/builds/release_macos.sh
       after_success:
-        - python -m pip install --user -q -U twine --ignore-installed six
+        - python -m pip install -q -U twine --ignore-installed six
         - twine upload -u $PYPI_USER -p $PYPI_PW wheelhouse/*.whl
 
     # Windows Builds
@@ -60,7 +60,7 @@ jobs:
         - export PATH=/c/Python37:/c/Python37/Scripts:$PATH
         - bash -x -e tools/ci_build/builds/release_windows.sh
       after_success:
-        - python -m pip install --user -q -U twine --ignore-installed six
+        - python -m pip install -q -U twine --ignore-installed six
         - twine upload -u $PYPI_USER -p $PYPI_PW artifacts/*.whl
 
 notifications:


### PR DESCRIPTION
Welp... installing twine as user for mac/windows puts it off the PATH:
https://travis-ci.org/tensorflow/addons/jobs/632643533#L4300

This should be the last fix for nightlies... sorry about the multiple PRs 