### PR TITLE
Ensuring flake8 is compatible with black.

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -3,8 +3,12 @@
 ignore =
     # defaults flake8 ignores
     E121,E123,E126,E226,E24,E704,W503,W504
-    # Function name should be lowercase
-    N802
+    # whitespace before ':'
+    # https://black.readthedocs.io/en/stable/the_black_code_style.html#slices
+    E203
+    # Line too long
+    # We use black, no need to enforce line length
+    E501
     # lowercase ... imported as non lowercase
     # Useful to ignore for "import keras.backend as K"
     N812
@@ -27,6 +31,3 @@ ignore =
 
 #imported but unused in __init__.py, that's ok.
 per-file-ignores = **/__init__.py:F401
-
-# TODO: reduce the max line length to 90-ish
-max-line-length = 210


### PR DESCRIPTION
See #932 for more context

Some modifications were added to ensure we don't get conflicts between black and flake8. 

Actually pycodestyle have checks that are really nice to have even if we use black. It would be beneficial for us to keep them. e.g.:

* do not compare types, use ‘isinstance()’
* do not use variables named ‘l’, ‘O’, or ‘I’
* do not use bare except, specify exception instead
and so on...

For this reason, I followed black's documentation and only changed a few rules to ensure compatibility.