### PR TITLE
Use py35 instead of 36 as much as possible.

### DIFF
--- a/.github/workflows/ci_test.yml
+++ b/.github/workflows/ci_test.yml
@@ -26,7 +26,7 @@ jobs:
     runs-on: macos-latest
     strategy:
       matrix:
-        python-version: ['3.7']
+        python-version: ['3.5']
     steps:
       - uses: actions/checkout@v1
       - uses: actions/setup-python@v1
@@ -42,7 +42,7 @@ jobs:
     runs-on: windows-latest
     strategy:
       matrix:
-        python-version: ['3.7']
+        python-version: ['3.5']
     steps:
       - uses: actions/checkout@v1
       - uses: actions/setup-python@v1
@@ -84,7 +84,7 @@ jobs:
       - uses: actions/checkout@v1
       - uses: actions/setup-python@v1
         with:
-          python-version: '3.7'
+          python-version: '3.5'
       - name: install tensorflow and typeguard
         run: pip install tensorflow-cpu typeguard
       - name: install tf addons
@@ -98,7 +98,7 @@ jobs:
       - uses: actions/checkout@v1
       - uses: actions/setup-python@v1
         with:
-          python-version: '3.7'
+          python-version: '3.5'
       - name: Run filename check
         run: python tools/ci_build/verify/check_file_name.py
   valid_build_files:
@@ -112,7 +112,7 @@ jobs:
           version: $BAZEL_VERSION
       - uses: actions/setup-python@v1
         with:
-          python-version: '3.7'
+          python-version: '3.5'
       - name: Setup the environement
         run: |
           pip install tensorflow-cpu

--- a/.github/workflows/macos_nightly.yml
+++ b/.github/workflows/macos_nightly.yml
@@ -33,7 +33,7 @@ jobs:
       - uses: actions/checkout@v1
       - uses: actions/setup-python@v1
         with:
-          python-version: 3.7
+          python-version: 3.5
       - name: Nightly build for macOS
         env:
           TF_NEED_CUDA: 0

--- a/.github/workflows/manylinux_nightly.yml
+++ b/.github/workflows/manylinux_nightly.yml
@@ -23,7 +23,7 @@ jobs:
       - uses: actions/checkout@v1
       - uses: actions/setup-python@v1
         with:
-          python-version: 3.6
+          python-version: 3.5
       - name: Build manylinux2010 wheels
         run: |
           docker run -e TF_NEED_CUDA=1 -v ${PWD}:/addons -w /addons \

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -124,7 +124,7 @@ jobs:
       - uses: actions/checkout@v1
       - uses: actions/setup-python@v1
         with:
-          python-version: 3.6
+          python-version: 3.5
       - name: Build manylinux2010 wheels
         run: |
           docker run -e TF_NEED_CUDA=1 -v ${PWD}:/addons -w /addons \

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -65,7 +65,7 @@ jobs:
       - uses: actions/checkout@v1
       - uses: actions/setup-python@v1
         with:
-          python-version: 3.7
+          python-version: 3.5
       - name: Release build for macOS
         env:
           TF_NEED_CUDA: 0
@@ -93,7 +93,7 @@ jobs:
       - uses: actions/checkout@v1
       - uses: actions/setup-python@v1
         with:
-          python-version: 3.7
+          python-version: 3.5
       - name: Release build for Windows
         env:
           TF_NEED_CUDA: 0

--- a/.github/workflows/windows_nightly.yml
+++ b/.github/workflows/windows_nightly.yml
@@ -37,7 +37,7 @@ jobs:
       - uses: actions/checkout@v1
       - uses: actions/setup-python@v1
         with:
-          python-version: 3.7
+          python-version: 3.5
       - name: Nightly build for Windows
         env:
           TF_NEED_CUDA: 0

--- a/tensorflow_addons/rnn/cell_test.py
+++ b/tensorflow_addons/rnn/cell_test.py
@@ -343,7 +343,7 @@ class LayerNormSimpleRNNTest(tf.test.TestCase):
             return_sequences=False)
         layer.build((None, None, 2))
         self.assertEqual(len(layer.losses), 4)
