### PR TITLE
HOTFIX: pin docker container pip install to py36

### DIFF
--- a/tools/docker/gpu_tests.Dockerfile
+++ b/tools/docker/gpu_tests.Dockerfile
@@ -2,11 +2,10 @@ FROM gcr.io/tensorflow-testing/nosla-cuda10.1-cudnn7-ubuntu16.04-manylinux2010
 
 COPY build_deps/build-requirements.txt ./
 
-# TODO: Remove pip pinned to 3.6 once #1116 is resolved.
-RUN pip3.6 install -r build-requirements.txt
+RUN python3 -m pip install -r build-requirements.txt
 
 COPY requirements.txt ./
-RUN pip3.6 install -r requirements.txt
+RUN python3 -m pip install -r requirements.txt
 
 COPY ./ /addons
 WORKDIR addons

--- a/tools/docker/gpu_tests.Dockerfile
+++ b/tools/docker/gpu_tests.Dockerfile
@@ -1,10 +1,12 @@
 FROM gcr.io/tensorflow-testing/nosla-cuda10.1-cudnn7-ubuntu16.04-manylinux2010
 
 COPY build_deps/build-requirements.txt ./
-RUN pip3 install -r build-requirements.txt
+
+# TODO: Remove pip pinned to 3.6 once #1116 is resolved.
+RUN pip3.6 install -r build-requirements.txt
 
 COPY requirements.txt ./
-RUN pip3 install -r requirements.txt
+RUN pip3.6 install -r requirements.txt
 
 COPY ./ /addons
 WORKDIR addons


### PR DESCRIPTION
Not really a good way to handle this. But it returns CI and then we can go from there.