### PR TITLE
Quick Fix for Time_Stopping Callback Bug

### DIFF
--- a/tensorflow_addons/callbacks/time_stopping.py
+++ b/tensorflow_addons/callbacks/time_stopping.py
@@ -36,14 +36,15 @@ class TimeStopping(Callback):
 
         self.seconds = seconds
         self.verbose = verbose
+        self.stopped_epoch = 0
 
     def on_train_begin(self, logs=None):
         self.stopping_time = time.time() + self.seconds
 
     def on_epoch_end(self, epoch, logs={}):
+        self.stopped_epoch = epoch
         if time.time() >= self.stopping_time:
             self.model.stop_training = True
-            self.stopped_epoch = epoch
 
     def on_train_end(self, logs=None):
         if self.verbose > 0:


### PR DESCRIPTION
Discovered by @RomainBrault in https://github.com/tensorflow/addons/issues/964, the time_stopping callback breaks when the training ends before the proposed time is passed, due to `self.stopped_epoch` been undefined when that case happened. This small PR fixed it. Thanks @RomainBrault for catching the bug and proposed fix!