### PR TITLE
make two tests faster

### DIFF
--- a/tensorflow_addons/optimizers/novograd_test.py
+++ b/tensorflow_addons/optimizers/novograd_test.py
@@ -123,7 +123,7 @@ class NovoGradTest(tf.test.TestCase):
         model.add(tf.keras.layers.Dense(input_shape=(3,), units=1))
         model.compile(NovoGrad(), loss="mse")
 
-        model.fit(x, y, epochs=10)
+        model.fit(x, y, epochs=2)
 
         x = np.random.standard_normal((100, 3))
         y = np.dot(x, w)

--- a/tensorflow_addons/optimizers/stochastic_weight_averaging_test.py
+++ b/tensorflow_addons/optimizers/stochastic_weight_averaging_test.py
@@ -83,7 +83,7 @@ class SWATest(tf.test.TestCase):
             "sgd", start_averaging=num_examples // 32 - 1, average_period=100
         )
         model.compile(optimizer, loss="mse")
-        model.fit(x, y, epochs=10)
+        model.fit(x, y, epochs=2)
         optimizer.assign_average_vars(model.variables)
 
         x = np.random.standard_normal((100, 3))


### PR DESCRIPTION
stochastic_weight_averaging_test: 57s -> 15s
novograd_test  : 58s -> 14s

related to https://github.com/tensorflow/addons/issues/1143