### PR TITLE
Use flake8 in the pre-commit.

### DIFF
--- a/tools/docker/pre-commit.Dockerfile
+++ b/tools/docker/pre-commit.Dockerfile
@@ -1,6 +1,6 @@
 FROM python:3.6
 
-RUN pip install black
+RUN pip install black==19.10b0 flake8==3.7.9
 
 COPY tools/ci_build/install/buildifier.sh ./buildifier.sh
 RUN bash buildifier.sh

--- a/tools/format.py
+++ b/tools/format.py
@@ -46,6 +46,7 @@ def run_format_and_flake8():
         _run_format_and_flake8()
     except CalledProcessError as error:
         print("Pre-commit returned exit code", error.returncode)
+        exit(error.returncode)
 
 
 if __name__ == "__main__":

--- a/tools/format.py
+++ b/tools/format.py
@@ -30,11 +30,15 @@ def _run_format_and_flake8():
     if files_changed:
         print("Some files have changed.")
         print("Please do git add and git commit again")
-        exit(1)
     else:
-        print("No formatting needed. Running flake8.")
-        check_bash_call("flake8")
-        print("Done")
+        print("No formatting needed.")
+
+    print("Running flake8.")
+    check_bash_call("flake8")
+    print("Done")
+
+    if files_changed:
+        exit(1)
 
 
 def run_format_and_flake8():

--- a/tools/format.py
+++ b/tools/format.py
@@ -29,3 +29,5 @@ if files_changed:
     print("Some files have changed.")
     print("Please do git add and git commit again")
     exit(1)
+else:
+    check_bash_call("flake8")

--- a/tools/format.py
+++ b/tools/format.py
@@ -6,28 +6,43 @@ def check_bash_call(string):
     check_call(["bash", "-c", string])
 
 
-files_changed = False
+def _run_format_and_flake8():
+    files_changed = False
 
-try:
-    check_bash_call("python -m black --check ./")
-except CalledProcessError:
-    check_bash_call("python -m black ./")
-    files_changed = True
+    try:
+        check_bash_call("python -m black --check ./")
+    except CalledProcessError:
+        check_bash_call("python -m black ./")
+        files_changed = True
 
-try:
-    check_bash_call("buildifier -mode=check -r .")
-except CalledProcessError:
-    check_bash_call("buildifier -r .")
-    files_changed = True
+    try:
+        check_bash_call("buildifier -mode=check -r .")
+    except CalledProcessError:
+        check_bash_call("buildifier -r .")
+        files_changed = True
 
-# todo: find a way to check if files changed
-# see https://github.com/DoozyX/clang-format-lint-action for inspiration
-check_bash_call("shopt -s globstar && clang-format-9 -i --style=google **/*.cc **/*.h")
+    # todo: find a way to check if files changed
+    # see https://github.com/DoozyX/clang-format-lint-action for inspiration
+    check_bash_call(
+        "shopt -s globstar && clang-format-9 -i --style=google **/*.cc **/*.h",
+    )
+
+    if files_changed:
+        print("Some files have changed.")
+        print("Please do git add and git commit again")
+        exit(1)
+    else:
+        print("No formatting needed. Running flake8.")
+        check_bash_call("flake8")
+        print("Done")
 
 
-if files_changed:
-    print("Some files have changed.")
-    print("Please do git add and git commit again")
-    exit(1)
-else:
-    check_bash_call("flake8")
+def run_format_and_flake8():
+    try:
+        _run_format_and_flake8()
+    except CalledProcessError as error:
+        print("Pre-commit returned exit code", error.returncode)
+
+
+if __name__ == "__main__":
+    run_format_and_flake8()

--- a/tools/pre-commit.sh
+++ b/tools/pre-commit.sh
@@ -3,5 +3,5 @@
 set -e
 
 export DOCKER_BUILDKIT=1
-docker build -t tf_addons_formatting -f tools/docker/formatting.Dockerfile .
+docker build -t tf_addons_formatting -f tools/docker/pre-commit.Dockerfile .
 docker run --rm -t -v "$(pwd -P):/addons" tf_addons_formatting


### PR DESCRIPTION
flake8 is very fast to run and contributors often submit pull requests with this check failing. I believe it will improve the contributor's experience to have the check running locally automatically.

I also remove the python stacktrace when there is an issue because it would make it harder to see what is the real problem.