### PR TITLE
fixed tqdm progress bar tutorial and comments

### DIFF
--- a/docs/tutorials/tqdm_progress_bar.ipynb
+++ b/docs/tutorials/tqdm_progress_bar.ipynb
@@ -30,8 +30,8 @@
     {
       "cell_type": "markdown",
       "metadata": {
-        "id": "MyujzrAv2Vpk",
-        "colab_type": "text"
+        "colab_type": "text",
+        "id": "MyujzrAv2Vpk"
       },
       "source": [
         "##### Copyright 2019 The TensorFlow Authors."
@@ -39,11 +39,13 @@
     },
     {
       "cell_type": "code",
+      "execution_count": 0,
       "metadata": {
-        "id": "rTUqXTqa2Vpm",
+        "colab": {},
         "colab_type": "code",
-        "colab": {}
+        "id": "rTUqXTqa2Vpm"
       },
+      "outputs": [],
       "source": [
         "#@title Licensed under the Apache License, Version 2.0 (the \"License\");\n",
         "# you may not use this file except in compliance with the License.\n",
@@ -56,15 +58,13 @@
         "# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.\n",
         "# See the License for the specific language governing permissions and\n",
         "# limitations under the License."
-      ],
-      "execution_count": 0,
-      "outputs": []
+      ]
     },
     {
       "cell_type": "markdown",
       "metadata": {
-        "id": "rNnfCHh82Vpq",
-        "colab_type": "text"
+        "colab_type": "text",
+        "id": "rNnfCHh82Vpq"
       },
       "source": [
         "# TensorFlow Addons Callbacks: TQDM Progress Bar"
@@ -73,8 +73,8 @@
     {
       "cell_type": "markdown",
       "metadata": {
-        "id": "4qrDJoTw2Vps",
-        "colab_type": "text"
+        "colab_type": "text",
+        "id": "4qrDJoTw2Vps"
       },
       "source": [
         "<table class=\"tfo-notebook-buttons\" align=\"left\">\n",
@@ -96,8 +96,8 @@
     {
       "cell_type": "markdown",
       "metadata": {
-        "id": "bVS_PkvX2Vpt",
-        "colab_type": "text"
+        "colab_type": "text",
+        "id": "bVS_PkvX2Vpt"
       },
       "source": [
         "## Overview\n",
@@ -107,8 +107,8 @@
     {
       "cell_type": "markdown",
       "metadata": {
-        "id": "sRldODz32Vpu",
-        "colab_type": "text"
+        "colab_type": "text",
+        "id": "sRldODz32Vpu"
       },
       "source": [
         "## Setup"
@@ -116,43 +116,52 @@
     },
     {
       "cell_type": "code",
+      "execution_count": 0,
       "metadata": {
-        "id": "ifZMP21C2Vp1",
+        "colab": {},
         "colab_type": "code",
-        "colab": {}
+        "id": "ifZMP21C2Vp1"
       },
+      "outputs": [],
       "source": [
         "try:\n",
         "    # %tensorflow_version only exists in Colab.\n",
         "    %tensorflow_version 2.x\n",
         "except Exception:\n",
         "    pass"
-      ],
-      "execution_count": 0,
-      "outputs": []
+      ]
     },
     {
       "cell_type": "code",
-      "metadata": {
-        "id": "etYr-Suo4KYj",
-        "colab_type": "code",
-        "colab": {}
-      },
-      "source": [
-        "import tensorflow as tf"
-      ],
       "execution_count": 0,
-      "outputs": []
-    },
-    {
-      "cell_type": "code",
       "metadata": {
-        "id": "SfXA0mI13pSE",
+        "colab": {},
         "colab_type": "code",
-        "colab": {}
+        "id": "etYr-Suo4KYj"
       },
+      "outputs": [],
       "source": [
+        "!pip install -q --no-deps tensorflow-addons~=0.7\n",
         "!pip install -q \"tqdm>=4.36.1\"\n",
+        "\n",
+        "import tensorflow as tf\n",
+        "import tensorflow_addons as tfa\n",
+        "\n",
+        "from tensorflow.keras.datasets import mnist\n",
+        "from tensorflow.keras.models import Sequential\n",
+        "from tensorflow.keras.layers import Dense, Dropout, Flatten"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": 0,
+      "metadata": {
+        "colab": {},
+        "colab_type": "code",
+        "id": "SfXA0mI13pSE"
+      },
+      "outputs": [],
+      "source": [
         "import tqdm\n",
         "\n",
         "# quietly deep-reload tqdm\n",
@@ -165,46 +174,13 @@
         "sys.stdout = stdout\n",
         "\n",
         "tqdm.__version__"
-      ],
-      "execution_count": 0,
-      "outputs": []
-    },
-    {
-      "cell_type": "code",
-      "metadata": {
-        "scrolled": true,
-        "id": "QJdDURmv2Vpv",
-        "colab_type": "code",
-        "colab": {}
-      },
-      "source": [
-        "!pip install -q --no-deps tensorflow-addons~=0.7"
-      ],
-      "execution_count": 0,
-      "outputs": []
-    },
-    {
-      "cell_type": "code",
-      "metadata": {
-        "id": "ErfOKh6A2Vp4",
-        "colab_type": "code",
-        "colab": {}
-      },
-      "source": [
-        "import tensorflow_addons as tfa\n",
-        "\n",
-        "from tensorflow.keras.datasets import mnist\n",
-        "from tensorflow.keras.models import Sequential\n",
-        "from tensorflow.keras.layers import Dense, Dropout, Flatten"
-      ],
-      "execution_count": 0,
-      "outputs": []
+      ]
     },
     {
       "cell_type": "markdown",
       "metadata": {
-        "id": "2RGuwIwe2Vp7",
-        "colab_type": "text"
+        "colab_type": "text",
+        "id": "2RGuwIwe2Vp7"
       },
       "source": [
         "## Import and Normalize Data"
@@ -212,25 +188,25 @@
     },
     {
       "cell_type": "code",
+      "execution_count": 0,
       "metadata": {
-        "id": "qKfrsOSP2Vp8",
+        "colab": {},
         "colab_type": "code",
-        "colab": {}
+        "id": "qKfrsOSP2Vp8"
       },
+      "outputs": [],
       "source": [
         "# the data, split between train and test sets\n",
         "(x_train, y_train), (x_test, y_test) = mnist.load_data()\n",
         "# normalize data\n",
         "x_train, x_test = x_train / 255.0, x_test / 255.0"
-      ],
-      "execution_count": 0,
-      "outputs": []
+      ]
     },
     {
       "cell_type": "markdown",
       "metadata": {
-        "id": "ORtL0s4X2VqB",
-        "colab_type": "text"
+        "colab_type": "text",
+        "id": "ORtL0s4X2VqB"
       },
       "source": [
         "## Build Simple MNIST CNN Model"
@@ -238,11 +214,13 @@
     },
     {
       "cell_type": "code",
+      "execution_count": 0,
       "metadata": {
-        "id": "z8uAGGV32VqC",
+        "colab": {},
         "colab_type": "code",
-        "colab": {}
+        "id": "z8uAGGV32VqC"
       },
+      "outputs": [],
       "source": [
         "# build the model using the Sequential API\n",
         "model = Sequential()\n",
@@ -254,15 +232,13 @@
         "model.compile(optimizer='adam',\n",
         "              loss = 'sparse_categorical_crossentropy',\n",
         "              metrics=['accuracy'])"
-      ],
-      "execution_count": 0,
-      "outputs": []
+      ]
     },
     {
       "cell_type": "markdown",
       "metadata": {
-        "id": "YWOnH1ga2VqF",
-        "colab_type": "text"
+        "colab_type": "text",
+        "id": "YWOnH1ga2VqF"
       },
       "source": [
         "## Default TQDMCallback Usage"
@@ -270,12 +246,14 @@
     },
     {
       "cell_type": "code",
+      "execution_count": 0,
       "metadata": {
-        "scrolled": true,
-        "id": "Vl_oj_OW2VqG",
+        "colab": {},
         "colab_type": "code",
-        "colab": {}
+        "id": "Vl_oj_OW2VqG",
+        "scrolled": true
       },
+      "outputs": [],
       "source": [
         "# initialize tqdm callback with default parameters\n",
         "tqdm_callback = tfa.callbacks.TQDMProgressBar()\n",
@@ -289,15 +267,13 @@
         "          verbose=0,\n",
         "          callbacks=[tqdm_callback],\n",
         "          validation_data=(x_test, y_test))"
-      ],
-      "execution_count": 0,
-      "outputs": []
+      ]
     },
     {
       "cell_type": "markdown",
       "metadata": {
-        "id": "uFvBfwJN2VqK",
-        "colab_type": "text"
+        "colab_type": "text",
+        "id": "uFvBfwJN2VqK"
       },
       "source": [
         "**Below is the expected output when you run the cell above**\n",

--- a/tensorflow_addons/callbacks/tqdm_progress_bar.py
+++ b/tensorflow_addons/callbacks/tqdm_progress_bar.py
@@ -27,7 +27,7 @@ class TQDMProgressBar(Callback):
 
     Args:
         metrics_separator: Custom separator between metrics.
-            Defaults to ' - '
+            Defaults to ' - '.
         overall_bar_format: Custom bar format for overall
             (outer) progress bar, see https://github.com/tqdm/tqdm#parameters
             for more detail.

--- a/tensorflow_addons/callbacks/tqdm_progress_bar.py
+++ b/tensorflow_addons/callbacks/tqdm_progress_bar.py
@@ -25,24 +25,24 @@ from tensorflow.keras.callbacks import Callback
 class TQDMProgressBar(Callback):
     """TQDM Progress Bar for Tensorflow Keras.
 
-    Arguments:
-        metrics_separator (string): Custom separator between metrics.
+    Args:
+        metrics_separator: Custom separator between metrics.
             Defaults to ' - '
-        overall_bar_format (string format): Custom bar format for overall
+        overall_bar_format: Custom bar format for overall
             (outer) progress bar, see https://github.com/tqdm/tqdm#parameters
             for more detail.
-        epoch_bar_format (string format): Custom bar format for epoch
+        epoch_bar_format: Custom bar format for epoch
             (inner) progress bar, see https://github.com/tqdm/tqdm#parameters
             for more detail.
-        update_per_second (int): Maximum number of updates in the epochs bar
+        update_per_second: Maximum number of updates in the epochs bar
             per second, this is to prevent small batches from slowing down
             training. Defaults to 10.
-        metrics_format (string): Custom format for how metrics are formatted.
+        metrics_format: Custom format for how metrics are formatted.
             See https://github.com/tqdm/tqdm#parameters for more detail.
-        leave_epoch_progress (bool): True to leave epoch progress bars
-        leave_overall_progress (bool): True to leave overall progress bar
-        show_epoch_progress (bool): False to hide epoch progress bars
-        show_overall_progress (bool): False to hide overall progress bar
+        leave_epoch_progress (bool): True to leave epoch progress bars.
+        leave_overall_progress (bool): True to leave overall progress bar.
+        show_epoch_progress (bool): False to hide epoch progress bars.
+        show_overall_progress (bool): False to hide overall progress bar.
     """
 
     def __init__(self,

--- a/tensorflow_addons/callbacks/tqdm_progress_bar.py
+++ b/tensorflow_addons/callbacks/tqdm_progress_bar.py
@@ -39,10 +39,10 @@ class TQDMProgressBar(Callback):
             training. Defaults to 10.
         metrics_format: Custom format for how metrics are formatted.
             See https://github.com/tqdm/tqdm#parameters for more detail.
-        leave_epoch_progress (bool): True to leave epoch progress bars.
-        leave_overall_progress (bool): True to leave overall progress bar.
-        show_epoch_progress (bool): False to hide epoch progress bars.
-        show_overall_progress (bool): False to hide overall progress bar.
+        leave_epoch_progress: True to leave epoch progress bars.
+        leave_overall_progress: True to leave overall progress bar.
+        show_epoch_progress: False to hide epoch progress bars.
+        show_overall_progress: False to hide overall progress bar.
     """
 
     def __init__(self,


### PR DESCRIPTION
This PR fixed TQDM Progress Bar tutorial failure (cause: installing importing tfa after deep reloading tqdm), this PR also fixed the comments for TQDM Progress Bar so that the doc generated on Tensorflow.org can display the arguments nicely (https://www.tensorflow.org/addons/api_docs/python/tfa/callbacks/TQDMProgressBar)

https://github.com/tensorflow/addons/issues/934