### PR TITLE
Do release at each commit (but not the upload)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -5,6 +5,14 @@ on:
     types: [published]
     tags:
       - v*
+  push:
+    branches:
+      - master
+      - r*
+  pull_request:
+    branches:
+      - master
+      - r*
 
 env:
   BAZEL_VERSION: 1.1.0

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -34,6 +34,7 @@ jobs:
     strategy:
       matrix:
         python-version: ['3.5', '3.6', '3.7']
+    if: github.event_name == 'release' || ${{ matrix.python-version }} == '3.5'
     steps:
       - uses: actions/checkout@v2
       - uses: actions/setup-python@v1

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -194,6 +194,7 @@ jobs:
           ls -la dist/
           sha256sum dist/*.whl
       - uses: pypa/gh-action-pypi-publish@master
+        if: github.event_name == 'release'
         with:
           user: __token__
           password: ${{ secrets.pypi_token }}


### PR DESCRIPTION
Fix part of #1122 . I believe the first step is to enable running EVERYTHING at each commit, and then, with other pull requests, we can reduce code duplication in the yaml and make the tests faster.