### PR TITLE
Remove time field from AttentionWrapperState

### DIFF
--- a/tensorflow_addons/seq2seq/attention_wrapper_test.py
+++ b/tensorflow_addons/seq2seq/attention_wrapper_test.py
@@ -476,7 +476,7 @@ class AttentionWrapperTest(tf.test.TestCase, parameterized.TestCase):
             self.assertIsInstance(final_state, wrapper.AttentionWrapperState)
 
             expected_time = (
-                expected_final_state.time if tf.executing_eagerly() else None
+                max(decoder_sequence_length) if tf.executing_eagerly() else None
             )
             self.assertEqual(
                 (batch_size, expected_time, attention_depth),
@@ -645,7 +645,6 @@ class AttentionWrapperTest(tf.test.TestCase, parameterized.TestCase):
             attention=ResultSummary(
                 shape=(5, 6), dtype=np.dtype(np.float32), mean=0.041453815
             ),
-            time=3,
             alignments=ResultSummary(
                 shape=(5, 8), dtype=np.dtype(np.float32), mean=0.125
             ),
@@ -686,7 +685,6 @@ class AttentionWrapperTest(tf.test.TestCase, parameterized.TestCase):
             attention=ResultSummary(
                 shape=(5, 6), dtype=np.dtype("float32"), mean=0.042427111
             ),
-            time=3,
             alignments=ResultSummary(
                 shape=(5, 8), dtype=np.dtype("float32"), mean=0.125
             ),
@@ -723,7 +721,6 @@ class AttentionWrapperTest(tf.test.TestCase, parameterized.TestCase):
             attention=ResultSummary(
                 shape=(5, 6), dtype=np.dtype("float32"), mean=-0.0318060
             ),
-            time=3,
             alignments=ResultSummary(
                 shape=(5, 8), dtype=np.dtype("float32"), mean=0.125
             ),
@@ -760,7 +757,6 @@ class AttentionWrapperTest(tf.test.TestCase, parameterized.TestCase):
             attention=ResultSummary(
                 shape=(5, 6), dtype=np.dtype("float32"), mean=-0.0318060
             ),
-            time=3,
             alignments=ResultSummary(
                 shape=(5, 8), dtype=np.dtype("float32"), mean=0.125
             ),
@@ -796,7 +792,6 @@ class AttentionWrapperTest(tf.test.TestCase, parameterized.TestCase):
             attention=ResultSummary(
                 shape=(5, 10), dtype=np.dtype("float32"), mean=0.026356646
             ),
-            time=3,
             alignments=ResultSummary(
                 shape=(5, 8), dtype=np.dtype("float32"), mean=0.125
             ),
@@ -835,7 +830,6 @@ class AttentionWrapperTest(tf.test.TestCase, parameterized.TestCase):
             attention=ResultSummary(
                 shape=(5, 6), dtype=np.dtype("float32"), mean=0.038682378
             ),
-            time=3,
             alignments=ResultSummary(
                 shape=(5, 8), dtype=np.dtype("float32"), mean=0.09778417
             ),
@@ -877,7 +871,6 @@ class AttentionWrapperTest(tf.test.TestCase, parameterized.TestCase):
             attention=ResultSummary(
                 shape=(5, 6), dtype=np.dtype("float32"), mean=0.068432882
             ),
-            time=3,
             alignments=ResultSummary(
                 shape=(5, 8), dtype=np.dtype("float32"), mean=0.0615656
             ),
@@ -919,7 +912,6 @@ class AttentionWrapperTest(tf.test.TestCase, parameterized.TestCase):
             attention=ResultSummary(
                 shape=(5, 6), dtype=np.dtype("float32"), mean=0.059128221
             ),
-            time=3,
             alignments=ResultSummary(
                 shape=(5, 8), dtype=np.dtype("float32"), mean=0.05112994
             ),
@@ -961,7 +953,6 @@ class AttentionWrapperTest(tf.test.TestCase, parameterized.TestCase):
             attention=ResultSummary(
                 shape=(5, 6), dtype=np.dtype("float32"), mean=0.059128221
             ),
-            time=3,
             alignments=ResultSummary(
                 shape=(5, 8), dtype=np.dtype("float32"), mean=0.05112994
             ),
@@ -1005,12 +996,16 @@ class AttentionWrapperTest(tf.test.TestCase, parameterized.TestCase):
         cell = wrapper.AttentionWrapper(cell, mechanism)
 
         var_len = tf.random.uniform(shape=(), minval=2, maxval=10, dtype=tf.int32)
+        lengths = tf.random.uniform(
+            shape=(var_len,), minval=1, maxval=var_len + 1, dtype=tf.int32
+        )
         data = tf.ones(shape=(var_len, var_len, 3))
+        mask = tf.sequence_mask(lengths, maxlen=var_len)
 
         mechanism.setup_memory(data)
         layer = tf.keras.layers.RNN(cell)
 
-        _ = layer(data)
+        _ = layer(data, mask=mask)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
This is a suggested fix for #1194.

The `time` attribute has a limited use in both internal and user codes:

* Internal: it was only used to append to `alignment_history`, but here it is an alias for `alignment_history.size()`
* User: the time component can be inferred from input or output of the layer.

Fixes #1194.