### PR TITLE
CLN: Consolidate test case label

### DIFF
--- a/.github/boring-cyborg.yml
+++ b/.github/boring-cyborg.yml
@@ -41,7 +41,7 @@ labelPRBasedOnFilePath:
   tutorials:
     - docs/tutorials/**/*
 
-  testing:
+  test-cases:
     - tools/ci_testing/**/
 
   style:


### PR DESCRIPTION
After this we can remove the duplicate `testing` label