### PR TITLE
[WIP] Fix cyclical learning rate test

### DIFF
--- a/tensorflow_addons/optimizers/cyclical_learning_rate.py
+++ b/tensorflow_addons/optimizers/cyclical_learning_rate.py
@@ -91,6 +91,7 @@ class CyclicalLearningRate(tf.keras.optimizers.schedules.LearningRateSchedule):
             dtype = initial_learning_rate.dtype
             maximal_learning_rate = tf.cast(self.maximal_learning_rate, dtype)
             step_size = tf.cast(self.step_size, dtype)
+            step = tf.cast(step, dtype)
             cycle = tf.floor(1 + step / (2 * step_size))
             x = tf.abs(step / step_size - 2 * cycle + 1)
 


### PR DESCRIPTION
Closes #1203 
Variable is ResourceVariable by default in TF2.

Marking as WIP as there is still a mismatch between the numpy implementation and the TF version though. Reference from the keras-contrib version:
https://github.com/keras-team/keras-contrib/blob/master/keras_contrib/callbacks/cyclical_learning_rate.py#L124