### PR TITLE
New pre-commit running black/buildifier/clang-format.

### DIFF
--- a/.github/workflows/ci_test.yml
+++ b/.github/workflows/ci_test.yml
@@ -146,8 +146,6 @@ jobs:
     steps:
       - uses: actions/checkout@v1
       - name: install buildifier
-        run: |
-          sudo wget -O /usr/local/bin/buildifier https://github.com/bazelbuild/buildtools/releases/download/0.29.0/buildifier
-          sudo chmod +x /usr/local/bin/buildifier
+        run: sudo bash tools/ci_build/install/buildifier.sh
       - name: Ensure contributor used "buildifier -r ./" before commit
         run: buildifier -mode=check -r ./

--- a/.gitignore
+++ b/.gitignore
@@ -37,5 +37,3 @@ wheels/
 /bazel-*
 /artifacts
 .bazelrc
-
-buildifier.*

--- a/makefile
+++ b/makefile
@@ -20,8 +20,7 @@ install-ci-dependency:
 	bash tools/ci_build/install/install_ci_dependency.sh --quiet
 
 code-format:
-
-	bash tools/format.sh
+	bash tools/pre-commit.sh
 
 sanity-check: install-ci-dependency
 	bash tools/ci_build/ci_sanity.sh --incremental

--- a/tools/ci_build/install/buildifier.sh
+++ b/tools/ci_build/install/buildifier.sh
@@ -1,0 +1,18 @@
+#!/usr/bin/env bash
+# Copyright 2019 The TensorFlow Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ==============================================================================
+
+wget -O /usr/local/bin/buildifier https://github.com/bazelbuild/buildtools/releases/download/0.29.0/buildifier
+chmod +x /usr/local/bin/buildifier

--- a/tools/ci_build/install/clang-format.sh
+++ b/tools/ci_build/install/clang-format.sh
@@ -1,3 +1,4 @@
+#!/usr/bin/env bash
 # Copyright 2019 The TensorFlow Authors. All Rights Reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -12,22 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 # ==============================================================================
-.PHONY: all
 
-all: code-format sanity-check unit-test
 
-install-ci-dependency:
-	bash tools/ci_build/install/install_ci_dependency.sh --quiet
-
-code-format:
-
-	bash tools/format.sh
-
-sanity-check: install-ci-dependency
-	bash tools/ci_build/ci_sanity.sh --incremental
-
-unit-test:
-	bash tools/ci_testing/addons_cpu.sh
-
-gpu-unit-test:
-	bash tools/ci_testing/addons_gpu.sh
+wget -O /usr/local/bin/clang-format-9 https://github.com/DoozyX/clang-format-lint-action/raw/master/clang-format/clang-format9
+chmod +x /usr/local/bin/clang-format-9

--- a/tools/docker/Dockerfile_formatting
+++ b/tools/docker/Dockerfile_formatting
@@ -1,0 +1,15 @@
+FROM python:3.7
+
+RUN pip install black
+
+COPY tools/ci_build/install/buildifier.sh ./buildifier.sh
+RUN bash buildifier.sh
+
+COPY tools/ci_build/install/clang-format.sh ./clang-format.sh
+RUN bash clang-format.sh
+
+RUN mkdir /addons
+WORKDIR /addons
+
+
+CMD ["bash", "tools/pre-commit.sh"]

--- a/tools/docker/Dockerfile_formatting
+++ b/tools/docker/Dockerfile_formatting
@@ -12,4 +12,4 @@ RUN mkdir /addons
 WORKDIR /addons
 
 
-CMD ["bash", "tools/pre-commit.sh"]
+CMD ["python", "tools/format.py"]

