### PR TITLE
FIX: Remove trailing comma from double star

### DIFF
--- a/tensorflow_addons/layers/polynomial.py
+++ b/tensorflow_addons/layers/polynomial.py
@@ -76,7 +76,7 @@ class PolynomialCrossing(tf.keras.layers.Layer):
         bias_initializer: types.Initializer = "zeros",
         kernel_regularizer: types.Regularizer = None,
         bias_regularizer: types.Regularizer = None,
-        **kwargs,
+        **kwargs
     ):
         super(PolynomialCrossing, self).__init__(**kwargs)
 


### PR DESCRIPTION
Windows/MacOS builds failed last night on Py35 for trailing comma.

Related: https://github.com/psf/black/issues/419

But going forward we should probably test oldest python and newest python in CI