### PR TITLE
Add a test for the documentation.

### DIFF
--- a/.github/workflows/ci_test.yml
+++ b/.github/workflows/ci_test.yml
@@ -152,5 +152,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v1
-      - name: Check building the docs
-        run: DOCKER_BUILDKIT=1 docker build -f tools/docker/sanity_check.Dockerfile --target=docs_tests ./
+      - name: Installing dependencies
+        run: pip install -r tools/docs/doc_requirements.txt -r requirements.txt -r build_deps/build-requirements.txt
+      - name: Installing tf addons
+        run: TF_ADDONS_NO_BUILD=1 pip install --no-deps -e .
+      - name: Building the docs
+        run: python tools/docs/build_docs.py

--- a/.github/workflows/ci_test.yml
+++ b/.github/workflows/ci_test.yml
@@ -153,4 +153,4 @@ jobs:
     steps:
       - uses: actions/checkout@v1
       - name: Check building the docs
-        run: docker build -f tools/docker/sanity_check.Dockerfile --target=docs_tests ./
+        run: DOCKER_BUILDKIT=1 docker build -f tools/docker/sanity_check.Dockerfile --target=docs_tests ./

--- a/.github/workflows/ci_test.yml
+++ b/.github/workflows/ci_test.yml
@@ -147,3 +147,10 @@ jobs:
       - uses: actions/checkout@v1
       - name: Checking the sanity check
         run: bash tools/run_sanity_check.sh
+  docs_tests:
+    name: Check that we can build the docs
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v1
+      - name: Check building the docs
+        run: docker build -f tools/docker/sanity_check.Dockerfile --target=docs_tests ./

--- a/.github/workflows/ci_test.yml
+++ b/.github/workflows/ci_test.yml
@@ -152,6 +152,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v1
+      - uses: actions/setup-python@v1
+        with:
+          python-version: '3.5'
       - name: Installing dependencies
         run: pip install -r tools/docs/doc_requirements.txt -r requirements.txt -r build_deps/build-requirements.txt
       - name: Installing tf addons

--- a/.github/workflows/ci_test.yml
+++ b/.github/workflows/ci_test.yml
@@ -152,12 +152,5 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v1
-      - uses: actions/setup-python@v1
-        with:
-          python-version: '3.5'
-      - name: Installing dependencies
-        run: pip install -r tools/docs/doc_requirements.txt -r requirements.txt -r build_deps/build-requirements.txt
-      - name: Installing tf addons
-        run: TF_ADDONS_NO_BUILD=1 pip install --no-deps -e .
       - name: Building the docs
-        run: python tools/docs/build_docs.py
+        run: DOCKER_BUILDKIT=1 docker build -f tools/docker/sanity_check.Dockerfile --target=docs_tests ./

--- a/tools/docker/sanity_check.Dockerfile
+++ b/tools/docker/sanity_check.Dockerfile
@@ -79,6 +79,22 @@ COPY ./ /addons
 RUN buildifier -mode=check -r /addons
 RUN touch /ok.txt
 
+
+# -------------------------------
+# docs tests
+FROM python:3.5
+
+RUN pip install tensorflow-cpu==2.1.0 typeguard==2.7.1
+
+COPY tools/docs/doc_requirements.txt ./
+RUN doc_requirements.txt
+
+COPY ./ /addons
+WORKDIR /addons
+RUN TF_ADDONS_NO_BUILD=1 pip install --no-deps -e .
+RUN python tools/docs/build_docs.py
+RUN touch /ok.txt
+
 # -------------------------------
 # ensure that all checks were successful
 # this is necessary if using docker buildkit
@@ -94,3 +110,4 @@ COPY --from=3 /ok.txt /ok3.txt
 COPY --from=4 /ok.txt /ok4.txt
 COPY --from=5 /ok.txt /ok5.txt
 COPY --from=6 /ok.txt /ok6.txt
+COPY --from=7 /ok.txt /ok7.txt

--- a/tools/docker/sanity_check.Dockerfile
+++ b/tools/docker/sanity_check.Dockerfile
@@ -82,7 +82,7 @@ RUN touch /ok.txt
 
 # -------------------------------
 # docs tests
-FROM python:3.5
+FROM python:3.6
 
 RUN pip install tensorflow-cpu==2.1.0
 RUN pip install typeguard==2.7.1

--- a/tools/docker/sanity_check.Dockerfile
+++ b/tools/docker/sanity_check.Dockerfile
@@ -84,13 +84,15 @@ RUN touch /ok.txt
 
 # -------------------------------
 # docs tests
-FROM python:3.6
+FROM python:3.6 as docs_tests
 
 RUN pip install tensorflow-cpu==2.1.0
 RUN pip install typeguard==2.7.1
 
 COPY tools/docs/doc_requirements.txt ./
 RUN pip install -r doc_requirements.txt
+
+RUN apt-get update && apt-get install -y rsync
 
 COPY ./ /addons
 WORKDIR /addons

--- a/tools/docker/sanity_check.Dockerfile
+++ b/tools/docker/sanity_check.Dockerfile
@@ -84,10 +84,11 @@ RUN touch /ok.txt
 # docs tests
 FROM python:3.5
 
-RUN pip install tensorflow-cpu==2.1.0 typeguard==2.7.1
+RUN pip install tensorflow-cpu==2.1.0
+RUN pip install typeguard==2.7.1
 
 COPY tools/docs/doc_requirements.txt ./
-RUN doc_requirements.txt
+RUN pip install -r doc_requirements.txt
 
 COPY ./ /addons
 WORKDIR /addons

--- a/tools/docker/sanity_check.Dockerfile
+++ b/tools/docker/sanity_check.Dockerfile
@@ -81,7 +81,6 @@ COPY ./ /addons
 RUN buildifier -mode=check -r /addons
 RUN touch /ok.txt
 
-
 # -------------------------------
 # docs tests
 FROM python:3.6 as docs_tests

--- a/tools/docs/doc_requirements.txt
+++ b/tools/docs/doc_requirements.txt
@@ -1,3 +1,3 @@
-git+https://github.com/tensorflow/docs
+git+https://github.com/tensorflow/docs@8192df1
 pathlib
 pyyaml


### PR DESCRIPTION
For now it's not super fast to use docker build in the CI, but I tried without and for building the docs, it's not much faster.

Wait until [docker buildx](https://github.com/docker/buildx) becomes stable and we're going to have super fast CI builds with remote caching!