### PR TITLE
Changes default value of Yogi hyper-parameters

### DIFF
--- a/tensorflow_addons/optimizers/yogi.py
+++ b/tensorflow_addons/optimizers/yogi.py
@@ -66,7 +66,7 @@ class Yogi(tf.keras.optimizers.Optimizer):
         epsilon: FloatTensorLike = 1e-3,
         l1_regularization_strength: FloatTensorLike = 0.0,
         l2_regularization_strength: FloatTensorLike = 0.0,
-        initial_accumulator_value: FloatTensorLike = 1.0,
+        initial_accumulator_value: FloatTensorLike = 1e-6,
         activation: str = "sign",
         name: str = "Yogi",
         **kwargs

--- a/tensorflow_addons/optimizers/yogi_test.py
+++ b/tensorflow_addons/optimizers/yogi_test.py
@@ -117,6 +117,7 @@ class YogiOptimizerTest(tf.test.TestCase):
                 beta1=beta1,
                 l1_regularization_strength=l1reg,
                 l2_regularization_strength=l2reg,
+                initial_accumulator_value=1.0,
             )
             if not tf.executing_eagerly():
                 update = opt.apply_gradients(zip([grads0, grads1], [var0, var1]))
@@ -235,6 +236,7 @@ class YogiOptimizerTest(tf.test.TestCase):
                 beta1=beta1,
                 l1_regularization_strength=l1reg,
                 l2_regularization_strength=l2reg,
+                initial_accumulator_value=1.0,
             )
 
             if not tf.executing_eagerly():
@@ -296,7 +298,7 @@ class YogiOptimizerTest(tf.test.TestCase):
             var1 = tf.Variable(var1_np)
             grads0 = tf.constant(grads0_np)
             grads1 = tf.constant(grads1_np)
-            opt = yogi.Yogi(tf.constant(0.01))
+            opt = yogi.Yogi(tf.constant(0.01), initial_accumulator_value=1.0)
 
             if not tf.executing_eagerly():
                 update = opt.apply_gradients(zip([grads0, grads1], [var0, var1]))
@@ -339,7 +341,7 @@ class YogiOptimizerTest(tf.test.TestCase):
             var1 = tf.Variable(var1_np)
             grads0 = tf.constant(grads0_np)
             grads1 = tf.constant(grads1_np)
-            opt = yogi.Yogi()
+            opt = yogi.Yogi(initial_accumulator_value=1.0)
 
             if not tf.executing_eagerly():
                 update1 = opt.apply_gradients(zip([grads0, grads1], [var0, var1]))


### PR DESCRIPTION
It is found initial_accumulator_value=1e-6 works better for a range of tasks. Thus switching the default value.