### PR TITLE
Target tensorflow stable instead of tensorflow-nightly.

### DIFF
--- a/.github/workflows/macos_nightly.yml
+++ b/.github/workflows/macos_nightly.yml
@@ -2,7 +2,6 @@ name: macos-nightly
 
 on:
   schedule:
-    # Shortly after tf-nightly is released
     - cron:  '0 11 * * *'
 
 env:

--- a/.github/workflows/ubuntu_nightly.yml
+++ b/.github/workflows/ubuntu_nightly.yml
@@ -3,7 +3,6 @@ name: ubuntu-cpu-nightly
 
 on:
   schedule:
-    # Shortly after tf-nightly is released
     - cron:  '0 11 * * *'
 
 env:

--- a/.github/workflows/windows_nightly.yml
+++ b/.github/workflows/windows_nightly.yml
@@ -2,7 +2,6 @@ name: windows-nightly
 
 on:
   schedule:
-    # Shortly after tf-nightly is released
     - cron:  '0 11 * * *'
 
 env:

--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ import tensorflow_addons as tfa
 
 #### Nightly Builds
 There are also nightly builds of TensorFlow Addons under the pip package
-`tfa-nightly`, which is built against `tf-nightly`. Nightly builds
+`tfa-nightly`, which is built against the latest stable version of TensorFlow. Nightly builds
 include newer features, but may be less stable than the versioned releases.
 
 ```

--- a/configure.sh
+++ b/configure.sh
@@ -81,11 +81,6 @@ BRANCH=$(git rev-parse --abbrev-ref HEAD)
 PYTHON_PATH=$(which python)
 REQUIRED_PKG=$(cat requirements.txt)
 
-if [[ ${BRANCH} == "master" ]]; then
-  echo "WARN: You're building from master branch, please ensure that you want to build \
-against tf-nightly. Otherwise please checkout a recent stable release branch."
-fi
-
 echo ""
 echo "> TensorFlow Addons will link to the framework in a pre-installed TF pacakge..."
 echo "> Checking installed packages in ${PYTHON_PATH}"

--- a/docs/overview.md
+++ b/docs/overview.md
@@ -34,7 +34,7 @@ import tensorflow_addons as tfa
 
 #### Nightly Builds
 There are also nightly builds of TensorFlow Addons under the pip package
-`tfa-nightly`, which is built against `tf-nightly`. Nightly builds
+`tfa-nightly`, which is built against the latest stable version of TensorFlow. Nightly builds
 include newer features, but may be less stable than the versioned releases.
 
 ```

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,1 @@
-tf-nightly
+tensorflow==2.1.0


### PR DESCRIPTION
Linked to #893

I'll try to list here the pros and cons so that we can decide if we go forward with this or not:

Pros:

* The CI can't fail out of nowhere because or a bug/API change on the Tensorflow side. The CI is more deterministic than before.
* The bump of the tensorflow version can be done in a isolated manner, in a pull request.
* We can make a minimal Dockerfile used for testing and tooling locally, and include bazel and tensorflow inside. Contributors won't have to download tf-nightly every day. Build once, run every day :)
* We don't have to support a single version of tensorflow, we can support a range of them and test against the oldest and the most recent in the CI: (eg: >=2.0.0,<2.2.0)
* If the dependency doesn't change every day, it means that the unit tests are reproductible. We can then use tools like `git biscect` to detect the commit which introduced a bug in the master branch.

Cons:

* We can't use the latest features available in tf-nightly.
* We have to bump the version number manually because it will be pinned, before it was done automatically.
* People using TensorFlow nightly might not be able to use the latest version of the addons master branch if TensorFlow inserted a regression or an API change.

To be honest, all the points made above (pros and cons) are pretty weak because tensorflow have strong API garantees. Those are generalities about pinning the version numbers in CIs. 

The only strong points might be the ones about tensorflow bugs and about not having to download tf-nightly every day when using Docker locally to test things.
