### PR TITLE
Finish the bazel install before building addons

### DIFF
--- a/tools/docker/cpu_tests.Dockerfile
+++ b/tools/docker/cpu_tests.Dockerfile
@@ -10,6 +10,9 @@ RUN bash bazel.sh
 COPY requirements.txt ./
 RUN pip install -r requirements.txt
 
+COPY tools/docker/finish_bazel_install.sh ./
+RUN bash finish_bazel_install.sh
+
 COPY ./ /addons
 WORKDIR addons
 RUN bash tools/ci_testing/addons_cpu.sh --no-deps

--- a/tools/docker/finish_bazel_install.sh
+++ b/tools/docker/finish_bazel_install.sh
@@ -1,0 +1,12 @@
+set -e
+# hack to have the dependecies in the docker cache
+# and have much faster local build with docker
+# can be removed once docker buildx/buildkit is stable
+# and we'll use "RUN --mount=cache ..." instead
+cd /tmp
+git clone https://github.com/tensorflow/addons.git
+cd addons
+python ./configure.py --no-deps
+bazel build --nobuild -- //tensorflow_addons/...
+cd ..
+rm -rf ./addons

--- a/tools/docker/gpu_tests.Dockerfile
+++ b/tools/docker/gpu_tests.Dockerfile
@@ -7,6 +7,10 @@ RUN python3 -m pip install -r build-requirements.txt
 COPY requirements.txt ./
 RUN python3 -m pip install -r requirements.txt
 
+COPY tools/docker/finish_bazel_install.sh ./
+RUN bash finish_bazel_install.sh
+
+
 COPY ./ /addons
 WORKDIR addons
 CMD ["bash", "tools/ci_testing/addons_gpu.sh"]

--- a/tools/docker/sanity_check.Dockerfile
+++ b/tools/docker/sanity_check.Dockerfile
@@ -45,6 +45,9 @@ RUN apt-get update && apt-get install sudo
 COPY tools/ci_build/install/bazel.sh ./
 RUN bash bazel.sh
 
+COPY tools/docker/finish_bazel_install.sh ./
+RUN bash finish_bazel_install.sh
+
 COPY ./ /addons
 WORKDIR /addons
 RUN python ./configure.py --no-deps


### PR DESCRIPTION
When running a dockerfile, bazel doesn't get installed completely after running the `tools/ci_build/install/bazel.sh`. Actually, when running the first build, bazel does 3 things:

* Unpacking the bazel install
* Downloading the JDK
* Downloading from http archives set in the `WORKSPACE` file.

This delayed install isn't really compatible with how docker build works, since those install steps are not cached. 

To get around the bazel hack of delayed install, I made another hack (fighting fire with fire XD) which is to clone the master branch and do a dry run of `bazel build` in a previous layer.

In that way, when the cache gets invalidated at the COPY step, we already have a full bazel install, no need to download the ~300MB of additional stuff at every build.

Depending on your internet connection, it can make a big difference. For example, before, locally, running the sanity check took me 2-3 minutes (and my internet connection is ~10Mbps, quite good on the global scale). Now it takes me 20 seconds . I get a similar speedup when running the cpu/gpu tests with docker.