### PR TITLE
Enable testing of poincare_test.py

### DIFF
--- a/tensorflow_addons/layers/BUILD
+++ b/tensorflow_addons/layers/BUILD
@@ -52,6 +52,18 @@ py_test(
 )
 
 py_test(
+    name = "poincare_test",
+    size = "small",
+    srcs = [
+        "poincare_test.py",
+    ],
+    main = "poincare_test.py",
+    deps = [
+        ":layers",
+    ],
+)
+
+py_test(
     name = "tlu_test",
     size = "small",
     srcs = [

--- a/tensorflow_addons/layers/poincare_test.py
+++ b/tensorflow_addons/layers/poincare_test.py
@@ -14,6 +14,8 @@
 # ==============================================================================
 """Tests for PoincareNormalize layer."""
 
+import unittest
+
 import numpy as np
 import tensorflow as tf
 
@@ -54,6 +56,7 @@ class PoincareNormalizeTest(tf.test.TestCase):
                 norm = np.linalg.norm(y, axis=dim)
                 self.assertLessEqual(norm.max(), 1.0 - epsilon + tol)
 
+    @unittest.skip("Failing. See https://github.com/tensorflow/addons/issues/1205")
     def testPoincareNormalizeDimArray(self):
         x_shape = [20, 7, 3]
         epsilon = 1e-5

--- a/tensorflow_addons/layers/poincare_test.py
+++ b/tensorflow_addons/layers/poincare_test.py
@@ -14,8 +14,6 @@
 # ==============================================================================
 """Tests for PoincareNormalize layer."""
 
-import unittest
-
 import numpy as np
 import tensorflow as tf
 
@@ -56,8 +54,8 @@ class PoincareNormalizeTest(tf.test.TestCase):
                 norm = np.linalg.norm(y, axis=dim)
                 self.assertLessEqual(norm.max(), 1.0 - epsilon + tol)
 
-    @unittest.skip("Failing. See https://github.com/tensorflow/addons/issues/1205")
     def testPoincareNormalizeDimArray(self):
+        self.skipTest("Failing. See https://github.com/tensorflow/addons/issues/1205")
         x_shape = [20, 7, 3]
         epsilon = 1e-5
         tol = 1e-6


### PR DESCRIPTION
Related to #1205 but doesn't close it.

Skipping the failing test. Should be fixed later on.