-    
+
     def test_configs_layernorm(self):
         config = {'layernorm_epsilon': 1e-6}
         cell1 = LayerNormSimpleRNNCell(units=8, **config)

--- a/tools/ci_build/verify/check_typing_info.py
+++ b/tools/ci_build/verify/check_typing_info.py
@@ -51,6 +51,7 @@ EXCEPTION_LIST = [
     tensorflow_addons.metrics.RSquare,
     tensorflow_addons.rnn.LayerNormLSTMCell,
     tensorflow_addons.rnn.NASCell,
+    tensorflow_addons.rnn.LayerNormSimpleRNNCell,
     tensorflow_addons.seq2seq.AttentionMechanism,
     tensorflow_addons.seq2seq.AttentionWrapper,
     tensorflow_addons.seq2seq.AttentionWrapperState,

--- a/tools/docker/Dockerfile_formatting
+++ b/tools/docker/Dockerfile_formatting
@@ -1,4 +1,4 @@
-FROM python:3.5
+FROM python:3.6
 
 RUN pip install black
 

--- a/tools/docker/Dockerfile_formatting
+++ b/tools/docker/Dockerfile_formatting
@@ -1,4 +1,4 @@
-FROM python:3.7
+FROM python:3.5
 
 RUN pip install black
 

--- a/tools/docker/sanity_check.Dockerfile
+++ b/tools/docker/sanity_check.Dockerfile
@@ -53,7 +53,7 @@ RUN touch /ok.txt
 
 # -------------------------------
 # Clang C++ code format
-FROM python:3.5
+FROM python:3.6
 
 RUN git clone https://github.com/gabrieldemarmiesse/clang-format-lint-action.git
 WORKDIR ./clang-format-lint-action

--- a/tools/docker/sanity_check.Dockerfile
+++ b/tools/docker/sanity_check.Dockerfile
@@ -9,7 +9,7 @@ RUN touch /ok.txt
 
 # -------------------------------
 # Black Python code format
-FROM python:3.5
+FROM python:3.6
 
 RUN pip install black==19.10b0
 COPY ./ /addons

--- a/tools/docker/sanity_check.Dockerfile
+++ b/tools/docker/sanity_check.Dockerfile
@@ -1,5 +1,5 @@
 # Flake8
-FROM python:3.7
+FROM python:3.5
 
 RUN pip install flake8==3.7.9
 COPY ./ /addons
@@ -9,7 +9,7 @@ RUN touch /ok.txt
 
 # -------------------------------
 # Black Python code format
-FROM python:3.7
+FROM python:3.5
 
 RUN pip install black==19.10b0
 COPY ./ /addons
@@ -18,7 +18,7 @@ RUN touch /ok.txt
 
 # -------------------------------
 # Check that the public API is typed
-FROM python:3.7
+FROM python:3.5
 
 RUN pip install tensorflow-cpu==2.1.0 typeguard==2.7.1
 COPY ./ /addons
@@ -28,7 +28,7 @@ RUN touch /ok.txt
 
 # -------------------------------
 # Verify python filenames work on case insensitive FS
-FROM python:3.7
+FROM python:3.5
 
 COPY ./ /addons
 WORKDIR /addons
@@ -37,7 +37,7 @@ RUN touch /ok.txt
 
 # -------------------------------
 # Valid build files
-FROM python:3.7
+FROM python:3.5
 
 RUN apt-get update && apt-get install sudo
 RUN git clone https://github.com/abhinavsingh/setup-bazel.git
@@ -53,7 +53,7 @@ RUN touch /ok.txt
 
 # -------------------------------
 # Clang C++ code format
-FROM python:3.7
+FROM python:3.5
 
 RUN git clone https://github.com/gabrieldemarmiesse/clang-format-lint-action.git
 WORKDIR ./clang-format-lint-action


### PR DESCRIPTION
Python being really good at backward compatibility, I think all our tests should run with the oldest version of python we support and some selected tests should run with the most recent version that we support.

See #1024

