### PR TITLE
Fix bug where each wheel has a different version number.

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -27,12 +27,14 @@ jobs:
         python-version: ['3.5', '3.6', '3.7']
       fail-fast: false
     steps:
-      - if: github.event_name == 'push'
-        run: echo "::set-env name=NIGHTLY_FLAG::--nightly"
-      - uses: actions/checkout@v2
       - uses: actions/setup-python@v1
         with:
           python-version: ${{ matrix.python-version }}
+      - if: github.event_name == 'push'
+        run: |
+          echo "::set-env name=NIGHTLY_FLAG::--nightly"
+          python -m pip install GitPython
+      - uses: actions/checkout@v2
       - name: Build wheels
         if: github.event_name == 'push' || github.event_name == 'release' || matrix.python-version == '3.5'
         env:

--- a/README.md
+++ b/README.md
@@ -77,7 +77,7 @@ There are also nightly builds of TensorFlow Addons under the pip package
 `tfa-nightly`, which is built against **the latest stable version of TensorFlow**. Nightly builds
 include newer features, but may be less stable than the versioned releases. Contrary to 
 what the name implies, nightly builds are not released every night, but at every commit 
-of the master branch. `0.9.0.dev20200306094440` means that the build time was 
+of the master branch. `0.9.0.dev20200306094440` means that the commit time was 
 2020/03/06 at 09:44:40 Coordinated Universal Time.
 
 ```

--- a/setup.py
+++ b/setup.py
@@ -27,17 +27,18 @@ of the community).
 import os
 import sys
 
-from datetime import datetime
 from setuptools import find_packages
 from setuptools import setup
 from setuptools.dist import Distribution
 from setuptools import Extension
 
+BASE_DIR = os.path.dirname(os.path.abspath(__file__))
+
 
 def get_last_commit_time() -> str:
     from git import Repo
 
-    return Repo("./").commit("HEAD").committed_datetime.strftime("%Y%m%d%H%M%S")
+    return Repo(BASE_DIR).commit("HEAD").committed_datetime.strftime("%Y%m%d%H%M%S")
 
 
 DOCLINES = __doc__.split("\n")
@@ -47,8 +48,7 @@ TFA_RELEASE = "tensorflow-addons"
 
 # Version
 version = {}
-base_dir = os.path.dirname(os.path.abspath(__file__))
-with open(os.path.join(base_dir, "tensorflow_addons", "version.py")) as fp:
+with open(os.path.join(BASE_DIR, "tensorflow_addons", "version.py")) as fp:
     exec(fp.read(), version)
 
 if "--nightly" in sys.argv:

--- a/setup.py
+++ b/setup.py
@@ -33,17 +33,17 @@ from setuptools import setup
 from setuptools.dist import Distribution
 from setuptools import Extension
 
+
+def get_last_commit_time() -> str:
+    from git import Repo
+
+    return Repo("./").commit("HEAD").committed_datetime.strftime("%Y%m%d%H%M%S")
+
+
 DOCLINES = __doc__.split("\n")
 
 TFA_NIGHTLY = "tfa-nightly"
 TFA_RELEASE = "tensorflow-addons"
-
-if "--nightly" in sys.argv:
-    project_name = TFA_NIGHTLY
-    nightly_idx = sys.argv.index("--nightly")
-    sys.argv.pop(nightly_idx)
-else:
-    project_name = TFA_RELEASE
 
 # Version
 version = {}
@@ -51,8 +51,13 @@ base_dir = os.path.dirname(os.path.abspath(__file__))
 with open(os.path.join(base_dir, "tensorflow_addons", "version.py")) as fp:
     exec(fp.read(), version)
 
-if project_name == TFA_NIGHTLY:
-    version["__version__"] += datetime.now().strftime("%Y%m%d%H%M%S")
+if "--nightly" in sys.argv:
+    project_name = TFA_NIGHTLY
+    nightly_idx = sys.argv.index("--nightly")
+    sys.argv.pop(nightly_idx)
+    version["__version__"] += get_last_commit_time()
+else:
+    project_name = TFA_RELEASE
 
 with open("requirements.txt") as f:
     required_pkgs = f.read().splitlines()


### PR DESCRIPTION
Because they're not built at the exact same time in github actions, the 9 wheels we upload have a different version number. Here we use the last commit time. It's also then easier to track back the commit used from the version number.