### PR TITLE
Simpler install for contributors.

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -182,7 +182,7 @@ then you don't need to use Bazel to run your tests.
 Just run from the root:
 
 ```
-TF_ADDONS_NO_BUILD=1 pip install -e ./
+pip install -e ./
 ```
 
 It's going to install Addons in editable mode without compiling anything.

--- a/build_deps/build_pip_pkg.sh
+++ b/build_deps/build_pip_pkg.sh
@@ -82,7 +82,7 @@ function main() {
   echo $(date) : "=== Building wheel"
 
 
-  BUILD_CMD="setup.py bdist_wheel"
+  BUILD_CMD="setup.py bdist_wheel --platlib-patch"
   if is_macos; then
     BUILD_CMD="${BUILD_CMD} --plat-name macosx_10_13_x86_64"
   fi

--- a/setup.py
+++ b/setup.py
@@ -45,6 +45,13 @@ if "--nightly" in sys.argv:
 else:
     project_name = TFA_RELEASE
 
+ext_modules = []
+if "--platlib-patch" in sys.argv:
+    if sys.platform.startswith("linux"):
+        # Manylinux2010 requires a patch for platlib
+        ext_modules = [Extension("_foo", ["stub.cc"])]
+    sys.argv.remove("--platlib-patch")
+
 # Version
 version = {}
 base_dir = os.path.dirname(os.path.abspath(__file__))
@@ -56,15 +63,6 @@ if project_name == TFA_NIGHTLY:
 
 with open("requirements.txt") as f:
     required_pkgs = f.read().splitlines()
-
-# Manylinux2010 requires a patch for platlib
-if (
-    sys.platform.startswith("linux")
-    and os.environ.get("TF_ADDONS_NO_BUILD", "0") == "0"
-):
-    ext_modules = [Extension("_foo", ["stub.cc"])]
-else:
-    ext_modules = []
 
 
 class BinaryDistribution(Distribution):

--- a/tools/docker/sanity_check.Dockerfile
+++ b/tools/docker/sanity_check.Dockerfile
@@ -28,7 +28,7 @@ RUN pip install -r typedapi.txt
 
 
 COPY ./ /addons
-RUN TF_ADDONS_NO_BUILD=1 pip install --no-deps -e /addons
+RUN pip install --no-deps -e /addons
 RUN python /addons/tools/ci_build/verify/check_typing_info.py
 RUN touch /ok.txt
 
@@ -102,7 +102,7 @@ RUN apt-get update && apt-get install -y rsync
 
 COPY ./ /addons
 WORKDIR /addons
-RUN TF_ADDONS_NO_BUILD=1 pip install --no-deps -e .
+RUN pip install --no-deps -e .
 RUN python tools/docs/build_docs.py
 RUN touch /ok.txt
 
@@ -126,7 +126,7 @@ COPY ./ /addons
 WORKDIR /addons
 RUN python configure.py --no-deps
 RUN bash tools/install_so_files.sh
-RUN TF_ADDONS_NO_BUILD=1 pip install --no-deps -e .
+RUN pip install --no-deps -e .
 RUN python -c "import tensorflow_addons as tfa; print(tfa.activations.lisht(0.2))"
 RUN touch /ok.txt
 


### PR DESCRIPTION
As we move towards being more and more contributor-friendly, this move is to make the install easier.

The following commands will work on all systems:

```bash
pip install -e ./
pip install ./
pip install git+https://github.com/tensorflow/addons.git # useful to ask people to try the latest commit.
```

Note that none of those commands build any SO file. So there is that.