### PR TITLE
DOC: Update bld matrix

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,9 +61,9 @@ import tensorflow_addons as tfa
 | Version    | Compatible With |Python versions  | Compiler  | cuDNN | CUDA | 
 |:----------------------- |:---|:---------- |:---------|:---------|:---------|
 | tfa-nightly | tensorflow>=2.1.0 | 3.5-3.7 | GCC 7.3.1 | 7.6 | 10.1 |
-| tensorflow-addons-0.7.0 | tensorflow>=2.1.0 | 2.7, 3.5-3.7 | GCC 7.3.1 | 7.6 | 10.1 |
-| tensorflow-addons-0.6.0 | tensorflow==2.0.0 <br> tensorflow-gpu==2.0.0 | 2.7, 3.5-3.7 | GCC 7.3.1 | 7.4 | 10.0 |
-| tensorflow-addons-0.5.2 | tensorflow==2.0.0 <br> tensorflow-gpu==2.0.0 | 2.7, 3.5-3.7 | GCC 7.3.1 | 7.4 | 10.0 |
+| tensorflow-addons-0.8.1 | tensorflow>=2.1.0 |3.5-3.7 | GCC 7.3.1 | 7.6 | 10.1 |
+| tensorflow-addons-0.7.1 | tensorflow>=2.1.0 | 2.7, 3.5-3.7 | GCC 7.3.1 | 7.6 | 10.1 |
+| tensorflow-addons-0.6.0 | tensorflow==2.0.0 | 2.7, 3.5-3.7 | GCC 7.3.1 | 7.4 | 10.0 |
 
 
 #### Nightly Builds


### PR DESCRIPTION
* Removed 0.5.2 since there is no reason to use that instead of 0.6
* Added 0.8.1
* Updated 0.7.0 to 0.7.1

Do we think it is sufficient to just label the tensorflow version? tf-gpu or tf-cpu could be added but IMO it can be inferred.