### PR TITLE
Cache clean in dockerfile to avoid invalidating layers

### DIFF
--- a/tools/docker/cpu_tests.Dockerfile
+++ b/tools/docker/cpu_tests.Dockerfile
@@ -7,7 +7,7 @@ RUN git clone https://github.com/abhinavsingh/setup-bazel.git
 RUN bash ./setup-bazel/setup-bazel.sh 1.1.0
 
 COPY requirements.txt ./
-RUN pip install -r requirements.txt
+RUN pip install --no-cache-dir -r requirements.txt
 
 COPY ./ /addons
 WORKDIR addons

--- a/tools/docker/gpu_tests.Dockerfile
+++ b/tools/docker/gpu_tests.Dockerfile
@@ -4,7 +4,7 @@ COPY build_deps/build-requirements.txt ./
 RUN pip3 install -r build-requirements.txt
 
 COPY requirements.txt ./
-RUN pip3 install -r requirements.txt
+RUN pip3 install -r --no-cache-dir requirements.txt
 
 COPY ./ /addons
 WORKDIR addons

--- a/tools/docker/sanity_check.Dockerfile
+++ b/tools/docker/sanity_check.Dockerfile
@@ -9,7 +9,7 @@ RUN touch /ok.txt
 # -------------------------------
 FROM python:3.6 as black-test
 
-RUN pip install --no-cache-dir black==19.10b0
+RUN pip install black==19.10b0
 COPY ./ /addons
 RUN black --check /addons
 RUN touch /ok.txt
@@ -17,11 +17,12 @@ RUN touch /ok.txt
 # -------------------------------
 FROM python:3.6 as public-api-typed
 
-RUN pip install --no-cache-dir tensorflow-cpu==2.1.0 typeguard==2.7.1
-RUN pip install --no-cache-dir git+https://github.com/gabrieldemarmiesse/typed_api.git@0.1.1
+RUN pip install tensorflow-cpu==2.1.0 \
+			typeguard==2.7.1 \
+			git+https://github.com/gabrieldemarmiesse/typed_api.git@0.1.1
 
 COPY ./ /addons
-RUN TF_ADDONS_NO_BUILD=1 pip install --no-deps -e /addons
+RUN TF_ADDONS_NO_BUILD=1 pip install --no-cache-dir --no-deps -e /addons
 RUN python /addons/tools/ci_build/verify/check_typing_info.py
 RUN touch /ok.txt
 
@@ -36,7 +37,7 @@ RUN touch /ok.txt
 # -------------------------------
 FROM python:3.5 as valid_build_files
 
-RUN pip install --no-cache-dir tensorflow-cpu==2.1.0
+RUN pip install tensorflow-cpu==2.1.0
 
 RUN apt-get update && apt-get install sudo
 RUN git clone https://github.com/abhinavsingh/setup-bazel.git
@@ -80,7 +81,7 @@ RUN touch /ok.txt
 # docs tests
 FROM python:3.6 as docs_tests
 
-RUN pip install --no-cache-dir tensorflow-cpu==2.1.0 typeguard==2.7.1
+RUN pip install tensorflow-cpu==2.1.0 typeguard==2.7.1
 
 COPY tools/docs/doc_requirements.txt ./
 RUN pip install --no-cache-dir -r doc_requirements.txt

--- a/tools/docker/sanity_check.Dockerfile
+++ b/tools/docker/sanity_check.Dockerfile
@@ -9,7 +9,7 @@ RUN touch /ok.txt
 # -------------------------------
 FROM python:3.6 as black-test
 
-RUN pip install black==19.10b0
+RUN pip install --no-cache-dir black==19.10b0
 COPY ./ /addons
 RUN black --check /addons
 RUN touch /ok.txt
@@ -17,9 +17,8 @@ RUN touch /ok.txt
 # -------------------------------
 FROM python:3.6 as public-api-typed
 
-RUN pip install tensorflow-cpu==2.1.0
-RUN pip install typeguard==2.7.1
-RUN pip install git+https://github.com/gabrieldemarmiesse/typed_api.git@0.1.1
+RUN pip install --no-cache-dir tensorflow-cpu==2.1.0 typeguard==2.7.1
+RUN pip install --no-cache-dir git+https://github.com/gabrieldemarmiesse/typed_api.git@0.1.1
 
 COPY ./ /addons
 RUN TF_ADDONS_NO_BUILD=1 pip install --no-deps -e /addons
@@ -37,7 +36,7 @@ RUN touch /ok.txt
 # -------------------------------
 FROM python:3.5 as valid_build_files
 
-RUN pip install tensorflow-cpu==2.1.0
+RUN pip install --no-cache-dir tensorflow-cpu==2.1.0
 
 RUN apt-get update && apt-get install sudo
 RUN git clone https://github.com/abhinavsingh/setup-bazel.git
@@ -81,11 +80,10 @@ RUN touch /ok.txt
 # docs tests
 FROM python:3.6 as docs_tests
 
-RUN pip install tensorflow-cpu==2.1.0
-RUN pip install typeguard==2.7.1
+RUN pip install --no-cache-dir tensorflow-cpu==2.1.0 typeguard==2.7.1
 
 COPY tools/docs/doc_requirements.txt ./
-RUN pip install -r doc_requirements.txt
+RUN pip install --no-cache-dir -r doc_requirements.txt
 
 RUN apt-get update && apt-get install -y rsync
 


### PR DESCRIPTION
Modified some parts of dockderfiles: put pagckages together to install and clean cache. To clean cache is if any of the files changed, that invalidates all later layers: we’ll need to re-run pip install. This can keep the correctness, and somehow have a smaller image size even it's not big. 
ref: https://www.docker.com/blog/intro-guide-to-dockerfile-best-practices/
