### PR TITLE
Remove explicit `reset_test=True` from test.

### DIFF
--- a/tensorflow_addons/optimizers/lazy_adam_test.py
+++ b/tensorflow_addons/optimizers/lazy_adam_test.py
@@ -203,7 +203,7 @@ class LazyAdamTest(tf.test.TestCase):
                         "LazyAdam/var0_%d/m:0" % (i,), opt.get_slot(var0, "m").name
                     )
 
-    @test_utils.run_in_graph_and_eager_modes(reset_test=True)
+    @test_utils.run_in_graph_and_eager_modes
     def testResourceBasic(self):
         self.doTestBasic()
 


### PR DESCRIPTION
The given value already is the default one, and I am exploring actually removing that parameter from `test_util.run_in_graph_and_eager_modes`, as nobody ever sets it to `False`.