### PR TITLE
Add tf.SparseTensor into TensorLike type

### DIFF
--- a/tensorflow_addons/utils/types.py
+++ b/tensorflow_addons/utils/types.py
@@ -42,7 +42,13 @@ Constraint = Union[None, dict, str, Callable]
 Activation = Union[None, str, Callable]
 
 TensorLike = Union[
-    List[Union[Number, list]], tuple, Number, np.ndarray, tf.Tensor, tf.Variable
+    List[Union[Number, list]],
+    tuple,
+    Number,
+    np.ndarray,
+    tf.Tensor,
+    tf.SparseTensor,
+    tf.Variable,
 ]
 FloatTensorLike = Union[tf.Tensor, float, np.float16, np.float32, np.float64]
 AcceptableDTypes = Union[tf.DType, np.dtype, type, int, str, None]


### PR DESCRIPTION
Add `tf.SparseTensor` into `TensorLike` type (`tensorflow_addons/utils/types.py`) as @autoih @gabrieldemarmiesse mentioned in #1088 .