### PR TITLE
Better error message for npairs on Windows

### DIFF
--- a/tensorflow_addons/losses/BUILD
+++ b/tensorflow_addons/losses/BUILD
@@ -2,35 +2,20 @@ licenses(["notice"])  # Apache 2.0
 
 package(default_visibility = ["//visibility:public"])
 
-# TODO: Build npairs for windows after SparseMatMul issue is solved
-# https://github.com/tensorflow/addons/issues/838
 py_library(
     name = "losses",
-    srcs = select({
-        "//tensorflow_addons:windows": [
-            "__init__.py",
-            "contrastive.py",
-            "focal_loss.py",
-            "giou_loss.py",
-            "lifted.py",
-            "metric_learning.py",
-            "quantiles.py",
-            "sparsemax_loss.py",
-            "triplet.py",
-        ],
-        "//conditions:default": [
-            "__init__.py",
-            "contrastive.py",
-            "focal_loss.py",
-            "giou_loss.py",
-            "lifted.py",
-            "metric_learning.py",
-            "npairs.py",
-            "quantiles.py",
-            "sparsemax_loss.py",
-            "triplet.py",
-        ],
-    }),
+    srcs = [
+        "__init__.py",
+        "contrastive.py",
+        "focal_loss.py",
+        "giou_loss.py",
+        "lifted.py",
+        "metric_learning.py",
+        "npairs.py",
+        "quantiles.py",
+        "sparsemax_loss.py",
+        "triplet.py",
+    ],
     deps = [
         "//tensorflow_addons/activations",
         "//tensorflow_addons/utils",
@@ -77,14 +62,8 @@ py_test(
 py_test(
     name = "npairs_test",
     size = "small",
-    srcs = select({
-        "//tensorflow_addons:windows": ["npairs_dummy_test.py"],
-        "//conditions:default": ["npairs_test.py"],
-    }),
-    main = select({
-        "//tensorflow_addons:windows": "npairs_dummy_test.py",
-        "//conditions:default": "npairs_test.py",
-    }),
+    srcs = ["npairs_test.py"],
+    main = "npairs_test.py",
     deps = [
         ":losses",
     ],

--- a/tensorflow_addons/losses/BUILD
+++ b/tensorflow_addons/losses/BUILD
@@ -58,7 +58,6 @@ py_test(
     ],
 )
 
-# Temporarily disable on windows
 py_test(
     name = "npairs_test",
     size = "small",

--- a/tensorflow_addons/losses/__init__.py
+++ b/tensorflow_addons/losses/__init__.py
@@ -30,14 +30,10 @@ from tensorflow_addons.losses.triplet import (
 )
 from tensorflow_addons.losses.quantiles import pinball_loss, PinballLoss
 
-# Temporarily disable for windows
-# Remove after: https://github.com/tensorflow/addons/issues/838
-import os
 
-if os.name != "nt":
-    from tensorflow_addons.losses.npairs import (
-        npairs_loss,
-        NpairsLoss,
-        npairs_multilabel_loss,
-        NpairsMultilabelLoss,
-    )
+from tensorflow_addons.losses.npairs import (
+    npairs_loss,
+    NpairsLoss,
+    npairs_multilabel_loss,
+    NpairsMultilabelLoss,
+)

--- a/tensorflow_addons/losses/npairs.py
+++ b/tensorflow_addons/losses/npairs.py
@@ -14,10 +14,20 @@
 # ==============================================================================
 """Implements npairs loss."""
 
+import platform
+
 import tensorflow as tf
 
 from tensorflow_addons.utils.types import TensorLike
 from typeguard import typechecked
+
+
+def check_if_windows(name):
+    if platform.system() != "Windows":
+        return
+    raise NotImplementedError(
+        "The function {} is not yet available on Windows.".format(name)
+    )
 
 
 @tf.keras.utils.register_keras_serializable(package="Addons")
@@ -49,6 +59,7 @@ def npairs_loss(y_true: TensorLike, y_pred: TensorLike) -> tf.Tensor:
     Returns:
       npairs_loss: float scalar.
     """
+    check_if_windows("npairs_loss")
     y_pred = tf.convert_to_tensor(y_pred)
     y_true = tf.cast(y_true, y_pred.dtype)
 
@@ -108,6 +119,7 @@ def npairs_multilabel_loss(y_true: TensorLike, y_pred: TensorLike) -> tf.Tensor:
     Returns:
       npairs_multilabel_loss: float scalar.
     """
+    check_if_windows("npairs_multilabel_loss")
     y_pred = tf.convert_to_tensor(y_pred)
     y_true = tf.cast(y_true, y_pred.dtype)
 

--- a/tensorflow_addons/losses/npairs_dummy_test.py
+++ b/tensorflow_addons/losses/npairs_dummy_test.py
@@ -1,3 +1,0 @@
-"""Temporary until SparseMatMul issue is solved for windows."""
-
-# Remove after: https://github.com/tensorflow/addons/issues/838

--- a/tensorflow_addons/losses/npairs_test.py
+++ b/tensorflow_addons/losses/npairs_test.py
@@ -13,12 +13,20 @@
 # limitations under the License.
 # ==============================================================================
 """Tests for npairs loss."""
+import platform
+import unittest
 
 import tensorflow as tf
 from tensorflow_addons.losses import npairs
 from tensorflow_addons.utils import test_utils
 
+IS_WINDOWS = platform.system() == "Windows"
 
+
+@unittest.skipIf(
+    IS_WINDOWS,
+    reason="Doesn't work on Windows, see https://github.com/tensorflow/addons/issues/838",
+)
 @test_utils.run_all_in_graph_and_eager_modes
 class NpairsLossTest(tf.test.TestCase):
     def test_config(self):
@@ -53,6 +61,10 @@ class NpairsLossTest(tf.test.TestCase):
         self.assertAllClose(loss, 0.253856)
 
 
+@unittest.skipIf(
+    IS_WINDOWS,
+    reason="Doesn't work on Windows, see https://github.com/tensorflow/addons/issues/838",
+)
 @test_utils.run_all_in_graph_and_eager_modes
 class NpairsMultilabelLossTest(tf.test.TestCase):
     def config(self):


### PR DESCRIPTION
A descriptive error message is better than `losses has no attribute ...`.