### PR TITLE
Added instructions to work on Addons on Windows.

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -90,6 +90,7 @@ This is if you want to stay in Windows world. In this case, you need:
  (if you want to compile custom ops on windows, optional).
  
  If you develop on Windows and you encounter issues, we'd be happy to have your feedback!
+ [This link](https://github.com/tensorflow/addons/issues/1134) might help you.
 
 ## Development Tips
 Try these useful commands below:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -86,7 +86,7 @@ This is if you want to stay in Windows world. In this case, you need:
 * Docker desktop with Linux containers (code format, testing on linux, etc...)
 * A local Python installation
 * Bazel (if you want to compile custom ops on Windows, optional)
-* [Visual Studio build tools 2017](https://devblogs.microsoft.com/cppblog/visual-studio-build-tools-now-include-the-vs2017-and-vs2015-msvc-toolsets/)
+* [Visual Studio build tools 2019](https://chocolatey.org/packages/visualstudio2019buildtools)
  (if you want to compile custom ops on windows, optional).
  
  If you develop on Windows and you encounter issues, we'd be happy to have your feedback!

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -86,7 +86,9 @@ This is if you want to stay in Windows world. In this case, you need:
 * Docker desktop with Linux containers (code format, testing on linux, etc...)
 * A local Python installation
 * Bazel (if you want to compile custom ops on Windows, optional)
-* [Visual Studio build tools 2019](https://chocolatey.org/packages/visualstudio2019buildtools)
+* Visual Studio build tools 2019
+[install with chocolatey](https://chocolatey.org/packages/visualstudio2019buildtools) or
+ [install manually](https://www.tensorflow.org/install/source_windows#install_visual_c_build_tools_2019)
  (if you want to compile custom ops on windows, optional).
  
  If you develop on Windows and you encounter issues, we'd be happy to have your feedback!

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -50,6 +50,46 @@ paper and understand how it fits into the TensorFlow community. This
 process can take longer than typical commit reviews so please bare with
 us**
 
+## Tools needed for developement
+
+#### Linux
+
+* Docker (code formatting / testing)
+* Nvidia-docker (for GPU testing, optional)
+* Bazel installed locally (to build custom ops locally, optional)
+* NVCC/Cuda installed locally (to build custom ops with gpu locally, optional)
+
+#### MacOS
+
+* Docker (code formatting / testing)
+* Bazel installed locally (to build custom ops locally, optional)
+
+#### Windows
+
+For Windows, you have two options:
+
+##### WSL 2
+
+WSL 2 is a very light virtual machine running with hyper-V. When running in 
+WSL 2, you're in a full linux environment, with a real linux kernel. 
+WSL 2 networking is shared with Windows and your Windows files can be found under 
+`/mnt/c`. When working with WSL 2, you can just follow the linux guides and tutorials
+and everything will work as in linux, including 
+Docker (that means you install docker with apt-get), git, ssh...
+See [the WSL 2 install guide](https://docs.microsoft.com/en-us/windows/wsl/wsl2-install).
+
+##### Powershell in Windows
+
+This is if you want to stay in Windows world. In this case, you need:
+
+* Git with git bash install on the PATH (meaning that you can run the `sh` command from Powershell).
+* Docker desktop with Linux containers (code format, testing on linux, etc...)
+* A local Python installation
+* Bazel (if you want to compile custom ops on Windows, optional)
+* [Visual Studio build tools 2017](https://devblogs.microsoft.com/cppblog/visual-studio-build-tools-now-include-the-vs2017-and-vs2015-msvc-toolsets/)
+ (if you want to compile custom ops on windows, optional).
+ 
+ If you develop on Windows and you encounter issues, we'd be happy to have your feedback!
 
 ## Development Tips
 Try these useful commands below:
@@ -59,10 +99,12 @@ Try these useful commands below:
 * Run CPU unit tests: `bash tools/run_cpu_tests.sh`
 * Run GPU unit tests: `bash tools/run_gpu_tests.sh`
 
+If you're running Powershell on Windows, use `sh` instead of `bash` when typing the commands.
+
 ## Coding style
 
 We provide a pre-commit hook to format your code automatically before each
-commit, so that you don't have to read our style guide. Install it with
+commit, so that you don't have to read our style guide. Install it on Linux/MacOS with
 
 ```
 cd .git/hooks && ln -s -f ../../tools/pre-commit.sh pre-commit
@@ -70,16 +112,17 @@ cd .git/hooks && ln -s -f ../../tools/pre-commit.sh pre-commit
 
 and you're good to go.
 
+On Windows, in powershell, do:
+
+```
+cd .git/hooks
+cmd /c mklink pre-commit ..\..\tools\pre-commit.sh
+```
+
 Note that this pre-commit needs Docker to run. 
 If you have docker 19.03+, it uses
 [Docker buildkit](https://docs.docker.com/develop/develop-images/build_enhancements/) 
 to make the build step much faster.
-
-
-It should also work on 
-Windows (with [Docker desktop for Windows](https://docs.docker.com/docker-for-windows/install/), 
-select "Run linux containers").
-But this has not been tested. If you work on Windows, we'd be happy to have your feedback!
 
 See our [Style Guide](STYLE_GUIDE.md) for more details.
 
@@ -95,10 +138,14 @@ subscribe for alerts please join the [addons-testing mailing list](https://group
 bash tools/run_cpu_tests.sh
 ```
 
+On PowerShell, just use `sh` instead of `bash`.
+
 #### GPU Testing Script
 ```bash
 bash tools/run_gpu_tests.sh
 ```
+
+On PowerShell, just use `sh` instead of `bash`.
 
 #### Run Manually
 

--- a/tools/pre-commit.sh
+++ b/tools/pre-commit.sh
@@ -12,4 +12,6 @@ if [ "$DOCKER_BUILDKIT" == "" ]; then
 fi
 
 docker build -t tf_addons_formatting -f tools/docker/pre-commit.Dockerfile .
+
+export MSYS_NO_PATHCONV=1
 docker run --rm -t -v "$(pwd -P):/addons" tf_addons_formatting


### PR DESCRIPTION
We don't have a windows Dockerfile but for the moment it's enough. With git bash on PATH and Docker desktop installed, everything worked out of the box. 

Except the pesky file path starting with / being translated automatically by git bash when using a windows command (ex; docker desktop). MSYS_NO_PATHCONV=1 is here to disable it.

That was way less pain than what I imagined 😄 

Fix #1134

There are no instructions to compile custom ops with windows but I think that people motivated enough to do that will be able to look at the github actions file to find out how it works.