### PR TITLE
Making the tests faster.

### DIFF
--- a/tools/ci_testing/addons_cpu.sh
+++ b/tools/ci_testing/addons_cpu.sh
@@ -14,6 +14,8 @@
 # limitations under the License.
 #
 # ==============================================================================
+# usage: bash tools/ci_testing/addons_cpu.sh [--no-deps]
+
 set -x
 
 # Make sure we're in the project root path.
@@ -42,9 +44,9 @@ export TF_NEED_CUDA=0
 
 # Check if python3 is available. On Windows VM it is not.
 if [ -x "$(command -v python3)" ]; then
-    python3 ./configure.py
+    python3 ./configure.py $1
   else
-    python ./configure.py
+    python ./configure.py $1
 fi
 
 cat ./.bazelrc

--- a/tools/ci_testing/addons_cpu.sh
+++ b/tools/ci_testing/addons_cpu.sh
@@ -16,7 +16,13 @@
 # ==============================================================================
 # usage: bash tools/ci_testing/addons_cpu.sh [--no-deps]
 
-set -x
+set -x -e
+
+
+if [ "$1" != "--no-deps" ] && [ "$1" != "" ]; then
+  echo Wrong argument $1
+  exit 1
+fi
 
 # Make sure we're in the project root path.
 SCRIPT_DIR=$( cd ${0%/*} && pwd -P )

--- a/tools/docker/cpu_tests.Dockerfile
+++ b/tools/docker/cpu_tests.Dockerfile
@@ -2,6 +2,7 @@ FROM python:3.5
 
 RUN pip install tensorflow-cpu==2.1.0
 
+RUN apt-get update && apt-get install sudo
 RUN git clone https://github.com/abhinavsingh/setup-bazel.git
 RUN bash ./setup-bazel/setup-bazel.sh 1.1.0
 

--- a/tools/docker/cpu_tests.Dockerfile
+++ b/tools/docker/cpu_tests.Dockerfile
@@ -10,4 +10,4 @@ RUN pip install -r requirements.txt
 
 COPY ./ /addons
 WORKDIR addons
-RUN bash tools/ci_testing/addons_cpu.sh
+RUN bash tools/ci_testing/addons_cpu.sh --no-deps

--- a/tools/docker/cpu_tests.Dockerfile
+++ b/tools/docker/cpu_tests.Dockerfile
@@ -1,10 +1,12 @@
-FROM gcr.io/tensorflow-testing/nosla-ubuntu16.04-manylinux2010
+FROM python:3.5
 
-COPY build_deps/build-requirements.txt ./
-RUN pip3 install -r build-requirements.txt
+RUN pip install tensorflow-cpu==2.1.0
+
+RUN git clone https://github.com/abhinavsingh/setup-bazel.git
+RUN bash ./setup-bazel/setup-bazel.sh 1.1.0
 
 COPY requirements.txt ./
-RUN pip3 install -r requirements.txt
+RUN pip install -r requirements.txt
 
 COPY ./ /addons
 WORKDIR addons


### PR DESCRIPTION
Keep in mind that the total time vary a lot in the CI, so it might not be fair to compare using that. This is why I compare the speed of the steps:

| Step | before (s)| after (s)|
| ------------- |:-------------:| -----:|
| Downloading docker image | 74 | 22 |
| installing tf | 93 | 54|
| installing bazel | 0 | 8|

The speed of compiling and testing should in theory be the same.

I also think it's nice to start from scratch to build and run because:

* it helps other to understand how to build tensorflow addons from source locally. We don't start from a big docker image with who-knows-what already installed in it. 
* Here we have full control over the python version and bazel version for example. 

We might want to do the same for the gpu and releases.