### PR TITLE
Fix broken master branch

### DIFF
--- a/tools/ci_build/builds/release_linux.sh
+++ b/tools/ci_build/builds/release_linux.sh
@@ -47,6 +47,11 @@ for version in ${PYTHON_VERSIONS}; do
     python3 get-pip.py -q
     python3 -m pip --version
 
+    # tenmporary fix for "no space available on github actions"
+    python3 -m pip install --no-cache-dir \
+      -r build_deps/build-requirements.txt \
+      -r requirements.txt
+
     #Link TF dependency
     python3 ./configure.py --quiet
 
@@ -62,6 +67,9 @@ for version in ${PYTHON_VERSIONS}; do
 
     # Package Whl
     bazel-bin/build_pip_pkg artifacts ${PKG_OPS}
+
+    # tenmporary fix for "no space available on github actions"
+    python3 -m pip uninstall -y tensorflow
 done
 
 # Clean up


### PR DESCRIPTION
Use less disk space when building wheels. It was causing issues in Github actions (no space left on device).

it should save use ~2.5GB of disk

We can look later on for a clean and permanent fix.
