### PR TITLE
Better error message for parse_time on windows.

### DIFF
--- a/tensorflow_addons/text/BUILD
+++ b/tensorflow_addons/text/BUILD
@@ -6,19 +6,12 @@ package(default_visibility = ["//visibility:public"])
 # https://github.com/tensorflow/addons/issues/782
 py_library(
     name = "text",
-    srcs = select({
-        "//tensorflow_addons:windows": [
-            "__init__.py",
-            "crf.py",
-            "skip_gram_ops.py",
-        ],
-        "//conditions:default": [
-            "__init__.py",
-            "crf.py",
-            "parse_time_op.py",
-            "skip_gram_ops.py",
-        ],
-    }),
+    srcs = [
+        "__init__.py",
+        "crf.py",
+        "parse_time_op.py",
+        "skip_gram_ops.py",
+    ],
     data = select({
         "//tensorflow_addons:windows": [
             "//tensorflow_addons/custom_ops/text:_skip_gram_ops.so",
@@ -56,18 +49,11 @@ py_test(
     ],
 )
 
-# Temporarily use dummy test for windows ParseTime
 py_test(
     name = "parse_time_op_test",
     size = "small",
-    srcs = select({
-        "//tensorflow_addons:windows": ["parse_time_dummy_test.py"],
-        "//conditions:default": ["parse_time_op_test.py"],
-    }),
-    main = select({
-        "//tensorflow_addons:windows": "parse_time_dummy_test.py",
-        "//conditions:default": "parse_time_op_test.py",
-    }),
+    srcs = ["parse_time_op_test.py"],
+    main = "parse_time_op_test.py",
     deps = [
         ":text",
     ],

--- a/tensorflow_addons/text/__init__.py
+++ b/tensorflow_addons/text/__init__.py
@@ -26,16 +26,8 @@ from tensorflow_addons.text.crf import crf_multitag_sequence_score
 from tensorflow_addons.text.crf import crf_sequence_score
 from tensorflow_addons.text.crf import crf_unary_score
 from tensorflow_addons.text.crf import viterbi_decode
+from tensorflow_addons.text.parse_time_op import parse_time
 
 # Skip Gram Sampling
 from tensorflow_addons.text.skip_gram_ops import skip_gram_sample
 from tensorflow_addons.text.skip_gram_ops import skip_gram_sample_with_text_vocab
-
-# Parse Time
-
-# Temporarily disable for windows
-# Remove after: https://github.com/tensorflow/addons/issues/782
-import os
-
-if os.name != "nt":
-    from tensorflow_addons.text.parse_time_op import parse_time

--- a/tensorflow_addons/text/parse_time_dummy_test.py
+++ b/tensorflow_addons/text/parse_time_dummy_test.py
@@ -1,3 +1,0 @@
-"""Temporary until ParseTime is able to run on windows."""
-
-# Remove after: https://github.com/tensorflow/addons/issues/782

--- a/tensorflow_addons/text/parse_time_op.py
+++ b/tensorflow_addons/text/parse_time_op.py
@@ -13,10 +13,13 @@
 # limitations under the License.
 # ==============================================================================
 """Parse time ops."""
+import platform
 
 import tensorflow as tf
 
 from tensorflow_addons.utils.resource_loader import LazySO
+
+IS_WINDOWS = platform.system() == "Windows"
 
 _parse_time_so = LazySO("custom_ops/text/_parse_time_op.so")
 
@@ -78,4 +81,6 @@ def parse_time(time_string: str, time_format: str, output_unit: str) -> str:
       ValueError: If `output_unit` is not a valid value,
         if parsing `time_string` according to `time_format` failed.
     """
+    if IS_WINDOWS:
+        raise NotImplementedError("parse_time is not yet implemented on Windows.")
     return _parse_time_so.ops.addons_parse_time(time_string, time_format, output_unit)

--- a/tensorflow_addons/text/parse_time_op_test.py
+++ b/tensorflow_addons/text/parse_time_op_test.py
@@ -13,13 +13,21 @@
 # limitations under the License.
 # ==============================================================================
 """Parse time op tests."""
+import unittest
+import platform
 
 import tensorflow as tf
 
 from tensorflow_addons import text
 from tensorflow_addons.utils import test_utils
 
+IS_WINDOWS = platform.system() == "Windows"
 
+
+@unittest.skipIf(
+    IS_WINDOWS,
+    reason="Doesn't work on Windows, see https://github.com/tensorflow/addons/issues/782",
+)
 @test_utils.run_all_in_graph_and_eager_modes
 class ParseTimeTest(tf.test.TestCase):
     def test_parse_time(self):


### PR DESCRIPTION
It's a bit better than `text has no attribute parse_time`.