### PR TITLE
Fix typing for poincare layer

### DIFF
--- a/tensorflow_addons/layers/poincare.py
+++ b/tensorflow_addons/layers/poincare.py
@@ -16,6 +16,7 @@
 
 import tensorflow as tf
 from typeguard import typechecked
+from typing import Union, List
 
 
 @tf.keras.utils.register_keras_serializable(package="Addons")
@@ -43,7 +44,7 @@ class PoincareNormalize(tf.keras.layers.Layer):
     """
 
     @typechecked
-    def __init__(self, axis: int = 1, epsilon: float = 1e-5, **kwargs):
+    def __init__(self, axis: Union[None, int, List[int]] = 1, epsilon: float = 1e-5, **kwargs):
         super().__init__(**kwargs)
         self.axis = axis
         self.epsilon = epsilon

--- a/tensorflow_addons/layers/poincare.py
+++ b/tensorflow_addons/layers/poincare.py
@@ -44,7 +44,9 @@ class PoincareNormalize(tf.keras.layers.Layer):
     """
 
     @typechecked
-    def __init__(self, axis: Union[None, int, List[int]] = 1, epsilon: float = 1e-5, **kwargs):
+    def __init__(
+        self, axis: Union[None, int, List[int]] = 1, epsilon: float = 1e-5, **kwargs
+    ):
         super().__init__(**kwargs)
         self.axis = axis
         self.epsilon = epsilon

--- a/tensorflow_addons/layers/poincare_test.py
+++ b/tensorflow_addons/layers/poincare_test.py
@@ -55,7 +55,6 @@ class PoincareNormalizeTest(tf.test.TestCase):
                 self.assertLessEqual(norm.max(), 1.0 - epsilon + tol)
 
     def testPoincareNormalizeDimArray(self):
-        self.skipTest("Failing. See https://github.com/tensorflow/addons/issues/1205")
         x_shape = [20, 7, 3]
         epsilon = 1e-5
         tol = 1e-6


### PR DESCRIPTION
Closes #1205 

axis is used in `reduce_sum` and supports several types:
https://github.com/tensorflow/tensorflow/blob/r2.1/tensorflow/python/ops/math_ops.py#L1555-L1564