### PR TITLE
Used pypi release for typedapi

### DIFF
--- a/tools/docker/sanity_check.Dockerfile
+++ b/tools/docker/sanity_check.Dockerfile
@@ -19,7 +19,7 @@ FROM python:3.6 as public-api-typed
 
 RUN pip install tensorflow-cpu==2.1.0
 RUN pip install typeguard==2.7.1
-RUN pip install git+https://github.com/gabrieldemarmiesse/typed_api.git@0.1.1
+RUN pip install typedapi==0.2.0
 
 COPY ./ /addons
 RUN TF_ADDONS_NO_BUILD=1 pip install --no-deps -e /addons


### PR DESCRIPTION
I believe it's a good opportunity to check the backport bot. We don't have to merge the PR opened by the bot, we can just close it afterwards.