### PR TITLE
Fix bug in "xy" mode for bilinear interpolation

### DIFF
--- a/tensorflow_addons/image/dense_image_warp.py
+++ b/tensorflow_addons/image/dense_image_warp.py
@@ -114,6 +114,7 @@ def interpolate_bilinear(grid, query_points, indexing="ij", name=None):
         floors = []
         ceils = []
         index_order = [0, 1] if indexing == "ij" else [1, 0]
+        x_axis_width = width if indexing == "ij" else height
         unstacked_query_points = tf.unstack(query_points, axis=2, num=2)
 
         for dim in index_order:
@@ -160,7 +161,7 @@ def interpolate_bilinear(grid, query_points, indexing="ij", name=None):
         def gather(y_coords, x_coords, name):
             with tf.name_scope("gather-" + name):
                 linear_coordinates = (
-                    batch_offsets + y_coords * width + x_coords)
+                    batch_offsets + y_coords * x_axis_width + x_coords)
                 gathered_values = tf.gather(flattened_grid, linear_coordinates)
                 return tf.reshape(gathered_values,
                                   [batch_size, num_queries, channels])

--- a/tensorflow_addons/image/dense_image_warp.py
+++ b/tensorflow_addons/image/dense_image_warp.py
@@ -114,14 +114,13 @@ def interpolate_bilinear(grid, query_points, indexing="ij", name=None):
         floors = []
         ceils = []
         index_order = [0, 1] if indexing == "ij" else [1, 0]
-        x_axis_width = width if indexing == "ij" else height
         unstacked_query_points = tf.unstack(query_points, axis=2, num=2)
 
-        for dim in index_order:
+        for i, dim in enumerate(index_order):
             with tf.name_scope("dim-" + str(dim)):
                 queries = unstacked_query_points[dim]
 
-                size_in_indexing_dimension = grid_shape[dim + 1]
+                size_in_indexing_dimension = grid_shape[i + 1]
 
                 # max_floor is size_in_indexing_dimension - 2 so that max_floor + 1
                 # is still a valid index into the grid.
@@ -161,7 +160,7 @@ def interpolate_bilinear(grid, query_points, indexing="ij", name=None):
         def gather(y_coords, x_coords, name):
             with tf.name_scope("gather-" + name):
                 linear_coordinates = (
-                    batch_offsets + y_coords * x_axis_width + x_coords)
+                    batch_offsets + y_coords * width + x_coords)
                 gathered_values = tf.gather(flattened_grid, linear_coordinates)
                 return tf.reshape(gathered_values,
                                   [batch_size, num_queries, channels])

--- a/tensorflow_addons/image/dense_image_warp_test.py
+++ b/tensorflow_addons/image/dense_image_warp_test.py
@@ -30,22 +30,28 @@ from tensorflow_addons.utils import test_utils
 @test_utils.run_all_in_graph_and_eager_modes
 class InterpolateBilinearTest(tf.test.TestCase):
     def test_interpolate_small_grid_ij(self):
-        grid = tf.constant([[0., 1., 2.], [3., 4., 5.], [6., 7., 8.], [9., 10., 11.]],
-                           shape=[1, 4, 3, 1])
-        query_points = tf.constant([[0., 0.], [1., 0.], [2., 0.5], [1.5, 1.5], [3., 2.]],
-                                   shape=[1, 5, 2])
-        expected_results = np.reshape(np.array([0., 3., 6.5, 6., 11.]), [1, 5, 1])
+        grid = tf.constant(
+            [[0., 1., 2.], [3., 4., 5.], [6., 7., 8.], [9., 10., 11.]],
+            shape=[1, 4, 3, 1])
+        query_points = tf.constant(
+            [[0., 0.], [1., 0.], [2., 0.5], [1.5, 1.5], [3., 2.]],
+            shape=[1, 5, 2])
+        expected_results = np.reshape(
+            np.array([0., 3., 6.5, 6., 11.]), [1, 5, 1])
 
         interp = interpolate_bilinear(grid, query_points)
 
         self.assertAllClose(expected_results, interp)
 
     def test_interpolate_small_grid_xy(self):
-        grid = tf.constant([[0., 1., 2.], [3., 4., 5.], [6., 7., 8.], [9., 10., 11.]],
-                           shape=[1, 4, 3, 1])
+        grid = tf.constant(
+            [[0., 1., 2.], [3., 4., 5.], [6., 7., 8.], [9., 10., 11.]],
+            shape=[1, 4, 3, 1])
         query_points = tf.constant(
-            [[0., 0.], [0., 1.], [0.5, 2.0], [1.5, 1.5], [2., 3.]], shape=[1, 5, 2])
-        expected_results = np.reshape(np.array([0., 3., 6.5, 6., 11.]), [1, 5, 1])
+            [[0., 0.], [0., 1.], [0.5, 2.0], [1.5, 1.5], [2., 3.]],
+            shape=[1, 5, 2])
+        expected_results = np.reshape(
+            np.array([0., 3., 6.5, 6., 11.]), [1, 5, 1])
 
         interp = interpolate_bilinear(grid, query_points, indexing="xy")
 

