### PR TITLE
Update dtype for multilabel CM test

### DIFF
--- a/tensorflow_addons/metrics/multilabel_confusion_matrix_test.py
+++ b/tensorflow_addons/metrics/multilabel_confusion_matrix_test.py
@@ -22,14 +22,13 @@ from tensorflow_addons.utils import test_utils
 @test_utils.run_all_in_graph_and_eager_modes
 class MultiLabelConfusionMatrixTest(tf.test.TestCase):
     def test_config(self):
-        self.skipTest("Failing. See https://github.com/tensorflow/addons/issues/1204")
         mcm_obj = MultiLabelConfusionMatrix(num_classes=3)
         self.assertEqual(mcm_obj.num_classes, 3)
-        self.assertEqual(mcm_obj.dtype, tf.int32)
+        self.assertEqual(mcm_obj.dtype, tf.float32)
         # Check save and restore config
         mcm_obj2 = MultiLabelConfusionMatrix.from_config(mcm_obj.get_config())
         self.assertEqual(mcm_obj2.num_classes, 3)
-        self.assertEqual(mcm_obj2.dtype, tf.int32)
+        self.assertEqual(mcm_obj2.dtype, tf.float32)
 
     def initialize_vars(self, n_classes, input_dtype):
         mcm_obj = MultiLabelConfusionMatrix(num_classes=n_classes, dtype=input_dtype)


### PR DESCRIPTION
Closes #1204 

The default dtype for a Keras metric results in a float:
https://github.com/tensorflow/tensorflow/blob/r2.1/tensorflow/python/keras/metrics.py#L145

However, since this is a confusion matrix I'm wondering if we should always cast it as an integer? 

++ @SSaishruthi as code owner for input