### PR TITLE
BLD: Limit releases to published

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -2,6 +2,7 @@ name: addons-release
 
 on:
   release:
+    types: [published]
     tags:
       - v*
 


### PR DESCRIPTION
When we cut the 0.8 release, 3 github actions were triggered:
https://github.com/tensorflow/addons/actions?query=workflow%3Aaddons-release

Need to limit this to just published releases.