### PR TITLE
[WIP] BLD: Use python3 in configuration

### DIFF
--- a/.github/workflows/ci_test.yml
+++ b/.github/workflows/ci_test.yml
@@ -42,7 +42,7 @@ jobs:
     runs-on: windows-latest
     strategy:
       matrix:
-        python-version: ['3.7']
+        python-version: ['3.7.6']
     steps:
       - uses: actions/checkout@v1
       - uses: actions/setup-python@v1
@@ -51,7 +51,8 @@ jobs:
       - name: CI test windows py${{ matrix.python-version }}
         shell: bash
         run: |
-            python -m pip install wheel setuptools
+            cp /c/hostedtoolcache/windows/Python/${{ matrix.python-version }}/x64/python /c/hostedtoolcache/windows/Python/${{ matrix.python-version }}/x64/python3
+            python3 -m pip install wheel setuptools
             curl -sSOL https://github.com/bazelbuild/bazel/releases/download/${BAZEL_VERSION}/bazel-${BAZEL_VERSION}-windows-x86_64.exe
             export BAZEL_VC=/c/Program\ Files\ \(x86\)/Microsoft\ Visual\ Studio/2019/Enterprise/VC/
             export BAZEL_PATH=/d/a/addons/addons/bazel-${BAZEL_VERSION}-windows-x86_64.exe

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -51,7 +51,8 @@ jobs:
       - name: CPU test Windows py${{ matrix.python-version }}
         shell: bash
         run: |
-          python -m pip install wheel setuptools
+          cp /c/hostedtoolcache/windows/Python/${{ matrix.python-version }}/x64/python /c/hostedtoolcache/windows/Python/${{ matrix.python-version }}/x64/python3
+          python3 -m pip install wheel setuptools
           curl -sSOL https://github.com/bazelbuild/bazel/releases/download/${BAZEL_VERSION}/bazel-${BAZEL_VERSION}-windows-x86_64.exe
           export BAZEL_VC=/c/Program\ Files\ \(x86\)/Microsoft\ Visual\ Studio/2019/Enterprise/VC/
           export BAZEL_PATH=/d/a/addons/addons/bazel-${BAZEL_VERSION}-windows-x86_64.exe
@@ -106,7 +107,8 @@ jobs:
           python-version: ${{ matrix.python-version }}
       - name: Build and release for Windows
         run: |
-          python -m pip install wheel setuptools
+          cp /c/hostedtoolcache/windows/Python/${{ matrix.python-version }}/x64/python /c/hostedtoolcache/windows/Python/${{ matrix.python-version }}/x64/python3
+          python3 -m pip install wheel setuptools
           curl -sSOL https://github.com/bazelbuild/bazel/releases/download/${BAZEL_VERSION}/bazel-${BAZEL_VERSION}-windows-x86_64.exe
           export BAZEL_VC=/c/Program\ Files\ \(x86\)/Microsoft\ Visual\ Studio/2019/Enterprise/VC/
           export BAZEL_PATH=/d/a/addons/addons/bazel-${BAZEL_VERSION}-windows-x86_64.exe

--- a/.github/workflows/windows_nightly.yml
+++ b/.github/workflows/windows_nightly.yml
@@ -22,7 +22,8 @@ jobs:
       - name: Nightly test Windows py${{ matrix.python-version }}
         shell: bash
         run: |
-          python -m pip install wheel setuptools
+          cp /c/hostedtoolcache/windows/Python/${{ matrix.python-version }}/x64/python /c/hostedtoolcache/windows/Python/${{ matrix.python-version }}/x64/python3
+          python3 -m pip install wheel setuptools
           curl -sSOL https://github.com/bazelbuild/bazel/releases/download/${BAZEL_VERSION}/bazel-${BAZEL_VERSION}-windows-x86_64.exe
           export BAZEL_VC=/c/Program\ Files\ \(x86\)/Microsoft\ Visual\ Studio/2019/Enterprise/VC/
           export BAZEL_PATH=/d/a/addons/addons/bazel-${BAZEL_VERSION}-windows-x86_64.exe
@@ -42,7 +43,8 @@ jobs:
           python-version: ${{ matrix.python-version }}
       - name: Nightly build and release for Windows
         run: |
-          python -m pip install wheel setuptools
+          cp /c/hostedtoolcache/windows/Python/${{ matrix.python-version }}/x64/python /c/hostedtoolcache/windows/Python/${{ matrix.python-version }}/x64/python3
+          python3 -m pip install wheel setuptools
           curl -sSOL https://github.com/bazelbuild/bazel/releases/download/${BAZEL_VERSION}/bazel-${BAZEL_VERSION}-windows-x86_64.exe
           export BAZEL_VC=/c/Program\ Files\ \(x86\)/Microsoft\ Visual\ Studio/2019/Enterprise/VC/
           export BAZEL_PATH=/d/a/addons/addons/bazel-${BAZEL_VERSION}-windows-x86_64.exe

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -94,9 +94,6 @@ GPU Docker: `docker run --runtime=nvidia --rm -it -v ${PWD}:/addons -w /addons g
 
 Configure:
 ```
