### PR TITLE
FIX: Build with the correct python version

### DIFF
--- a/tools/ci_build/builds/release_linux.sh
+++ b/tools/ci_build/builds/release_linux.sh
@@ -34,11 +34,11 @@ add-apt-repository -y ppa:deadsnakes/ppa
 apt-get -y -qq update
 
 for version in ${PYTHON_VERSIONS}; do
-    export PYTHON_VERSION=${version}
-    apt-get -y -qq install ${PYTHON_VERSION}
+    apt-get -y -qq install ${version}
+    ln -sf /usr/bin/${version} /usr/bin/python
 
-    ${PYTHON_VERSION} get-pip.py -q
-    ${PYTHON_VERSION} -m pip --version
+    python get-pip.py -q
+    python -m pip --version
 
     #Link TF dependency
     yes 'y' | ./configure.sh --quiet

--- a/tools/ci_build/builds/tf_auditwheel_patch.sh
+++ b/tools/ci_build/builds/tf_auditwheel_patch.sh
@@ -16,6 +16,7 @@
 
 set -e
 
+SITE_PKG_LOCATION=$(python -c "import site; print(site.getsitepackages()[0])")
 TF_SHARED_LIBRARY_NAME=$(grep -r TF_SHARED_LIBRARY_NAME .bazelrc | awk -F= '{print$2}')
-POLICY_JSON="/usr/local/lib/python3.6/dist-packages/auditwheel/policy/policy.json"
+POLICY_JSON="${SITE_PKG_LOCATION}/auditwheel/policy/policy.json"
 sed -i "s/libresolv.so.2\"/libresolv.so.2\", $TF_SHARED_LIBRARY_NAME/g" $POLICY_JSON

--- a/tools/ci_build/builds/wheel_verify.sh
+++ b/tools/ci_build/builds/wheel_verify.sh
@@ -20,7 +20,7 @@ if [[ $(uname) == "Darwin" ]]; then
     CMD="delocate-wheel -w wheelhouse"
 elif [[ $(uname) == "Linux" ]]; then
     apt-get -y -qq update && apt-get install patchelf
-    pip3.6 install -U auditwheel==2.0.0
+    python -m pip install -U auditwheel==2.0.0
     tools/ci_build/builds/tf_auditwheel_patch.sh
     CMD="auditwheel repair --plat manylinux2010_x86_64"
 fi


### PR DESCRIPTION
Current build is failing since it's trying to build a python2 whl after the new changes:
https://travis-ci.org/tensorflow/addons/jobs/639961631#L281

The real issue is that the configure script now removed a hacky PYTHON_VERSION env lookup. Instead I've created a symlink in the loop. 

Also cleaned up some hard-coded hackiness in the auditwheel check.