--- a/tools/format.py
+++ b/tools/format.py
@@ -1,0 +1,33 @@
+#!/usr/bin/env python
+from subprocess import check_call, CalledProcessError
+
+
+def check_bash_call(string):
+    check_call(["bash", "-c", string])
+
+
+files_changed = False
+
+try:
+    check_bash_call("python -m black --check ./")
+except CalledProcessError:
+    check_bash_call("python -m black ./")
+    files_changed = True
+
+try:
+    check_bash_call("buildifier --check -r .")
+except CalledProcessError:
+    check_bash_call("buildifier -r .")
+    files_changed = True
+
+# todo: find a way to check if files changed
+# see https://github.com/DoozyX/clang-format-lint-action for inspiration
+check_bash_call(
+    "shopt -s globstar && " "clang-format-9 -i --style=google **/*.cc **/*.h"
+)
+
+
+if files_changed:
+    print("Some files have changed.")
+    print("Please do git add and git commit again")
+    exit(1)

--- a/tools/format.py
+++ b/tools/format.py
@@ -15,16 +15,14 @@ except CalledProcessError:
     files_changed = True
 
 try:
-    check_bash_call("buildifier --check -r .")
+    check_bash_call("buildifier -mode=check -r .")
 except CalledProcessError:
     check_bash_call("buildifier -r .")
     files_changed = True
 
 # todo: find a way to check if files changed
 # see https://github.com/DoozyX/clang-format-lint-action for inspiration
-check_bash_call(
-    "shopt -s globstar && " "clang-format-9 -i --style=google **/*.cc **/*.h"
-)
+check_bash_call("shopt -s globstar && clang-format-9 -i --style=google **/*.cc **/*.h")
 
 
 if files_changed:

--- a/tools/pre-commit-docker.sh
+++ b/tools/pre-commit-docker.sh
@@ -1,0 +1,6 @@
+#!/usr/bin/env bash
+
+set -x -e
+
+docker build -t tf_addons_formatting -f tools/docker/Dockerfile_formatting .
+docker run --rm -t -v "$(pwd -P):/addons" tf_addons_formatting

--- a/tools/pre-commit-docker.sh
+++ b/tools/pre-commit-docker.sh
@@ -1,7 +1,0 @@
-#!/usr/bin/env bash
-
-set -x -e
-
-export DOCKER_BUILDKIT=1
-docker build -t tf_addons_formatting -f tools/docker/Dockerfile_formatting .
-docker run --rm -t -v "$(pwd -P):/addons" tf_addons_formatting

--- a/tools/pre-commit-docker.sh
+++ b/tools/pre-commit-docker.sh
@@ -2,5 +2,6 @@
 
 set -x -e
 
+export DOCKER_BUILDKIT=1
 docker build -t tf_addons_formatting -f tools/docker/Dockerfile_formatting .
 docker run --rm -t -v "$(pwd -P):/addons" tf_addons_formatting

--- a/tools/pre-commit.sh
+++ b/tools/pre-commit.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-set -x -e
+set -e
 
 export DOCKER_BUILDKIT=1
 docker build -t tf_addons_formatting -f tools/docker/Dockerfile_formatting .

--- a/tools/pre-commit.sh
+++ b/tools/pre-commit.sh
@@ -1,16 +1,7 @@
 #!/usr/bin/env bash
 
+set -x -e
 
-python -m black --check ./
-need_format=$?
-
-set -e
-if [ $need_format -ne 0 ]
-then
-    python -m black ./
-    echo Some Python files were formatted
-    echo You need to do git add and git commit again
-    exit $need_format
-fi
-
-python -m flake8
+export DOCKER_BUILDKIT=1
+docker build -t tf_addons_formatting -f tools/docker/Dockerfile_formatting .
+docker run --rm -t -v "$(pwd -P):/addons" tf_addons_formatting


### PR DESCRIPTION
Use docker to run. Is quite fast if buildkit is available (docker 19.03+). On my machine, the docker build step takes 0.2s.

I had to remove the buildifier from the gitignore as it was ignoring the install script that I made. Now that everything runs in docker I'm not sure this glob ignore is needed. We can change it later if necessary.