-# Temporary until /usr/bin/python is py3 by default on ubuntu.
-ln -sf /usr/bin/python3.6 /usr/bin/python && rm /usr/bin/python2 
-
 ./configure.sh  # Links project with TensorFlow dependency
 ```
 Run selected tests:

--- a/configure.sh
+++ b/configure.sh
@@ -78,19 +78,19 @@ elif [[ -n "$1" ]]; then
 fi
 
 BRANCH=$(git rev-parse --abbrev-ref HEAD)
-PYTHON_PATH=$(which python)
+PYTHON_PATH=$(which python3)
 REQUIRED_PKG=$(cat requirements.txt)
 
 echo ""
 echo "> TensorFlow Addons will link to the framework in a pre-installed TF pacakge..."
 echo "> Checking installed packages in ${PYTHON_PATH}"
-python build_deps/check_deps.py
+python3 build_deps/check_deps.py
 
 if [[ $? == 1 ]]; then
   read -r -p "Package ${REQUIRED_PKG} will be installed. Are You Sure? [y/n] " reply
   case $reply in
       [yY]*) echo "> Installing..."
-         python -m pip install $PIP_INSTALL_OPTS -r requirements.txt;;
+         python3 -m pip install $PIP_INSTALL_OPTS -r requirements.txt;;
       * ) echo "> Exiting..."; exit;;
   esac
 else
@@ -99,9 +99,9 @@ fi
 
 [[ -f .bazelrc ]] && rm .bazelrc
 
-TF_CFLAGS=($(python -c 'import logging; logging.disable(logging.WARNING);import tensorflow as tf; print(" ".join(tf.sysconfig.get_compile_flags()))'))
-TF_LFLAGS=($(python -c 'import logging; logging.disable(logging.WARNING);import tensorflow as tf; print(" ".join(tf.sysconfig.get_link_flags()))'))
-TF_CXX11_ABI_FLAG=($(python -c 'import logging; logging.disable(logging.WARNING);import tensorflow as tf; print(tf.sysconfig.CXX11_ABI_FLAG)'))
+TF_CFLAGS=($(python3 -c 'import logging; logging.disable(logging.WARNING);import tensorflow as tf; print(" ".join(tf.sysconfig.get_compile_flags()))'))
+TF_LFLAGS=($(python3 -c 'import logging; logging.disable(logging.WARNING);import tensorflow as tf; print(" ".join(tf.sysconfig.get_link_flags()))'))
+TF_CXX11_ABI_FLAG=($(python3 -c 'import logging; logging.disable(logging.WARNING);import tensorflow as tf; print(tf.sysconfig.CXX11_ABI_FLAG)'))
 
 TF_SHARED_LIBRARY_NAME=$(generate_shared_lib_name ${TF_LFLAGS[1]})
 TF_HEADER_DIR=${TF_CFLAGS:2}

--- a/tools/run_docker.sh
+++ b/tools/run_docker.sh
@@ -71,19 +71,16 @@ case ${DEVICE} in
         ;;
 esac
 
-# Temporary until /usr/bin/python default to py3 on ubuntu.
-ENVIRONMENT_CMD="ln -sf /usr/bin/python3.6 /usr/bin/python && rm /usr/bin/python2"
 
 if [[ -z "${COMMAND}" ]]; then
     echo "command string cannot be empty"
     exit 1
 fi
 
-DOCKER_CMD="${ENVIRONMENT_CMD} && ${COMMAND}"
 echo "Docker image: ${DOCKER_IMAGE}"
-echo "Docker command: ${DOCKER_CMD}"
+echo "Docker command: ${COMMAND}"
 docker run ${DOCKER_OPTS}                   \
     --network=host                          \
     --rm -v ${ROOT_DIR}:/addons -w /addons  \
     ${DOCKER_IMAGE}                         \
-    /bin/bash -c "${DOCKER_CMD}"
+    /bin/bash -c "${COMMAND}"


### PR DESCRIPTION
Previously we kept the configuration as `python` since windows doesn't have a python3 symlink. I would prefer not leaving having the `ln -sf /usr/bin/python3.6 /usr/bin/python && rm /usr/bin/python2` in our instructions since a large majority of our developers run in the docker container.

SIG IO has done a similar thing:
https://github.com/tensorflow/io/blob/master/.github/workflows/build.yml#L203