### PR TITLE
BLD: Remove bazel artifact upload/download

### DIFF
--- a/.github/workflows/macos_nightly.yml
+++ b/.github/workflows/macos_nightly.yml
@@ -25,22 +25,27 @@ jobs:
           bash tools/ci_testing/install_bazel_macos.sh $BAZEL_VERSION
           bash -x -e tools/ci_testing/addons_cpu.sh
 
-  macos-nightly-bazel:
-    name: Bazel nightly for macOS
+  macos-nightly-wheel:
+    name: Build nightly wheels for macOS
     needs: [macos-cpu-nightly-test]
     runs-on: macos-latest
+    strategy:
+      matrix:
+        python-version: ['3.5', '3.6', '3.7']
     steps:
       - uses: actions/checkout@v1
       - uses: actions/setup-python@v1
         with:
-          python-version: 3.5
-      - name: Nightly build for macOS
+          python-version: ${{ matrix.python-version }}
+      - name: Build macOS wheels
         env:
           TF_NEED_CUDA: 0
         run: |
-          python --version
-          bash tools/ci_testing/install_bazel_macos.sh $BAZEL_VERSION
+          python3 --version
+          python3 -m pip install delocate wheel setuptools
           python3 ./configure.py --quiet
+
+          bash tools/ci_testing/install_bazel_macos.sh $BAZEL_VERSION
           bazel build \
             -c opt \
             --noshow_progress \
@@ -48,31 +53,6 @@ jobs:
             --verbose_failures \
             --test_output=errors \
             build_pip_pkg
