### PR TITLE
Have faster filters_test 

### DIFF
--- a/tensorflow_addons/image/filters_test.py
+++ b/tensorflow_addons/image/filters_test.py
@@ -149,12 +149,12 @@ class MeanFilter2dTest(_Filter2dTest):
 
     def test_reflect_padding_with_3x3_filter(self):
         expected_plane = tf.constant(
-            [ 
-               [3.6666667, 4.       , 4.3333335],
-               [4.6666665, 5.       , 5.3333335],
-               [5.6666665, 6.       , 6.3333335],
+            [
+                [3.6666667, 4.0, 4.3333335],
+                [4.6666665, 5.0, 5.3333335],
+                [5.6666665, 6.0, 6.3333335],
             ]
-       )
+        )
 
         for image_shape in self._image_shapes_to_test:
             self._verify_values(
@@ -167,11 +167,7 @@ class MeanFilter2dTest(_Filter2dTest):
 
     def test_reflect_padding_with_4x4_filter(self):
         expected_plane = tf.constant(
-            [
-                [5., 5., 5.],
-                [5., 5., 5.],
-                [5., 5., 5.],
-            ]
+            [[5.0, 5.0, 5.0], [5.0, 5.0, 5.0], [5.0, 5.0, 5.0],]
         )
 
         for image_shape in self._image_shapes_to_test:
@@ -187,7 +183,7 @@ class MeanFilter2dTest(_Filter2dTest):
         expected_plane = tf.constant(
             [
                 [1.3333334, 2.3333333, 1.7777778],
-                [3.       , 5.       , 3.6666667],
+                [3.0, 5.0, 3.6666667],
                 [2.6666667, 4.3333335, 3.1111112],
             ]
         )
@@ -204,7 +200,7 @@ class MeanFilter2dTest(_Filter2dTest):
         expected_plane = tf.constant(
             [
                 [1.8888888, 2.6666667, 2.3333333],
-                [3.3333333, 5.       , 4.       ],
+                [3.3333333, 5.0, 4.0],
                 [3.2222223, 4.6666665, 3.6666667],
             ]
         )
@@ -221,9 +217,9 @@ class MeanFilter2dTest(_Filter2dTest):
     def test_symmetric_padding_with_3x3_filter(self):
         expected_plane = tf.constant(
             [
-                [2.3333333, 3.       , 3.6666667],
-                [4.3333335, 5.       , 5.6666665],
-                [6.3333335, 7.       , 7.6666665], 
+                [2.3333333, 3.0, 3.6666667],
+                [4.3333335, 5.0, 5.6666665],
+                [6.3333335, 7.0, 7.6666665],
             ]
         )
 

--- a/tensorflow_addons/image/filters_test.py
+++ b/tensorflow_addons/image/filters_test.py
@@ -149,12 +149,12 @@ class MeanFilter2dTest(_Filter2dTest):
 
     def test_reflect_padding_with_3x3_filter(self):
         expected_plane = tf.constant(
-            [
-                [33.0 / 9.0, 36.0 / 9.0, 39.0 / 9.0],
-                [42.0 / 9.0, 45.0 / 9.0, 48.0 / 9.0],
-                [51.0 / 9.0, 54.0 / 9.0, 57.0 / 9.0],
+            [ 
+               [3.6666667, 4.       , 4.3333335],
+               [4.6666665, 5.       , 5.3333335],
+               [5.6666665, 6.       , 6.3333335],
             ]
-        )
+       )
 
         for image_shape in self._image_shapes_to_test:
             self._verify_values(
@@ -168,9 +168,9 @@ class MeanFilter2dTest(_Filter2dTest):
     def test_reflect_padding_with_4x4_filter(self):
         expected_plane = tf.constant(
             [
-                [80.0 / 16.0, 80.0 / 16.0, 80.0 / 16.0],
-                [80.0 / 16.0, 80.0 / 16.0, 80.0 / 16.0],
-                [80.0 / 16.0, 80.0 / 16.0, 80.0 / 16.0],
+                [5., 5., 5.],
+                [5., 5., 5.],
+                [5., 5., 5.],
             ]
         )
 
@@ -186,9 +186,9 @@ class MeanFilter2dTest(_Filter2dTest):
     def test_constant_padding_with_3x3_filter(self):
         expected_plane = tf.constant(
             [
-                [12.0 / 9.0, 21.0 / 9.0, 16.0 / 9.0],
-                [27.0 / 9.0, 45.0 / 9.0, 33.0 / 9.0],
-                [24.0 / 9.0, 39.0 / 9.0, 28.0 / 9.0],
+                [1.3333334, 2.3333333, 1.7777778],
+                [3.       , 5.       , 3.6666667],
+                [2.6666667, 4.3333335, 3.1111112],
             ]
         )
 
@@ -203,9 +203,9 @@ class MeanFilter2dTest(_Filter2dTest):
 
         expected_plane = tf.constant(
             [
-                [17.0 / 9.0, 24.0 / 9.0, 21.0 / 9.0],
-                [30.0 / 9.0, 45.0 / 9.0, 36.0 / 9.0],
-                [29.0 / 9.0, 42.0 / 9.0, 33.0 / 9.0],
+                [1.8888888, 2.6666667, 2.3333333],
+                [3.3333333, 5.       , 4.       ],
+                [3.2222223, 4.6666665, 3.6666667],
             ]
         )
 
@@ -221,9 +221,9 @@ class MeanFilter2dTest(_Filter2dTest):
     def test_symmetric_padding_with_3x3_filter(self):
         expected_plane = tf.constant(
             [
-                [21.0 / 9.0, 27.0 / 9.0, 33.0 / 9.0],
-                [39.0 / 9.0, 45.0 / 9.0, 51.0 / 9.0],
-                [57.0 / 9.0, 63.0 / 9.0, 69.0 / 9.0],
+                [2.3333333, 3.       , 3.6666667],
+                [4.3333335, 5.       , 5.6666665],
+                [6.3333335, 7.       , 7.6666665], 
             ]
         )
 


### PR DESCRIPTION
filters_test: 56.8s -> 41s (by replacing divide op)
related to [1143](https://github.com/tensorflow/addons/issues/1143)