--- a/tensorflow_addons/image/dense_image_warp_test.py
+++ b/tensorflow_addons/image/dense_image_warp_test.py
@@ -51,6 +51,17 @@ class InterpolateBilinearTest(tf.test.TestCase):
 
         self.assertAllClose(expected_results, interp)
 
+    def test_interpolate_small_non_square_grid_xy(self):
+        grid = tf.constant([[0., 1., 2.], [3., 4., 5.]],
+                           shape=[1, 2, 3, 1])
+        query_points = tf.constant([[0., 0.], [1., 0.], [2., 0.], [0., 1.], [1., 1.], [2., 1.]],
+                                   shape=[1, 6, 2])
+        expected_results = np.reshape(np.array([0., 1., 2., 3., 4., 5.]), [1, 6, 1])
+
+        interp = interpolate_bilinear(grid, query_points)
+
+        self.assertAllClose(expected_results, interp)
+
     def test_interpolate_small_grid_batched(self):
         grid = tf.constant([[[0., 1.], [3., 4.]], [[5., 6.], [7., 8.]]],
                            shape=[2, 2, 2, 1])

--- a/tensorflow_addons/image/dense_image_warp_test.py
+++ b/tensorflow_addons/image/dense_image_warp_test.py
@@ -30,35 +30,24 @@ from tensorflow_addons.utils import test_utils
 @test_utils.run_all_in_graph_and_eager_modes
 class InterpolateBilinearTest(tf.test.TestCase):
     def test_interpolate_small_grid_ij(self):
-        grid = tf.constant([[0., 1., 2.], [3., 4., 5.], [6., 7., 8.]],
-                           shape=[1, 3, 3, 1])
-        query_points = tf.constant([[0., 0.], [1., 0.], [2., 0.5], [1.5, 1.5]],
-                                   shape=[1, 4, 2])
-        expected_results = np.reshape(np.array([0., 3., 6.5, 6.]), [1, 4, 1])
+        grid = tf.constant([[0., 1., 2.], [3., 4., 5.], [6., 7., 8.], [9., 10., 11.]],
+                           shape=[1, 4, 3, 1])
+        query_points = tf.constant([[0., 0.], [1., 0.], [2., 0.5], [1.5, 1.5], [3., 2.]],
+                                   shape=[1, 5, 2])
+        expected_results = np.reshape(np.array([0., 3., 6.5, 6., 11.]), [1, 5, 1])
 
         interp = interpolate_bilinear(grid, query_points)
 
         self.assertAllClose(expected_results, interp)
 
     def test_interpolate_small_grid_xy(self):
-        grid = tf.constant([[0., 1., 2.], [3., 4., 5.], [6., 7., 8.]],
-                           shape=[1, 3, 3, 1])
+        grid = tf.constant([[0., 1., 2.], [3., 4., 5.], [6., 7., 8.], [9., 10., 11.]],
+                           shape=[1, 4, 3, 1])
         query_points = tf.constant(
-            [[0., 0.], [0., 1.], [0.5, 2.0], [1.5, 1.5]], shape=[1, 4, 2])
-        expected_results = np.reshape(np.array([0., 3., 6.5, 6.]), [1, 4, 1])
+            [[0., 0.], [0., 1.], [0.5, 2.0], [1.5, 1.5], [2., 3.]], shape=[1, 5, 2])
+        expected_results = np.reshape(np.array([0., 3., 6.5, 6., 11.]), [1, 5, 1])
 
         interp = interpolate_bilinear(grid, query_points, indexing="xy")
-
-        self.assertAllClose(expected_results, interp)
-
-    def test_interpolate_small_non_square_grid_xy(self):
-        grid = tf.constant([[0., 1., 2.], [3., 4., 5.]],
-                           shape=[1, 2, 3, 1])
-        query_points = tf.constant([[0., 0.], [1., 0.], [2., 0.], [0., 1.], [1., 1.], [2., 1.]],
-                                   shape=[1, 6, 2])
-        expected_results = np.reshape(np.array([0., 1., 2., 3., 4., 5.]), [1, 6, 1])
-
-        interp = interpolate_bilinear(grid, query_points)
 
         self.assertAllClose(expected_results, interp)
 


### PR DESCRIPTION
Fixed incorrect clipping of query indices for non-square images.
Also modified tests to use non-square images.

Additional note: a single tf.reverse(query_points, -1) operation in an if statement could simplify this function for "ij" vs "xy" mode.