-      - uses: actions/upload-artifact@v1
-        with:
-          name: ${{ runner.os }}-bazel-bin
-          path: bazel-bin
-
-  macos-nightly-wheel:
-    name: Build nightly wheels for macOS
-    needs: [macos-nightly-bazel]
-    runs-on: macos-latest
-    strategy:
-      matrix:
-        python-version: ['3.5', '3.6', '3.7']
-    steps:
-      - uses: actions/checkout@v1
-      - uses: actions/download-artifact@v1
-        with:
-          name: ${{ runner.os }}-bazel-bin
-          path: bazel-bin
-      - uses: actions/setup-python@v1
-        with:
-          python-version: ${{ matrix.python-version }}
-      - name: Build macOS wheels
-        run: |
-          chmod +x bazel-bin/build_pip_pkg
-          python3 -m pip install delocate wheel setuptools
 
           bazel-bin/build_pip_pkg artifacts --nightly
           for f in artifacts/*.whl; do

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -57,65 +57,6 @@ jobs:
           export BAZEL_PATH=/d/a/addons/addons/bazel-${BAZEL_VERSION}-windows-x86_64.exe
           bash -x -e ./tools/ci_testing/addons_cpu.sh
 
-  macos-release-bazel:
-    name: Bazel release for macOS
-    needs: [macos-cpu-release-test]
-    runs-on: macos-latest
-    steps:
-      - uses: actions/checkout@v1
-      - uses: actions/setup-python@v1
-        with:
-          python-version: 3.5
-      - name: Release build for macOS
-        env:
-          TF_NEED_CUDA: 0
-        run: |
-          python --version
-          bash tools/ci_testing/install_bazel_macos.sh $BAZEL_VERSION
-          python3 ./configure.py --quiet
-          bazel build \
-            -c opt \
-            --noshow_progress \
-            --noshow_loading_progress \
-            --verbose_failures \
-            --test_output=errors \
-            build_pip_pkg
-      - uses: actions/upload-artifact@v1
-        with:
-          name: ${{ runner.os }}-bazel-bin
-          path: bazel-bin
-
-  windows-release-bazel:
-    name: Build release for Windows
-    needs: [windows-cpu-release-test]
-    runs-on: windows-latest
-    steps:
-      - uses: actions/checkout@v1
-      - uses: actions/setup-python@v1
-        with:
-          python-version: 3.5
-      - name: Release build for Windows
-        env:
-          TF_NEED_CUDA: 0
-          BAZEL_VC: "C:/Program Files (x86)/Microsoft Visual Studio/2019/Enterprise/VC/"
-        shell: bash
-        run: |
-          python --version
-          curl -sSOL https://github.com/bazelbuild/bazel/releases/download/${BAZEL_VERSION}/bazel-${BAZEL_VERSION}-windows-x86_64.exe
-          python ./configure.py --quiet
-          ./bazel-${BAZEL_VERSION}-windows-x86_64.exe build \
-            -c opt \
-            --enable_runfiles \
-            --noshow_progress \
-            --noshow_loading_progress \
-            --verbose_failures \
-            --test_output=errors \
-            build_pip_pkg
-      - uses: actions/upload-artifact@v1
-        with:
-          name: ${{ runner.os }}-bazel-bin
-          path: bazel-bin
-
   manylinux-release-wheel:
     name: Build release wheels for manylinux2010
     needs: [manylinux-cpu-release-test]
@@ -146,24 +87,30 @@ jobs:
 
   macos-release-wheel:
     name: Build release wheels for macOS
-    needs: [macos-release-bazel]
+    needs: [macos-cpu-release-test]
     runs-on: macos-latest
     strategy:
       matrix:
         python-version: ['3.5', '3.6', '3.7']
     steps:
       - uses: actions/checkout@v1
-      - uses: actions/download-artifact@v1
-        with:
-          name: ${{ runner.os }}-bazel-bin
-          path: bazel-bin
       - uses: actions/setup-python@v1
         with:
           python-version: ${{ matrix.python-version }}
       - name: Build macOS wheels
         run: |
-          chmod +x bazel-bin/build_pip_pkg
+          python3 --version
           python3 -m pip install delocate wheel setuptools
+          python3 ./configure.py --quiet
+
+          bash tools/ci_testing/install_bazel_macos.sh $BAZEL_VERSION
+          bazel build \
+            -c opt \
+            --noshow_progress \
+            --noshow_loading_progress \
+            --verbose_failures \
+            --test_output=errors \
+            build_pip_pkg
 
           bazel-bin/build_pip_pkg artifacts
           for f in artifacts/*.whl; do
@@ -176,25 +123,31 @@ jobs:
 
   windows-release-wheel:
     name: Build release wheels for Windows
-    needs: [windows-release-bazel]
+    needs: [windows-cpu-release-test]
     runs-on: windows-latest
     strategy:
       matrix:
         python-version: ['3.5', '3.6', '3.7']
     steps:
       - uses: actions/checkout@v1
-      - uses: actions/download-artifact@v1
-        with:
-          name: ${{ runner.os }}-bazel-bin
-          path: bazel-bin
       - uses: actions/setup-python@v1
         with:
           python-version: ${{ matrix.python-version }}
       - name: Build Windows wheels
         shell: bash
         run: |
-          chmod +x bazel-bin/build_pip_pkg
           python -m pip install wheel setuptools
+          python ./configure.py --quiet
+
+          curl -sSOL https://github.com/bazelbuild/bazel/releases/download/${BAZEL_VERSION}/bazel-${BAZEL_VERSION}-windows-x86_64.exe
+          ./bazel-${BAZEL_VERSION}-windows-x86_64.exe build \
+            -c opt \
+            --enable_runfiles \
+            --noshow_progress \
+            --noshow_loading_progress \
+            --verbose_failures \
+            --test_output=errors \
+            build_pip_pkg
           bazel-bin/build_pip_pkg artifacts
       - uses: actions/upload-artifact@v1
         with:

--- a/.github/workflows/windows_nightly.yml
+++ b/.github/workflows/windows_nightly.yml
@@ -29,24 +29,28 @@ jobs:
           export BAZEL_PATH=/d/a/addons/addons/bazel-${BAZEL_VERSION}-windows-x86_64.exe
           bash -x -e ./tools/ci_testing/addons_cpu.sh
 
-  windows-nightly-bazel:
-    name: Build nightly for Windows
+  windows-nightly-wheel:
+    name: Build nightly wheels for Windows
     needs: [windows-cpu-nightly-test]
     runs-on: windows-latest
+    strategy:
+      matrix:
+        python-version: ['3.5', '3.6', '3.7']
     steps:
       - uses: actions/checkout@v1
       - uses: actions/setup-python@v1
         with:
-          python-version: 3.5
-      - name: Nightly build for Windows
+          python-version: ${{ matrix.python-version }}
+      - name: Build Windows wheels
         env:
           TF_NEED_CUDA: 0
           BAZEL_VC: "C:/Program Files (x86)/Microsoft Visual Studio/2019/Enterprise/VC/"
         shell: bash
         run: |
-          python --version
-          curl -sSOL https://github.com/bazelbuild/bazel/releases/download/${BAZEL_VERSION}/bazel-${BAZEL_VERSION}-windows-x86_64.exe
+          python -m pip install wheel setuptools
           python ./configure.py --quiet
+
+          curl -sSOL https://github.com/bazelbuild/bazel/releases/download/${BAZEL_VERSION}/bazel-${BAZEL_VERSION}-windows-x86_64.exe
           ./bazel-${BAZEL_VERSION}-windows-x86_64.exe build \
             -c opt \
             --enable_runfiles \
@@ -55,32 +59,6 @@ jobs:
             --verbose_failures \
             --test_output=errors \
             build_pip_pkg
-      - uses: actions/upload-artifact@v1
-        with:
-          name: ${{ runner.os }}-bazel-bin
-          path: bazel-bin
-
-  windows-nightly-wheel:
-    name: Build nightly wheels for Windows
-    needs: [windows-nightly-bazel]
-    runs-on: windows-latest
-    strategy:
-      matrix:
-        python-version: ['3.5', '3.6', '3.7']
-    steps:
-      - uses: actions/checkout@v1
-      - uses: actions/download-artifact@v1
-        with:
-          name: ${{ runner.os }}-bazel-bin
-          path: bazel-bin
-      - uses: actions/setup-python@v1
-        with:
-          python-version: ${{ matrix.python-version }}
-      - name: Build Windows wheels
-        shell: bash
-        run: |
-          chmod +x bazel-bin/build_pip_pkg
-          python -m pip install wheel setuptools
           bazel-bin/build_pip_pkg artifacts --nightly
       - uses: actions/upload-artifact@v1
         with:


### PR DESCRIPTION
So the shared bazel artifact was meant to improve build time, but we've been getting timeout errors on our uploads/downloads using GitHub actions:
https://github.com/tensorflow/addons/actions/runs/35265244

IMO the extra computation time is not really an issue compared to missing releases.