### PR TITLE
Fast dense_image_warp_test

### DIFF
--- a/tensorflow_addons/image/dense_image_warp_test.py
+++ b/tensorflow_addons/image/dense_image_warp_test.py
@@ -209,7 +209,7 @@ class DenseImageWarpTest(tf.test.TestCase):
     def test_interpolation(self):
         """Apply _check_interpolation_correctness() for a few sizes and
         types."""
-        shapes_to_try = [[3, 4, 5, 6], [1, 5, 5, 3], [1, 2, 2, 1]]
+        shapes_to_try = [[3, 4, 5, 6], [1, 2, 2, 1]]
         for im_type in ["float32", "float64", "float16"]:
             for flow_type in ["float32", "float64", "float16"]:
                 for shape in shapes_to_try:
@@ -218,7 +218,7 @@ class DenseImageWarpTest(tf.test.TestCase):
     def test_unknown_shapes(self):
         """Apply _check_interpolation_correctness() for a few sizes and check
         for tf.Dataset compatibility."""
-        shapes_to_try = [[3, 4, 5, 6], [1, 5, 5, 3], [1, 2, 2, 1]]
+        shapes_to_try = [[3, 4, 5, 6], [1, 2, 2, 1]]
         for shape in shapes_to_try:
             self._check_interpolation_correctness(shape, "float32", "float32", True)
 


### PR DESCRIPTION
Reduce few cases in `shapes_to_try` and have 40.9s -> 19.6s
related to [1143](https://github.com/tensorflow/addons/issues/1143)