### PR TITLE
Moved the bazel format check outside the sanity check. 

### DIFF
--- a/.github/workflows/ci_test.yml
+++ b/.github/workflows/ci_test.yml
@@ -100,3 +100,13 @@ jobs:
         run: TF_ADDONS_NO_BUILD=1 pip install --no-deps -e .
       - name: Run type check
         run: python tools/ci_build/verify/check_typing_info.py
+  check-bazel-format:
+    name: Bazel code format
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v1
+      - name: install buildifier
+        run: |
+          wget -O /usr/local/bin/buildifier https://github.com/bazelbuild/buildtools/releases/download/0.29.0/buildifier
+      - name: Check that the Bazel files are formatted with buildifier
+        run: buildifier -mode=check -r ./

--- a/.github/workflows/ci_test.yml
+++ b/.github/workflows/ci_test.yml
@@ -109,5 +109,5 @@ jobs:
         run: |
           sudo wget -O /usr/local/bin/buildifier https://github.com/bazelbuild/buildtools/releases/download/0.29.0/buildifier
           sudo chmod +x /usr/local/bin/buildifier
-      - name: Check that the Bazel files are formatted with buildifier
+      - name: Ensure contributor used "buildifier -r ./" before commit
         run: buildifier -mode=check -r ./

--- a/.github/workflows/ci_test.yml
+++ b/.github/workflows/ci_test.yml
@@ -108,5 +108,6 @@ jobs:
       - name: install buildifier
         run: |
           sudo wget -O /usr/local/bin/buildifier https://github.com/bazelbuild/buildtools/releases/download/0.29.0/buildifier
+          sudo chmod +x /usr/local/bin/buildifier
       - name: Check that the Bazel files are formatted with buildifier
         run: buildifier -mode=check -r ./

--- a/.github/workflows/ci_test.yml
+++ b/.github/workflows/ci_test.yml
@@ -107,6 +107,6 @@ jobs:
       - uses: actions/checkout@v1
       - name: install buildifier
         run: |
-          wget -O /usr/local/bin/buildifier https://github.com/bazelbuild/buildtools/releases/download/0.29.0/buildifier
+          sudo wget -O /usr/local/bin/buildifier https://github.com/bazelbuild/buildtools/releases/download/0.29.0/buildifier
       - name: Check that the Bazel files are formatted with buildifier
         run: buildifier -mode=check -r ./

--- a/build_deps/tf_dependency/tf_configure.bzl
+++ b/build_deps/tf_dependency/tf_configure.bzl
@@ -135,7 +135,6 @@ def _symlink_genrule_for_dir(
         src_files = [],
         dest_files = [],
         tf_pip_dir_rename_pair = []):
-
     """Returns a genrule to symlink(or copy if on Windows) a set of files.
     If src_dir is passed, files will be read from the given directory; otherwise
     we assume files are in src_files and dest_files.
@@ -153,10 +152,11 @@ def _symlink_genrule_for_dir(
     Returns:
         genrule target that creates the symlinks.
     """
+
     # Check that tf_pip_dir_rename_pair has the right length
     tf_pip_dir_rename_pair_len = len(tf_pip_dir_rename_pair)
-    if tf_pip_dir_rename_pair_len != 0 and tf_pip_dir_rename_pair_len !=2:
-      _fail("The size of argument tf_pip_dir_rename_pair should be either 0 or 2, but %d is given." % tf_pip_dir_rename_pair_len)
+    if tf_pip_dir_rename_pair_len != 0 and tf_pip_dir_rename_pair_len != 2:
+        _fail("The size of argument tf_pip_dir_rename_pair should be either 0 or 2, but %d is given." % tf_pip_dir_rename_pair_len)
 
     if src_dir != None:
         src_dir = _norm_path(src_dir)
@@ -165,9 +165,9 @@ def _symlink_genrule_for_dir(
 
         # Create a list with the src_dir stripped to use for outputs.
         if tf_pip_dir_rename_pair_len:
-          dest_files = files.replace(src_dir, "").replace(tf_pip_dir_rename_pair[0], tf_pip_dir_rename_pair[1]).splitlines()
+            dest_files = files.replace(src_dir, "").replace(tf_pip_dir_rename_pair[0], tf_pip_dir_rename_pair[1]).splitlines()
         else:
-          dest_files = files.replace(src_dir, "").splitlines()
+            dest_files = files.replace(src_dir, "").splitlines()
         src_files = files.splitlines()
     command = []
     outs = []
@@ -197,14 +197,13 @@ def _tf_pip_impl(repository_ctx):
         tf_header_dir,
         "include",
         "tf_header_include",
-        tf_pip_dir_rename_pair = ["tensorflow_core", "tensorflow"]
+        tf_pip_dir_rename_pair = ["tensorflow_core", "tensorflow"],
     )
 
     tf_shared_library_dir = repository_ctx.os.environ[_TF_SHARED_LIBRARY_DIR]
     tf_shared_library_name = repository_ctx.os.environ[_TF_SHARED_LIBRARY_NAME]
     tf_shared_library_path = "%s/%s" % (tf_shared_library_dir, tf_shared_library_name)
     tf_cx11_abi = "-D_GLIBCXX_USE_CXX11_ABI=%s" % (repository_ctx.os.environ[_TF_CXX11_ABI_FLAG])
