### PR TITLE
Move ubuntu CPU testing to github actions

### DIFF
--- a/.github/workflows/ci_test.yml
+++ b/.github/workflows/ci_test.yml
@@ -12,6 +12,15 @@ env:
   BAZEL_VERSION: 1.1.0
 
 jobs:
+  linux-test:
+    name: Ubuntu CPU Python3
+    runs-on: ubuntu-18.04
+    steps:
+      - uses: actions/checkout@v1
+      - name: CI test Ubuntu CPU
+        run: |
+          set -x -e
+          bash tools/run_docker.sh -d cpu -c 'make unit-test'
   macos-test:
     name: MacOS CPU Python3
     runs-on: macos-latest

--- a/.github/workflows/ubuntu_nightly.yml
+++ b/.github/workflows/ubuntu_nightly.yml
@@ -11,7 +11,7 @@ env:
 
 jobs:
   ubuntu-cpu-nightly:
-    name: Test nightly on macOS
+    name: Test nightly on Ubuntu
     runs-on: ubuntu-18.04
     steps:
       - uses: actions/checkout@v1

--- a/.github/workflows/ubuntu_nightly.yml
+++ b/.github/workflows/ubuntu_nightly.yml
@@ -1,0 +1,22 @@
+
+name: ubuntu-cpu-nightly
+
+on:
+  schedule:
+    # Shortly after tf-nightly is released
+    - cron:  '0 11 * * *'
+
+env:
+  BAZEL_VERSION: 1.1.0
+
+jobs:
+  ubuntu-cpu-nightly:
+    name: Test nightly on macOS
+    runs-on: ubuntu-18.04
+    steps:
+      - uses: actions/checkout@v1
+      - uses: actions/setup-python@v1
+      - name: Nightly test Ubuntu
+        run: |
+          set -x -e
+          bash tools/run_docker.sh -d cpu -c 'make unit-test'

--- a/README.md
+++ b/README.md
@@ -12,10 +12,8 @@
 
 | Build Type      | Status |
 | ---             | ---    |
-| **Linux Py2 CPU**   | [![Status](https://storage.googleapis.com/tensorflow-kokoro-build-badges/addons/ubuntu-py2.svg)](https://storage.googleapis.com/tensorflow-kokoro-build-badges/addons/ubuntu-py2.html) |
-| **Linux Py2 GPU**   | [![Status](https://storage.googleapis.com/tensorflow-kokoro-build-badges/addons/ubuntu-gpu-py2.svg)](https://storage.googleapis.com/tensorflow-kokoro-build-badges/addons/ubuntu-gpu-py2.html) |
-| **Linux Py3 CPU**   | [![Status](https://storage.googleapis.com/tensorflow-kokoro-build-badges/addons/ubuntu-py3.svg)](https://storage.googleapis.com/tensorflow-kokoro-build-badges/addons/ubuntu-py3.html) |
-| **Linux Py3 GPU**   | [![Status](https://storage.googleapis.com/tensorflow-kokoro-build-badges/addons/ubuntu-gpu-py3.svg)](https://storage.googleapis.com/tensorflow-kokoro-build-badges/addons/ubuntu-gpu-py3.html) |
+| **Ubuntu Py3 CPU**   | [![Status](https://github.com/tensorflow/addons/workflows/ubuntu-cpu-nightly/badge.svg)](https://github.com/tensorflow/addons/actions?query=workflow%3Aubuntu-cpu-nightly) |
+| **Ubuntu Py3 GPU**   | [![Status](https://storage.googleapis.com/tensorflow-kokoro-build-badges/addons/ubuntu-gpu-py3.svg)](https://storage.googleapis.com/tensorflow-kokoro-build-badges/addons/ubuntu-gpu-py3.html) |
 | **MacOS Py3 CPU**   | [![Status](https://github.com/tensorflow/addons/workflows/macos-nightly/badge.svg)](https://github.com/tensorflow/addons/actions?query=workflow%3Amacos-nightly) |
 | **Windows Py3 CPU**   | [![Status](https://github.com/tensorflow/addons/workflows/windows-nightly/badge.svg)](https://github.com/tensorflow/addons/actions?query=workflow%3Awindows-nightly) |
 


### PR DESCRIPTION
Moving CPU testing to github. After this merges we can contact TF team to update per #863 