### PR TITLE
Running the sanity check locally

### DIFF
--- a/.github/workflows/ci_test.yml
+++ b/.github/workflows/ci_test.yml
@@ -142,3 +142,10 @@ jobs:
           sudo chmod +x /usr/local/bin/buildifier
       - name: Ensure contributor used "buildifier -r ./" before commit
         run: buildifier -mode=check -r ./
+  local-dev-tools:
+    name: Check that local dev tools work
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v1
+      - name: Checking the sanity check
+        run: bash tools/run_sanity_check.sh

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -55,14 +55,10 @@ us**
 Try these useful commands below:
 
 * Format code automatically: `bash tools/run_docker.sh -c 'make code-format'`
+* Run sanity check: `bash tools/run_sanity_check.sh`
 * Run CPU unit tests: `bash tools/run_docker.sh -c 'make unit-test'`
 * Run GPU unit tests: `bash tools/run_docker.sh -d gpu -c 'make gpu-unit-test'`
 * All of the above: `bash tools/run_docker.sh -d gpu -c 'make'`
-
-
-For the moment we don't have an easy way to run the small tests done 
-in the CI locally. But it's coming soon.
-See https://github.com/tensorflow/addons/issues/991 for updates.
 
 ## Coding style
 

--- a/tools/docker/sanity_check.Dockerfile
+++ b/tools/docker/sanity_check.Dockerfile
@@ -94,13 +94,3 @@ COPY --from=3 /ok.txt /ok3.txt
 COPY --from=4 /ok.txt /ok4.txt
 COPY --from=5 /ok.txt /ok5.txt
 COPY --from=6 /ok.txt /ok6.txt
-
-
-
-
-
-
-
-
-
-

--- a/tools/docker/sanity_check.Dockerfile
+++ b/tools/docker/sanity_check.Dockerfile
@@ -1,0 +1,106 @@
+# Flake8
+FROM python:3.7
+
+RUN pip install flake8==3.7.9
+COPY ./ /addons
+WORKDIR /addons
+RUN flake8
+RUN touch /ok.txt
+
+# -------------------------------
+# Black Python code format
+FROM python:3.7
+
+RUN pip install black==19.10b0
+COPY ./ /addons
+RUN black --check /addons
+RUN touch /ok.txt
+
+# -------------------------------
+# Check that the public API is typed
+FROM python:3.7
+
+RUN pip install tensorflow-cpu==2.1.0 typeguard==2.7.1
+COPY ./ /addons
+RUN TF_ADDONS_NO_BUILD=1 pip install --no-deps -e /addons
+RUN python /addons/tools/ci_build/verify/check_typing_info.py
+RUN touch /ok.txt
+
+# -------------------------------
+# Verify python filenames work on case insensitive FS
+FROM python:3.7
+
+COPY ./ /addons
+WORKDIR /addons
+RUN python /addons/tools/ci_build/verify/check_file_name.py
+RUN touch /ok.txt
+
+# -------------------------------
+# Valid build files
+FROM python:3.7
+
+RUN apt-get update && apt-get install sudo
+RUN git clone https://github.com/abhinavsingh/setup-bazel.git
+RUN bash ./setup-bazel/setup-bazel.sh 1.1.0
+
+RUN pip install tensorflow-cpu==2.1.0
+
+COPY ./ /addons
+WORKDIR /addons
+RUN python ./configure.py --no-deps
+RUN bazel build --nobuild -- //tensorflow_addons/...
+RUN touch /ok.txt
+
+# -------------------------------
+# Clang C++ code format
+FROM python:3.7
+
+RUN git clone https://github.com/gabrieldemarmiesse/clang-format-lint-action.git
+WORKDIR ./clang-format-lint-action
+RUN git checkout 1044fee
+
+COPY ./ /addons
+RUN python run-clang-format.py \
+               -r \
+               --cli-args=--style=google \
+               --clang-format-executable ./clang-format/clang-format9 \
+               /addons
+RUN touch /ok.txt
+
+# -------------------------------
+# Bazel code format
+FROM alpine:3.11
+
+RUN wget -O /usr/local/bin/buildifier \
+            https://github.com/bazelbuild/buildtools/releases/download/0.29.0/buildifier
+RUN chmod +x /usr/local/bin/buildifier
+
+COPY ./ /addons
+RUN buildifier -mode=check -r /addons
+RUN touch /ok.txt
+
+# -------------------------------
+# ensure that all checks were successful
+# this is necessary if using docker buildkit
+# with "export DOCKER_BUILDKIT=1"
+# otherwise dead branch elimination doesn't
+# run all tests
+FROM scratch
+
+COPY --from=0 /ok.txt /ok0.txt
+COPY --from=1 /ok.txt /ok1.txt
+COPY --from=2 /ok.txt /ok2.txt
+COPY --from=3 /ok.txt /ok3.txt
+COPY --from=4 /ok.txt /ok4.txt
+COPY --from=5 /ok.txt /ok5.txt
+COPY --from=6 /ok.txt /ok6.txt
+
+
+
+
+
+
+
+
+
+

--- a/tools/run_sanity_check.sh
+++ b/tools/run_sanity_check.sh
@@ -1,2 +1,2 @@
 set -e
-DOCKER_BUILDKIT=0 docker build -f tools/docker/sanity_check.Dockerfile ./
+DOCKER_BUILDKIT=1 docker build -f tools/docker/sanity_check.Dockerfile ./

--- a/tools/run_sanity_check.sh
+++ b/tools/run_sanity_check.sh
@@ -1,0 +1,2 @@
+set -e
+DOCKER_BUILDKIT=0 docker build -f tools/docker/sanity_check.Dockerfile ./


### PR DESCRIPTION
See #991 for background. 

This pull request add a sanity check that users can run locally.

It requires docker to run, but the daemon doesn't have to be present locally. 

It makes use of buildkit if the docker daemon installed is recent enough:  https://docs.docker.com/develop/develop-images/build_enhancements/

Basically buildkit does everything in parallel if possible (pulling images, getting docker context, executing run statements...)

Without buildkit (second pass): 90s
with buildkit (second pass) 60s

I used images as small as possible, I couldn't use alpine python because it lacked a gcc compiler.

later on with docker buildx and remote caching, we may have the luxury of running docker in the CI for very fast tasks.

I'll also do some cleanup about duplicated code for install after this PR is merged.
