### PR TITLE
FIX: GitHub build

### DIFF
--- a/.github/workflows/macos_nightly.yml
+++ b/.github/workflows/macos_nightly.yml
@@ -26,6 +26,8 @@ jobs:
           bash -x -e tools/ci_testing/addons_cpu.sh
   macos-nightly-release:
     name: Build and release nightly for macOS
+    env:
+      PYPI_PW: ${{ secrets.pypi_password }}
     needs: [macos-nightly]
     runs-on: macos-latest
     strategy:
@@ -41,8 +43,5 @@ jobs:
           python --version
           bash tools/ci_testing/install_bazel_macos.sh $BAZEL_VERSION
           bash -x -e tools/ci_build/builds/release_macos.sh
-      - uses: pypa/gh-action-pypi-publish@master
-        with:
-          user: __token__
-          password: ${{ secrets.pypi_password }}
-          packages_dir: wheelhouse/
+          python -m pip install -U twine
+          twine upload -u __token__ -p $PYPI_PW wheelhouse/*.whl

--- a/.github/workflows/ubuntu_nightly.yml
+++ b/.github/workflows/ubuntu_nightly.yml
@@ -16,6 +16,8 @@ jobs:
           bash tools/run_docker.sh -d cpu -c 'make unit-test'
   manylinux-nightly-release:
     name: Build and release nightly for manylinux2010
+    env:
+      PYPI_PW: ${{ secrets.pypi_password }}
     needs: [ubuntu-cpu-nightly]
     runs-on: ubuntu-18.04
     steps:
@@ -23,8 +25,5 @@ jobs:
       - name: Nightly build and release for Linux
         run: |
           docker run -e TF_NEED_CUDA=1 -v ${PWD}:/addons -w /addons gcr.io/tensorflow-testing/nosla-cuda10.1-cudnn7-ubuntu16.04-manylinux2010 tools/ci_build/builds/release_linux.sh
-      - uses: pypa/gh-action-pypi-publish@master
-        with:
-          user: __token__
-          password: ${{ secrets.pypi_password }}
-          packages_dir: wheelhouse/
+          python -m pip install -U twine
+          twine upload -u __token__ -p $PYPI_PW wheelhouse/*.whl

--- a/.github/workflows/windows_nightly.yml
+++ b/.github/workflows/windows_nightly.yml
@@ -30,6 +30,8 @@ jobs:
           bash -x -e ./tools/ci_testing/addons_cpu.sh
   windows-nightly-release:
     name: Build and release nightly for Windows
+    env:
+      PYPI_PW: ${{ secrets.pypi_password }}
     needs: [windows-nightly]
     runs-on: windows-latest
     strategy:
@@ -49,8 +51,5 @@ jobs:
           export BAZEL_PATH=/d/a/addons/addons/bazel-${BAZEL_VERSION}-windows-x86_64.exe
           export PATH=/c/hostedtoolcache/windows/Python/${{ matrix.python-version }}/x64/:$PATH
           bash -x -e tools/ci_build/builds/release_windows.sh
-      - uses: pypa/gh-action-pypi-publish@master
-        with:
-          user: __token__
-          password: ${{ secrets.pypi_password }}
-          packages_dir: artifacts/
+          python -m pip install -U twine
+          twine upload -u __token__ -p $PYPI_PW artifacts/*.whl

--- a/tools/ci_build/builds/tf_auditwheel_patch.sh
+++ b/tools/ci_build/builds/tf_auditwheel_patch.sh
@@ -16,7 +16,7 @@
 
 set -e
 
-SITE_PKG_LOCATION=$(python -c "import site; print(site.getsitepackages()[0])")
+SITE_PKG_LOCATION=$(python3 -c "import site; print(site.getsitepackages()[0])")
 TF_SHARED_LIBRARY_NAME=$(grep -r TF_SHARED_LIBRARY_NAME .bazelrc | awk -F= '{print$2}')
 POLICY_JSON="${SITE_PKG_LOCATION}/auditwheel/policy/policy.json"
 sed -i "s/libresolv.so.2\"/libresolv.so.2\", $TF_SHARED_LIBRARY_NAME/g" $POLICY_JSON


### PR DESCRIPTION
Feedback cycle on this is painfully slow. If this doesn't work tomorrow then I'll modify the yaml so we can troubleshoot on each push.

PyPi Github action is only for linux. We could work around this by uploading /downloading the artifacts and pushing once. But I'd like to see the builds succeed and publish prior to optimizing so as to change as little as possible.