### PR TITLE
Fix: Remove descriptions about global_step in tfa.optimizers.{SGDW, AdamW}

### DIFF
--- a/tensorflow_addons/optimizers/weight_decay_optimizers.py
+++ b/tensorflow_addons/optimizers/weight_decay_optimizers.py
@@ -114,9 +114,7 @@ class DecoupledWeightDecayExtension:
                 to all variables in var_list.
             name: Optional name for the returned operation.
         Returns:
-            An Operation that updates the variables in `var_list`.  If
-            `global_step` was not `None`, that operation also increments
-            `global_step`.
+            An Operation that updates the variables in `var_list`.
         Raises:
             ValueError: If some of the variables are not `Variable` objects.
         """
@@ -137,9 +135,7 @@ class DecoupledWeightDecayExtension:
             decay_var_list: Optional list of variables to be decayed. Defaults
                 to all variables in var_list.
         Returns:
-            An `Operation` that applies the specified gradients. If
-            `global_step` was not None, that operation also increments
-            `global_step`.
+            An `Operation` that applies the specified gradients.
         Raises:
             TypeError: If `grads_and_vars` is malformed.
             ValueError: If none of the variables have gradients.


### PR DESCRIPTION
`tfa.optimizers.SGDW` and `tfa.optimizers.AdamW` do not have `global_step` argument for `minimize()` method.
But the document describes about them. This PR removes them.