### PR TITLE
Fix test-release for nightlies

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -78,7 +78,7 @@ jobs:
         shell: bash
         run: |
           pip install tensorflow~=2.1.0
-          pip install wheel/tensorflow_addons-*.whl
+          pip install wheel/*.whl
           python -c "import tensorflow_addons as tfa; print(tfa.activations.lisht(0.2))"
 
   upload-wheels:


### PR DESCRIPTION
Last night's release failed:
https://github.com/tensorflow/addons/runs/485118606?check_suite_focus=true

This was because the wheel file did not match `tensorflow_addons-*.whl` since its `tfa-*`. A single wheel artifact is downloaded so a wildcard should work here.