-
 
     tf_shared_library_rule = _symlink_genrule_for_dir(
         repository_ctx,
@@ -221,10 +220,13 @@ def _tf_pip_impl(repository_ctx):
         "%{TF_SHARED_LIBRARY_NAME}": tf_shared_library_name,
     })
 
-    _tpl(repository_ctx,
-        "build_defs.bzl", {
+    _tpl(
+        repository_ctx,
+        "build_defs.bzl",
+        {
             "%{tf_cx11_abi}": tf_cx11_abi,
-    })
+        },
+    )
 
 tf_configure = repository_rule(
     environ = [

--- a/tensorflow_addons/tensorflow_addons.bzl
+++ b/tensorflow_addons/tensorflow_addons.bzl
@@ -1,5 +1,5 @@
 load("@local_config_tf//:build_defs.bzl", "D_GLIBCXX_USE_CXX11_ABI")
-load("@local_config_cuda//cuda:build_defs.bzl", "if_cuda_is_configured", "if_cuda")
+load("@local_config_cuda//cuda:build_defs.bzl", "if_cuda", "if_cuda_is_configured")
 
 def custom_op_library(
         name,
@@ -37,13 +37,20 @@ def custom_op_library(
         deps = deps + if_cuda_is_configured([":" + basename + "_gpu"])
 
     copts = copts + select({
-        "//tensorflow_addons:windows": ["/DEIGEN_STRONG_INLINE=inline",
+        "//tensorflow_addons:windows": [
+            "/DEIGEN_STRONG_INLINE=inline",
             "-DTENSORFLOW_MONOLITHIC_BUILD",
             "/D_USE_MATH_DEFINES",
-             "/DPLATFORM_WINDOWS", "/DEIGEN_HAS_C99_MATH",
-             "/DTENSORFLOW_USE_EIGEN_THREADPOOL", "/DEIGEN_AVOID_STL_ARRAY",
-             "/Iexternal/gemmlowp", "/wd4018", "/wd4577", "/DNOGDI",
-             "/UTF_COMPILE_LIBRARY"],
+            "/DPLATFORM_WINDOWS",
+            "/DEIGEN_HAS_C99_MATH",
+            "/DTENSORFLOW_USE_EIGEN_THREADPOOL",
+            "/DEIGEN_AVOID_STL_ARRAY",
+            "/Iexternal/gemmlowp",
+            "/wd4018",
+            "/wd4577",
+            "/DNOGDI",
+            "/UTF_COMPILE_LIBRARY",
+        ],
         "//conditions:default": ["-pthread", "-std=c++11", D_GLIBCXX_USE_CXX11_ABI],
     })
 

--- a/tools/ci_build/builds/builds_common.sh
+++ b/tools/ci_build/builds/builds_common.sh
@@ -38,19 +38,6 @@ get_changed_files_from_master_branch() {
     git diff ${ANCESTOR} --diff-filter=d --name-only "$@"
 }
 
-# List bazel files changed that still exist,
-# i.e., not removed.
-# Usage: get_bazel_files_to_check [--incremental]
-get_bazel_files_to_check() {
-    if [[ "$1" == "--incremental" ]]; then
-        get_changed_files_from_master_branch -- '*BUILD' '*.bazel' '*.bzl'
-    elif [[ -z "$1" ]]; then
-        find . -name 'BUILD' -o -name '*.bazel' -o -name '*.bzl'
-    else
-        die "Found unsupported args: $@ for get_bazel_files_to_check."
-    fi
-}
-
 # List .h|.cc files changed that still exist,
 # i.e., not removed.
 # Usage: get_clang_files_to_check [--incremental]


### PR DESCRIPTION
Linked to #991

I bumped the buildifier version from 0.4.5 to 0.29 because there is a very nice option (`-r` for recursive search in directory) that we need.

The check runs in 3s :)