### PR TITLE
Make bazel run all files with pytest instead of unittest

### DIFF
--- a/tensorflow_addons/activations/activations_test.py
+++ b/tensorflow_addons/activations/activations_test.py
@@ -53,4 +53,4 @@ class ActivationsTest(tf.test.TestCase):
 
 
 if __name__ == "__main__":
-    tf.test.main()
+    sys.exit(pytest.main([__file__]))

--- a/tensorflow_addons/activations/activations_test.py
+++ b/tensorflow_addons/activations/activations_test.py
@@ -13,6 +13,9 @@
 # limitations under the License.
 # ==============================================================================
 
+import sys
+
+import pytest
 import tensorflow as tf
 from tensorflow_addons import activations
 from tensorflow_addons.utils import test_utils

--- a/tensorflow_addons/activations/gelu_test.py
+++ b/tensorflow_addons/activations/gelu_test.py
@@ -76,4 +76,4 @@ class GeluTest(tf.test.TestCase, parameterized.TestCase):
 
 
 if __name__ == "__main__":
-    tf.test.main()
+    sys.exit(pytest.main([__file__]))

--- a/tensorflow_addons/activations/gelu_test.py
+++ b/tensorflow_addons/activations/gelu_test.py
@@ -13,6 +13,9 @@
 # limitations under the License.
 # ==============================================================================
 
+import sys
+
+import pytest
 from absl.testing import parameterized
 
 import numpy as np

--- a/tensorflow_addons/activations/hardshrink_test.py
+++ b/tensorflow_addons/activations/hardshrink_test.py
@@ -13,6 +13,9 @@
 # limitations under the License.
 # ==============================================================================
 
+import sys
+
+import pytest
 from absl.testing import parameterized
 
 import numpy as np

--- a/tensorflow_addons/activations/hardshrink_test.py
+++ b/tensorflow_addons/activations/hardshrink_test.py
@@ -80,4 +80,4 @@ class HardshrinkTest(tf.test.TestCase, parameterized.TestCase):
 
 
 if __name__ == "__main__":
-    tf.test.main()
+    sys.exit(pytest.main([__file__]))

--- a/tensorflow_addons/activations/lisht_test.py
+++ b/tensorflow_addons/activations/lisht_test.py
@@ -69,4 +69,4 @@ class LishtTest(tf.test.TestCase, parameterized.TestCase):
 
 
 if __name__ == "__main__":
-    tf.test.main()
+    sys.exit(pytest.main([__file__]))

--- a/tensorflow_addons/activations/lisht_test.py
+++ b/tensorflow_addons/activations/lisht_test.py
@@ -13,6 +13,9 @@
 # limitations under the License.
 # ==============================================================================
 
+import sys
+
+import pytest
 from absl.testing import parameterized
 
 import numpy as np

--- a/tensorflow_addons/activations/mish_test.py
+++ b/tensorflow_addons/activations/mish_test.py
@@ -13,6 +13,9 @@
 # limitations under the License.
 # ==============================================================================
 
+import sys
+
+import pytest
 from absl.testing import parameterized
 
 import numpy as np

--- a/tensorflow_addons/activations/mish_test.py
+++ b/tensorflow_addons/activations/mish_test.py
@@ -67,4 +67,4 @@ class MishTest(tf.test.TestCase, parameterized.TestCase):
 
 
 if __name__ == "__main__":
-    tf.test.main()
+    sys.exit(pytest.main([__file__]))

--- a/tensorflow_addons/activations/rrelu_test.py
+++ b/tensorflow_addons/activations/rrelu_test.py
@@ -90,4 +90,4 @@ class RreluTest(tf.test.TestCase, parameterized.TestCase):
 #             self.run_op_benchmark(sess, result.op, min_iters=25)
 
 if __name__ == "__main__":
-    tf.test.main()
+    sys.exit(pytest.main([__file__]))

--- a/tensorflow_addons/activations/rrelu_test.py
+++ b/tensorflow_addons/activations/rrelu_test.py
@@ -13,6 +13,9 @@
 # limitations under the License.
 # ==============================================================================
 
+import sys
+
+import pytest
 from absl.testing import parameterized
 
 import numpy as np

--- a/tensorflow_addons/activations/softshrink_test.py
+++ b/tensorflow_addons/activations/softshrink_test.py
@@ -13,6 +13,9 @@
 # limitations under the License.
 # ==============================================================================
 
+import sys
+
+import pytest
 from absl.testing import parameterized
 
 import numpy as np

--- a/tensorflow_addons/activations/softshrink_test.py
+++ b/tensorflow_addons/activations/softshrink_test.py
@@ -83,4 +83,4 @@ class SoftshrinkTest(tf.test.TestCase, parameterized.TestCase):
 
 
 if __name__ == "__main__":
-    tf.test.main()
+    sys.exit(pytest.main([__file__]))

--- a/tensorflow_addons/activations/sparsemax_test.py
+++ b/tensorflow_addons/activations/sparsemax_test.py
@@ -280,4 +280,4 @@ class SparsemaxTest(tf.test.TestCase):
 
 
 if __name__ == "__main__":
-    tf.test.main()
+    sys.exit(pytest.main([__file__]))

--- a/tensorflow_addons/activations/sparsemax_test.py
+++ b/tensorflow_addons/activations/sparsemax_test.py
@@ -13,6 +13,9 @@
 # limitations under the License.
 # ==============================================================================
 
+import sys
+
+import pytest
 import numpy as np
 import tensorflow as tf
 

--- a/tensorflow_addons/activations/tanhshrink_test.py
+++ b/tensorflow_addons/activations/tanhshrink_test.py
@@ -13,6 +13,9 @@
 # limitations under the License.
 # ==============================================================================
 
+import sys
+
+import pytest
 from absl.testing import parameterized
 
 import numpy as np

--- a/tensorflow_addons/activations/tanhshrink_test.py
+++ b/tensorflow_addons/activations/tanhshrink_test.py
@@ -46,4 +46,4 @@ class TanhshrinkTest(tf.test.TestCase, parameterized.TestCase):
 
 
 if __name__ == "__main__":
-    tf.test.main()
+    sys.exit(pytest.main([__file__]))

--- a/tensorflow_addons/image/connected_components_test.py
+++ b/tensorflow_addons/image/connected_components_test.py
@@ -14,6 +14,9 @@
 # ==============================================================================
 """Tests for connected component analysis."""
 
+import sys
+
+import pytest
 import logging
 import tensorflow as tf
 import numpy as np

--- a/tensorflow_addons/image/connected_components_test.py
+++ b/tensorflow_addons/image/connected_components_test.py
@@ -171,4 +171,4 @@ def connected_components_reference_implementation(images):
 
 
 if __name__ == "__main__":
-    tf.test.main()
+    sys.exit(pytest.main([__file__]))

--- a/tensorflow_addons/image/dense_image_warp_test.py
+++ b/tensorflow_addons/image/dense_image_warp_test.py
@@ -14,6 +14,9 @@
 # ==============================================================================
 """Tests for dense_image_warp."""
 
+import sys
+
+import pytest
 import math
 
 import numpy as np

--- a/tensorflow_addons/image/dense_image_warp_test.py
+++ b/tensorflow_addons/image/dense_image_warp_test.py
@@ -259,4 +259,4 @@ class DenseImageWarpTest(tf.test.TestCase):
 
 
 if __name__ == "__main__":
-    tf.test.main()
+    sys.exit(pytest.main([__file__]))

--- a/tensorflow_addons/image/distance_transform_test.py
+++ b/tensorflow_addons/image/distance_transform_test.py
@@ -131,4 +131,4 @@ class DistanceOpsTest(tf.test.TestCase):
 
 
 if __name__ == "__main__":
-    tf.test.main()
+    sys.exit(pytest.main([__file__]))

--- a/tensorflow_addons/image/distance_transform_test.py
+++ b/tensorflow_addons/image/distance_transform_test.py
@@ -14,6 +14,9 @@
 # ==============================================================================
 """Tests for distance transform ops."""
 
+import sys
+
+import pytest
 import numpy as np
 import tensorflow as tf
 

--- a/tensorflow_addons/image/distort_image_ops_test.py
+++ b/tensorflow_addons/image/distort_image_ops_test.py
@@ -14,6 +14,9 @@
 # ==============================================================================
 """Tests for python distort_image_ops."""
 
+import sys
+
+import pytest
 import numpy as np
 
 import tensorflow as tf

--- a/tensorflow_addons/image/distort_image_ops_test.py
+++ b/tensorflow_addons/image/distort_image_ops_test.py
@@ -378,4 +378,4 @@ class AdjustSaturationInYiqBenchmark(tf.test.Benchmark):
 
 
 if __name__ == "__main__":
-    tf.test.main()
+    sys.exit(pytest.main([__file__]))

--- a/tensorflow_addons/image/filters_test.py
+++ b/tensorflow_addons/image/filters_test.py
@@ -13,6 +13,9 @@
 # limitations under the License.
 # ==============================================================================
 
+import sys
+
+import pytest
 import tensorflow as tf
 from tensorflow_addons.image import mean_filter2d
 from tensorflow_addons.image import median_filter2d

--- a/tensorflow_addons/image/filters_test.py
+++ b/tensorflow_addons/image/filters_test.py
@@ -356,4 +356,4 @@ class MedianFilter2dTest(_Filter2dTest):
 
 
 if __name__ == "__main__":
-    tf.test.main()
+    sys.exit(pytest.main([__file__]))

--- a/tensorflow_addons/image/interpolate_spline_test.py
+++ b/tensorflow_addons/image/interpolate_spline_test.py
@@ -14,6 +14,9 @@
 # ==============================================================================
 """Tests for interpolate_spline."""
 
+import sys
+
+import pytest
 import numpy as np
 from scipy import interpolate as sc_interpolate
 

--- a/tensorflow_addons/image/interpolate_spline_test.py
+++ b/tensorflow_addons/image/interpolate_spline_test.py
@@ -309,4 +309,4 @@ class InterpolateSplineTest(tf.test.TestCase):
 
 
 if __name__ == "__main__":
-    tf.test.main()
+    sys.exit(pytest.main([__file__]))

--- a/tensorflow_addons/image/resampler_ops_test.py
+++ b/tensorflow_addons/image/resampler_ops_test.py
@@ -249,4 +249,4 @@ class ResamplerTest(tf.test.TestCase, parameterized.TestCase):
 
 
 if __name__ == "__main__":
-    tf.test.main()
+    sys.exit(pytest.main([__file__]))

--- a/tensorflow_addons/image/resampler_ops_test.py
+++ b/tensorflow_addons/image/resampler_ops_test.py
@@ -14,6 +14,9 @@
 # ============================================================================
 """Tests for resampler."""
 
+import sys
+
+import pytest
 from absl.testing import parameterized
 
 import numpy as np

--- a/tensorflow_addons/image/sparse_image_warp_test.py
+++ b/tensorflow_addons/image/sparse_image_warp_test.py
@@ -14,6 +14,9 @@
 # ==============================================================================
 """Tests for sparse_image_warp."""
 
+import sys
+
+import pytest
 import numpy as np
 import tensorflow as tf
 from tensorflow_addons.image import sparse_image_warp

--- a/tensorflow_addons/image/sparse_image_warp_test.py
+++ b/tensorflow_addons/image/sparse_image_warp_test.py
@@ -267,4 +267,4 @@ class SparseImageWarpTest(tf.test.TestCase):
 
 
 if __name__ == "__main__":
-    tf.test.main()
+    sys.exit(pytest.main([__file__]))

--- a/tensorflow_addons/image/transform_ops_test.py
+++ b/tensorflow_addons/image/transform_ops_test.py
@@ -14,6 +14,9 @@
 # ==============================================================================
 """Tests for transform ops."""
 
+import sys
+
+import pytest
 import numpy as np
 import tensorflow as tf
 

--- a/tensorflow_addons/image/transform_ops_test.py
+++ b/tensorflow_addons/image/transform_ops_test.py
@@ -301,4 +301,4 @@ class RotateOpTest(tf.test.TestCase):
 
 
 if __name__ == "__main__":
-    tf.test.main()
+    sys.exit(pytest.main([__file__]))

--- a/tensorflow_addons/image/translate_ops_test.py
+++ b/tensorflow_addons/image/translate_ops_test.py
@@ -50,4 +50,4 @@ class TranslateOpTest(tf.test.TestCase):
 
 
 if __name__ == "__main__":
-    tf.test.main()
+    sys.exit(pytest.main([__file__]))

--- a/tensorflow_addons/image/translate_ops_test.py
+++ b/tensorflow_addons/image/translate_ops_test.py
@@ -14,6 +14,9 @@
 # ==============================================================================
 """Tests for translate ops."""
 
+import sys
+
+import pytest
 import tensorflow as tf
 
 from tensorflow_addons.image import translate_ops

--- a/tensorflow_addons/image/utils_test.py
+++ b/tensorflow_addons/image/utils_test.py
@@ -14,6 +14,9 @@
 # ==============================================================================
 """Tests for util ops."""
 
+import sys
+
+import pytest
 import tensorflow as tf
 
 from tensorflow_addons.image import utils as img_utils

--- a/tensorflow_addons/image/utils_test.py
+++ b/tensorflow_addons/image/utils_test.py
@@ -88,4 +88,4 @@ class UtilsOpsTest(tf.test.TestCase):
 
 
 if __name__ == "__main__":
-    tf.test.main()
+    sys.exit(pytest.main([__file__]))

--- a/tensorflow_addons/layers/gelu_test.py
+++ b/tensorflow_addons/layers/gelu_test.py
@@ -17,6 +17,9 @@
 import sys
 
 import pytest
+import sys
+
+import pytest
 import numpy as np
 import tensorflow as tf
 from absl.testing import parameterized

--- a/tensorflow_addons/layers/gelu_test.py
+++ b/tensorflow_addons/layers/gelu_test.py
@@ -17,9 +17,6 @@
 import sys
 
 import pytest
-import sys
-
-import pytest
 import numpy as np
 import tensorflow as tf
 from absl.testing import parameterized

--- a/tensorflow_addons/layers/gelu_test.py
+++ b/tensorflow_addons/layers/gelu_test.py
@@ -14,6 +14,9 @@
 # ==============================================================================
 """Tests for GELU activation."""
 
+import sys
+
+import pytest
 import numpy as np
 import tensorflow as tf
 from absl.testing import parameterized
@@ -33,4 +36,4 @@ class TestGELU(tf.test.TestCase):
 
 
 if __name__ == "__main__":
-    tf.test.main()
+    sys.exit(pytest.main([__file__]))

--- a/tensorflow_addons/layers/maxout_test.py
+++ b/tensorflow_addons/layers/maxout_test.py
@@ -14,6 +14,9 @@
 # ==============================================================================
 """Tests for Maxout layer."""
 
+import sys
+
+import pytest
 import numpy as np
 import tensorflow as tf
 

--- a/tensorflow_addons/layers/maxout_test.py
+++ b/tensorflow_addons/layers/maxout_test.py
@@ -61,4 +61,4 @@ class MaxOutTest(tf.test.TestCase):
 
 
 if __name__ == "__main__":
-    tf.test.main()
+    sys.exit(pytest.main([__file__]))

--- a/tensorflow_addons/layers/normalizations_test.py
+++ b/tensorflow_addons/layers/normalizations_test.py
@@ -329,4 +329,4 @@ class NormalizationTest(tf.test.TestCase):
 
 
 if __name__ == "__main__":
-    tf.test.main()
+    sys.exit(pytest.main([__file__]))

--- a/tensorflow_addons/layers/normalizations_test.py
+++ b/tensorflow_addons/layers/normalizations_test.py
@@ -13,6 +13,9 @@
 # limitations under the License.
 # =============================================================================
 
+import sys
+
+import pytest
 import numpy as np
 import tensorflow as tf
 

--- a/tensorflow_addons/layers/optical_flow_test.py
+++ b/tensorflow_addons/layers/optical_flow_test.py
@@ -223,4 +223,4 @@ class CorrelationCostTest(tf.test.TestCase):
 
 
 if __name__ == "__main__":
-    tf.test.main()
+    sys.exit(pytest.main([__file__]))

--- a/tensorflow_addons/layers/optical_flow_test.py
+++ b/tensorflow_addons/layers/optical_flow_test.py
@@ -13,6 +13,9 @@
 # limitations under the License.
 # ==============================================================================
 
+import sys
+
+import pytest
 import numpy as np
 import tensorflow as tf
 from tensorflow_addons.layers.optical_flow import CorrelationCost

--- a/tensorflow_addons/layers/poincare_test.py
+++ b/tensorflow_addons/layers/poincare_test.py
@@ -76,4 +76,4 @@ class PoincareNormalizeTest(tf.test.TestCase):
 
 
 if __name__ == "__main__":
-    tf.test.main()
+    sys.exit(pytest.main([__file__]))

--- a/tensorflow_addons/layers/poincare_test.py
+++ b/tensorflow_addons/layers/poincare_test.py
@@ -14,6 +14,9 @@
 # ==============================================================================
 """Tests for PoincareNormalize layer."""
 
+import sys
+
+import pytest
 import numpy as np
 import tensorflow as tf
 

--- a/tensorflow_addons/layers/polynomial_test.py
+++ b/tensorflow_addons/layers/polynomial_test.py
@@ -14,6 +14,9 @@
 # ==============================================================================
 """Tests for PolynomialCrossing layer."""
 
+import sys
+
+import pytest
 import numpy as np
 import tensorflow as tf
 

--- a/tensorflow_addons/layers/polynomial_test.py
+++ b/tensorflow_addons/layers/polynomial_test.py
@@ -56,4 +56,4 @@ class PolynomialCrossingTest(tf.test.TestCase):
 
 
 if __name__ == "__main__":
-    tf.test.main()
+    sys.exit(pytest.main([__file__]))

--- a/tensorflow_addons/layers/sparsemax_test.py
+++ b/tensorflow_addons/layers/sparsemax_test.py
@@ -65,4 +65,4 @@ class SparsemaxTest(tf.test.TestCase):
 
 
 if __name__ == "__main__":
-    tf.test.main()
+    sys.exit(pytest.main([__file__]))

--- a/tensorflow_addons/layers/sparsemax_test.py
+++ b/tensorflow_addons/layers/sparsemax_test.py
@@ -13,6 +13,9 @@
 # limitations under the License.
 # ==============================================================================
 
+import sys
+
+import pytest
 import numpy as np
 import tensorflow as tf
 

--- a/tensorflow_addons/layers/tlu_test.py
+++ b/tensorflow_addons/layers/tlu_test.py
@@ -56,4 +56,4 @@ class TestTLU(tf.test.TestCase):
 
 
 if __name__ == "__main__":
-    tf.test.main()
+    sys.exit(pytest.main([__file__]))

--- a/tensorflow_addons/layers/tlu_test.py
+++ b/tensorflow_addons/layers/tlu_test.py
@@ -14,6 +14,9 @@
 # ==============================================================================
 """Tests for TLU activation."""
 
+import sys
+
+import pytest
 import numpy as np
 import tensorflow as tf
 from absl.testing import parameterized

--- a/tensorflow_addons/layers/wrappers_test.py
+++ b/tensorflow_addons/layers/wrappers_test.py
@@ -13,10 +13,12 @@
 # limitations under the License.
 # =============================================================================
 
+import sys
 import os
 import tempfile
 from absl.testing import parameterized
 
+import pytest
 import numpy as np
 import tensorflow as tf
 

--- a/tensorflow_addons/layers/wrappers_test.py
+++ b/tensorflow_addons/layers/wrappers_test.py
@@ -177,4 +177,4 @@ class WeightNormalizationTest(tf.test.TestCase, parameterized.TestCase):
 
 
 if __name__ == "__main__":
-    tf.test.main()
+    sys.exit(pytest.main([__file__]))

--- a/tensorflow_addons/losses/contrastive_test.py
+++ b/tensorflow_addons/losses/contrastive_test.py
@@ -14,6 +14,9 @@
 # ==============================================================================
 """Tests for contrastive loss."""
 
+import sys
+
+import pytest
 import tensorflow as tf
 from tensorflow_addons.losses import contrastive
 from tensorflow_addons.utils import test_utils

--- a/tensorflow_addons/losses/contrastive_test.py
+++ b/tensorflow_addons/losses/contrastive_test.py
@@ -147,4 +147,4 @@ class ContrastiveLossTest(tf.test.TestCase):
 
 
 if __name__ == "__main__":
-    tf.test.main()
+    sys.exit(pytest.main([__file__]))

--- a/tensorflow_addons/losses/focal_loss_test.py
+++ b/tensorflow_addons/losses/focal_loss_test.py
@@ -14,6 +14,9 @@
 # ==============================================================================
 """Tests for focal loss."""
 
+import sys
+
+import pytest
 import numpy as np
 import tensorflow as tf
 import tensorflow.keras.backend as K

--- a/tensorflow_addons/losses/focal_loss_test.py
+++ b/tensorflow_addons/losses/focal_loss_test.py
@@ -127,4 +127,4 @@ class SigmoidFocalCrossEntropyTest(tf.test.TestCase):
 
 
 if __name__ == "__main__":
-    tf.test.main()
+    sys.exit(pytest.main([__file__]))

--- a/tensorflow_addons/losses/giou_loss_test.py
+++ b/tensorflow_addons/losses/giou_loss_test.py
@@ -116,4 +116,4 @@ class GIoULossTest(tf.test.TestCase, parameterized.TestCase):
 
 
 if __name__ == "__main__":
-    tf.test.main()
+    sys.exit(pytest.main([__file__]))

--- a/tensorflow_addons/losses/giou_loss_test.py
+++ b/tensorflow_addons/losses/giou_loss_test.py
@@ -14,6 +14,9 @@
 # ==============================================================================
 """Tests for GIoU loss."""
 
+import sys
+
+import pytest
 from absl.testing import parameterized
 
 import numpy as np

--- a/tensorflow_addons/losses/lifted_test.py
+++ b/tensorflow_addons/losses/lifted_test.py
@@ -111,4 +111,4 @@ class LiftedStructLossTest(tf.test.TestCase):
 
 
 if __name__ == "__main__":
-    tf.test.main()
+    sys.exit(pytest.main([__file__]))

--- a/tensorflow_addons/losses/lifted_test.py
+++ b/tensorflow_addons/losses/lifted_test.py
@@ -14,6 +14,9 @@
 # ==============================================================================
 """Tests for lifted loss."""
 
+import sys
+
+import pytest
 import numpy as np
 import tensorflow as tf
 

--- a/tensorflow_addons/losses/metric_test.py
+++ b/tensorflow_addons/losses/metric_test.py
@@ -58,4 +58,4 @@ class PairWiseDistance(tf.test.TestCase):
 
 
 if __name__ == "__main__":
-    tf.test.main()
+    sys.exit(pytest.main([__file__]))

--- a/tensorflow_addons/losses/metric_test.py
+++ b/tensorflow_addons/losses/metric_test.py
@@ -14,6 +14,9 @@
 # ==============================================================================
 """Tests for metric learning."""
 
+import sys
+
+import pytest
 import numpy as np
 import tensorflow as tf
 from tensorflow_addons.losses.metric_learning import pairwise_distance

--- a/tensorflow_addons/losses/npairs_test.py
+++ b/tensorflow_addons/losses/npairs_test.py
@@ -13,9 +13,12 @@
 # limitations under the License.
 # ==============================================================================
 """Tests for npairs loss."""
+
+import sys
 import platform
 import unittest
 
+import pytest
 import tensorflow as tf
 from tensorflow_addons.losses import npairs
 from tensorflow_addons.utils import test_utils

--- a/tensorflow_addons/losses/npairs_test.py
+++ b/tensorflow_addons/losses/npairs_test.py
@@ -149,4 +149,4 @@ class NpairsMultilabelLossTest(tf.test.TestCase):
 
 
 if __name__ == "__main__":
-    tf.test.main()
+    sys.exit(pytest.main([__file__]))

--- a/tensorflow_addons/losses/quantiles_test.py
+++ b/tensorflow_addons/losses/quantiles_test.py
@@ -131,4 +131,4 @@ class PinballLossTest(tf.test.TestCase):
 
 
 if __name__ == "__main__":
-    tf.test.main()
+    sys.exit(pytest.main([__file__]))

--- a/tensorflow_addons/losses/quantiles_test.py
+++ b/tensorflow_addons/losses/quantiles_test.py
@@ -14,6 +14,9 @@
 # ==============================================================================
 """Tests for pinball loss."""
 
+import sys
+
+import pytest
 import tensorflow as tf
 
 from tensorflow_addons.losses import quantiles

--- a/tensorflow_addons/losses/sparsemax_loss_test.py
+++ b/tensorflow_addons/losses/sparsemax_loss_test.py
@@ -241,4 +241,4 @@ class SparsemaxTest(tf.test.TestCase):
 
 
 if __name__ == "__main__":
-    tf.test.main()
+    sys.exit(pytest.main([__file__]))

--- a/tensorflow_addons/losses/sparsemax_loss_test.py
+++ b/tensorflow_addons/losses/sparsemax_loss_test.py
@@ -13,6 +13,9 @@
 # limitations under the License.
 # ==============================================================================
 
+import sys
+
+import pytest
 import tensorflow as tf
 import numpy as np
 

--- a/tensorflow_addons/losses/triplet_test.py
+++ b/tensorflow_addons/losses/triplet_test.py
@@ -14,6 +14,9 @@
 # ==============================================================================
 """Tests for triplet loss."""
 
+import sys
+
+import pytest
 import numpy as np
 import tensorflow as tf
 

--- a/tensorflow_addons/losses/triplet_test.py
+++ b/tensorflow_addons/losses/triplet_test.py
@@ -202,4 +202,4 @@ class TripletHardLossTest(tf.test.TestCase):
 
 
 if __name__ == "__main__":
-    tf.test.main()
+    sys.exit(pytest.main([__file__]))

--- a/tensorflow_addons/metrics/cohens_kappa_test.py
+++ b/tensorflow_addons/metrics/cohens_kappa_test.py
@@ -229,4 +229,4 @@ class CohenKappaTest(tf.test.TestCase):
 
 
 if __name__ == "__main__":
-    tf.test.main()
+    sys.exit(pytest.main([__file__]))

--- a/tensorflow_addons/metrics/cohens_kappa_test.py
+++ b/tensorflow_addons/metrics/cohens_kappa_test.py
@@ -14,6 +14,9 @@
 # ==============================================================================
 """Tests for Cohen's Kappa Metric."""
 
+import sys
+
+import pytest
 import numpy as np
 import tensorflow as tf
 from tensorflow_addons.metrics import CohenKappa

--- a/tensorflow_addons/metrics/f_test.py
+++ b/tensorflow_addons/metrics/f_test.py
@@ -14,6 +14,9 @@
 # ==============================================================================
 """Tests F beta metrics."""
 
+import sys
+
+import pytest
 from absl.testing import parameterized
 
 import tensorflow as tf

--- a/tensorflow_addons/metrics/f_test.py
+++ b/tensorflow_addons/metrics/f_test.py
@@ -155,4 +155,4 @@ class F1ScoreTest(tf.test.TestCase):
 
 
 if __name__ == "__main__":
-    tf.test.main()
+    sys.exit(pytest.main([__file__]))

--- a/tensorflow_addons/metrics/hamming_test.py
+++ b/tensorflow_addons/metrics/hamming_test.py
@@ -14,6 +14,9 @@
 # ==============================================================================
 """Tests Hamming metrics."""
 
+import sys
+
+import pytest
 import tensorflow as tf
 from tensorflow_addons.metrics import HammingLoss, hamming_distance
 from tensorflow_addons.utils import test_utils

--- a/tensorflow_addons/metrics/hamming_test.py
+++ b/tensorflow_addons/metrics/hamming_test.py
@@ -184,4 +184,4 @@ class HammingMetricsTest(tf.test.TestCase):
 
 
 if __name__ == "__main__":
-    tf.test.main()
+    sys.exit(pytest.main([__file__]))

--- a/tensorflow_addons/metrics/matthews_correlation_coefficient_test.py
+++ b/tensorflow_addons/metrics/matthews_correlation_coefficient_test.py
@@ -89,4 +89,4 @@ class MatthewsCorrelationCoefficientTest(tf.test.TestCase):
 
 
 if __name__ == "__main__":
-    tf.test.main()
+    sys.exit(pytest.main([__file__]))

--- a/tensorflow_addons/metrics/matthews_correlation_coefficient_test.py
+++ b/tensorflow_addons/metrics/matthews_correlation_coefficient_test.py
@@ -14,6 +14,9 @@
 # ==============================================================================
 """Matthews Correlation Coefficient Test."""
 
+import sys
+
+import pytest
 import tensorflow as tf
 
 import numpy as np

--- a/tensorflow_addons/metrics/metrics_test.py
+++ b/tensorflow_addons/metrics/metrics_test.py
@@ -14,7 +14,9 @@
 # ==============================================================================
 import unittest
 import inspect
+import sys
 
+import pytest
 from tensorflow.keras.metrics import Metric
 from tensorflow_addons import metrics
 
@@ -39,4 +41,4 @@ def check_update_state_signature(metric_class):
 
 
 if __name__ == "__main__":
-    unittest.main()
+    sys.exit(pytest.main([__file__]))

--- a/tensorflow_addons/metrics/multilabel_confusion_matrix_test.py
+++ b/tensorflow_addons/metrics/multilabel_confusion_matrix_test.py
@@ -158,4 +158,4 @@ class MultiLabelConfusionMatrixTest(tf.test.TestCase):
 
 
 if __name__ == "__main__":
-    tf.test.main()
+    sys.exit(pytest.main([__file__]))

--- a/tensorflow_addons/metrics/multilabel_confusion_matrix_test.py
+++ b/tensorflow_addons/metrics/multilabel_confusion_matrix_test.py
@@ -14,6 +14,9 @@
 # ==============================================================================
 """Tests for Multilabel Confusion Matrix Metric."""
 
+import sys
+
+import pytest
 import tensorflow as tf
 from tensorflow_addons.metrics import MultiLabelConfusionMatrix
 from tensorflow_addons.utils import test_utils

--- a/tensorflow_addons/metrics/r_square_test.py
+++ b/tensorflow_addons/metrics/r_square_test.py
@@ -14,6 +14,9 @@
 # ==============================================================================
 """Tests for R-Square Metric."""
 
+import sys
+
+import pytest
 import tensorflow as tf
 from tensorflow_addons.metrics import RSquare
 from tensorflow_addons.utils import test_utils

--- a/tensorflow_addons/metrics/r_square_test.py
+++ b/tensorflow_addons/metrics/r_square_test.py
@@ -80,4 +80,4 @@ class RSquareTest(tf.test.TestCase):
 
 
 if __name__ == "__main__":
-    tf.test.main()
+    sys.exit(pytest.main([__file__]))

--- a/tensorflow_addons/optimizers/conditional_gradient_test.py
+++ b/tensorflow_addons/optimizers/conditional_gradient_test.py
@@ -841,4 +841,4 @@ class ConditionalGradientTest(tf.test.TestCase):
 
 
 if __name__ == "__main__":
-    tf.test.main()
+    sys.exit(pytest.main([__file__]))

--- a/tensorflow_addons/optimizers/conditional_gradient_test.py
+++ b/tensorflow_addons/optimizers/conditional_gradient_test.py
@@ -14,6 +14,9 @@
 # ==============================================================================
 """Tests for Conditional Gradient."""
 
+import sys
+
+import pytest
 import tensorflow as tf
 from tensorflow_addons.utils import test_utils
 import numpy as np

--- a/tensorflow_addons/optimizers/cyclical_learning_rate_test.py
+++ b/tensorflow_addons/optimizers/cyclical_learning_rate_test.py
@@ -153,3 +153,7 @@ class CyclicalLearningRateTest(tf.test.TestCase, parameterized.TestCase):
             ) * np.maximum(0, 1 - non_bounded_value) * scale_fn(i)
             self.assertAllClose(self.evaluate(custom_cyclical_lr(step)), expected, 1e-6)
             self.evaluate(step.assign_add(1))
+
+
+if __name__ == "__main__":
+    sys.exit(pytest.main([__file__]))

--- a/tensorflow_addons/optimizers/cyclical_learning_rate_test.py
+++ b/tensorflow_addons/optimizers/cyclical_learning_rate_test.py
@@ -14,6 +14,9 @@
 # ==============================================================================
 """Tests for Cyclical Learning Rate."""
 
+import sys
+
+import pytest
 from absl.testing import parameterized
 
 import tensorflow as tf

--- a/tensorflow_addons/optimizers/lamb_test.py
+++ b/tensorflow_addons/optimizers/lamb_test.py
@@ -14,6 +14,9 @@
 # ==============================================================================
 """Tests for LAMB Optimizer."""
 
+import sys
+
+import pytest
 import numpy as np
 from numpy import linalg
 

--- a/tensorflow_addons/optimizers/lamb_test.py
+++ b/tensorflow_addons/optimizers/lamb_test.py
@@ -403,4 +403,4 @@ class LAMBTest(tf.test.TestCase):
 
 
 if __name__ == "__main__":
-    tf.test.main()
+    sys.exit(pytest.main([__file__]))

--- a/tensorflow_addons/optimizers/lazy_adam_test.py
+++ b/tensorflow_addons/optimizers/lazy_adam_test.py
@@ -14,6 +14,9 @@
 # ==============================================================================
 """Tests for LazyAdam."""
 
+import sys
+
+import pytest
 import numpy as np
 import tensorflow as tf
 

--- a/tensorflow_addons/optimizers/lazy_adam_test.py
+++ b/tensorflow_addons/optimizers/lazy_adam_test.py
@@ -310,4 +310,4 @@ class LazyAdamTest(tf.test.TestCase):
 
 
 if __name__ == "__main__":
-    tf.test.main()
+    sys.exit(pytest.main([__file__]))

--- a/tensorflow_addons/optimizers/lookahead_test.py
+++ b/tensorflow_addons/optimizers/lookahead_test.py
@@ -158,4 +158,4 @@ class LookaheadTest(tf.test.TestCase):
 
 
 if __name__ == "__main__":
-    tf.test.main()
+    sys.exit(pytest.main([__file__]))

--- a/tensorflow_addons/optimizers/lookahead_test.py
+++ b/tensorflow_addons/optimizers/lookahead_test.py
@@ -14,6 +14,9 @@
 # ==============================================================================
 """Tests for Lookahead optimizer."""
 
+import sys
+
+import pytest
 import numpy as np
 import tensorflow as tf
 

--- a/tensorflow_addons/optimizers/moving_average_test.py
+++ b/tensorflow_addons/optimizers/moving_average_test.py
@@ -189,4 +189,4 @@ class MovingAverageTest(tf.test.TestCase):
 
 
 if __name__ == "__main__":
-    tf.test.main()
+    sys.exit(pytest.main([__file__]))

--- a/tensorflow_addons/optimizers/moving_average_test.py
+++ b/tensorflow_addons/optimizers/moving_average_test.py
@@ -14,6 +14,9 @@
 # ==============================================================================
 """Tests for MovingAverage optimizers."""
 
+import sys
+
+import pytest
 import numpy as np
 import tensorflow as tf
 

--- a/tensorflow_addons/optimizers/novograd_test.py
+++ b/tensorflow_addons/optimizers/novograd_test.py
@@ -141,4 +141,4 @@ class NovoGradTest(tf.test.TestCase):
 
 
 if __name__ == "__main__":
-    tf.test.main()
+    sys.exit(pytest.main([__file__]))

--- a/tensorflow_addons/optimizers/novograd_test.py
+++ b/tensorflow_addons/optimizers/novograd_test.py
@@ -14,6 +14,9 @@
 # ==============================================================================
 """Tests for NovoGrad Optimizer."""
 
+import sys
+
+import pytest
 import numpy as np
 import tensorflow as tf
 

--- a/tensorflow_addons/optimizers/rectified_adam_test.py
+++ b/tensorflow_addons/optimizers/rectified_adam_test.py
@@ -170,4 +170,4 @@ class RectifiedAdamTest(tf.test.TestCase):
 
 
 if __name__ == "__main__":
-    tf.test.main()
+    sys.exit(pytest.main([__file__]))

--- a/tensorflow_addons/optimizers/rectified_adam_test.py
+++ b/tensorflow_addons/optimizers/rectified_adam_test.py
@@ -14,6 +14,9 @@
 # ==============================================================================
 """Tests for Rectified Adam optimizer."""
 
+import sys
+
+import pytest
 import tensorflow as tf
 
 from tensorflow_addons.utils import test_utils

--- a/tensorflow_addons/optimizers/stochastic_weight_averaging_test.py
+++ b/tensorflow_addons/optimizers/stochastic_weight_averaging_test.py
@@ -126,4 +126,4 @@ class SWATest(tf.test.TestCase):
 
 
 if __name__ == "__main__":
-    tf.test.main()
+    sys.exit(pytest.main([__file__]))

--- a/tensorflow_addons/optimizers/stochastic_weight_averaging_test.py
+++ b/tensorflow_addons/optimizers/stochastic_weight_averaging_test.py
@@ -14,6 +14,9 @@
 # ==============================================================================
 """Tests for Stochastic Weight Averaging optimizer."""
 
+import sys
+
+import pytest
 import numpy as np
 import tensorflow as tf
 

--- a/tensorflow_addons/optimizers/weight_decay_optimizers_test.py
+++ b/tensorflow_addons/optimizers/weight_decay_optimizers_test.py
@@ -14,6 +14,9 @@
 # ==============================================================================
 """Tests for optimizers with weight decay."""
 
+import sys
+
+import pytest
 import numpy as np
 import tensorflow as tf
 

--- a/tensorflow_addons/optimizers/weight_decay_optimizers_test.py
+++ b/tensorflow_addons/optimizers/weight_decay_optimizers_test.py
@@ -291,4 +291,4 @@ class ExtendWithWeightDecayTest(SGDWTest):
 
 
 if __name__ == "__main__":
-    tf.test.main()
+    sys.exit(pytest.main([__file__]))

--- a/tensorflow_addons/optimizers/yogi_test.py
+++ b/tensorflow_addons/optimizers/yogi_test.py
@@ -14,6 +14,9 @@
 # ==============================================================================
 """Tests for Yogi optimizer."""
 
+import sys
+
+import pytest
 import numpy as np
 import tensorflow as tf
 

--- a/tensorflow_addons/optimizers/yogi_test.py
+++ b/tensorflow_addons/optimizers/yogi_test.py
@@ -381,4 +381,4 @@ class YogiOptimizerTest(tf.test.TestCase):
 
 
 if __name__ == "__main__":
-    tf.test.main()
+    sys.exit(pytest.main([__file__]))

--- a/tensorflow_addons/rnn/cell_test.py
+++ b/tensorflow_addons/rnn/cell_test.py
@@ -418,4 +418,4 @@ class LayerNormSimpleRNNTest(tf.test.TestCase):
 
 
 if __name__ == "__main__":
-    tf.test.main()
+    sys.exit(pytest.main([__file__]))

--- a/tensorflow_addons/rnn/cell_test.py
+++ b/tensorflow_addons/rnn/cell_test.py
@@ -14,6 +14,9 @@
 # ==============================================================================
 """Tests for RNN cells."""
 
+import sys
+
+import pytest
 import numpy as np
 import tensorflow as tf
 import tensorflow.keras as keras

--- a/tensorflow_addons/seq2seq/attention_wrapper_test.py
+++ b/tensorflow_addons/seq2seq/attention_wrapper_test.py
@@ -1009,4 +1009,4 @@ class AttentionWrapperTest(tf.test.TestCase, parameterized.TestCase):
 
 
 if __name__ == "__main__":
-    tf.test.main()
+    sys.exit(pytest.main([__file__]))

--- a/tensorflow_addons/seq2seq/attention_wrapper_test.py
+++ b/tensorflow_addons/seq2seq/attention_wrapper_test.py
@@ -15,7 +15,9 @@
 """Tests for tfa.seq2seq.attention_wrapper."""
 
 import collections
+import sys
 
+import pytest
 from absl.testing import parameterized
 import numpy as np
 import tensorflow as tf

--- a/tensorflow_addons/seq2seq/basic_decoder_test.py
+++ b/tensorflow_addons/seq2seq/basic_decoder_test.py
@@ -17,8 +17,10 @@
 import sys
 import pytest
 from absl.testing import parameterized
-import numpy as np
+import sys
 
+import pytest
+import numpy as np
 import tensorflow as tf
 
 from tensorflow_addons.seq2seq import attention_wrapper

--- a/tensorflow_addons/seq2seq/basic_decoder_test.py
+++ b/tensorflow_addons/seq2seq/basic_decoder_test.py
@@ -17,10 +17,8 @@
 import sys
 import pytest
 from absl.testing import parameterized
-import sys
-
-import pytest
 import numpy as np
+
 import tensorflow as tf
 
 from tensorflow_addons.seq2seq import attention_wrapper

--- a/tensorflow_addons/seq2seq/beam_search_decoder_test.py
+++ b/tensorflow_addons/seq2seq/beam_search_decoder_test.py
@@ -14,8 +14,10 @@
 # ==============================================================================
 """Tests for tfa.seq2seq.seq2seq.beam_search_decoder."""
 
-import numpy as np
+import sys
 
+import pytest
+import numpy as np
 import tensorflow as tf
 
 from tensorflow_addons.seq2seq import attention_wrapper

--- a/tensorflow_addons/seq2seq/beam_search_decoder_test.py
+++ b/tensorflow_addons/seq2seq/beam_search_decoder_test.py
@@ -664,4 +664,4 @@ class BeamSearchDecoderTest(tf.test.TestCase):
 
 
 if __name__ == "__main__":
-    tf.test.main()
+    sys.exit(pytest.main([__file__]))

--- a/tensorflow_addons/seq2seq/beam_search_ops_test.py
+++ b/tensorflow_addons/seq2seq/beam_search_ops_test.py
@@ -15,6 +15,9 @@
 """Tests for tfa.seq2seq.beam_search_ops."""
 
 import itertools
+import sys
+
+import pytest
 import numpy as np
 import tensorflow as tf
 

--- a/tensorflow_addons/seq2seq/beam_search_ops_test.py
+++ b/tensorflow_addons/seq2seq/beam_search_ops_test.py
@@ -145,4 +145,4 @@ class GatherTreeTest(tf.test.TestCase):
 
 
 if __name__ == "__main__":
-    tf.test.main()
+    sys.exit(pytest.main([__file__]))

--- a/tensorflow_addons/seq2seq/decoder_test.py
+++ b/tensorflow_addons/seq2seq/decoder_test.py
@@ -186,4 +186,4 @@ class DecodeRNNTest(test_utils.keras_parameterized.TestCase, tf.test.TestCase):
 
 
 if __name__ == "__main__":
-    tf.test.main()
+    sys.exit(pytest.main([__file__]))

--- a/tensorflow_addons/seq2seq/decoder_test.py
+++ b/tensorflow_addons/seq2seq/decoder_test.py
@@ -14,6 +14,9 @@
 # ==============================================================================
 """Tests for tfa.seq2seq.decoder."""
 
+import sys
+
+import pytest
 import numpy as np
 import tensorflow as tf
 

--- a/tensorflow_addons/seq2seq/loss_test.py
+++ b/tensorflow_addons/seq2seq/loss_test.py
@@ -14,8 +14,10 @@
 # ==============================================================================
 """Tests for tf.addons.seq2seq.python.loss_ops."""
 
-import numpy as np
+import sys
 
+import pytest
+import numpy as np
 import tensorflow as tf
 
 from tensorflow_addons.seq2seq import loss

--- a/tensorflow_addons/seq2seq/loss_test.py
+++ b/tensorflow_addons/seq2seq/loss_test.py
@@ -378,4 +378,4 @@ class DenseTargetLossTest(LossTest):
 
 
 if __name__ == "__main__":
-    tf.test.main()
+    sys.exit(pytest.main([__file__]))

--- a/tensorflow_addons/text/crf_test.py
+++ b/tensorflow_addons/text/crf_test.py
@@ -410,4 +410,4 @@ class CrfTest(tf.test.TestCase):
 
 
 if __name__ == "__main__":
-    tf.test.main()
+    sys.exit(pytest.main([__file__]))

--- a/tensorflow_addons/text/crf_test.py
+++ b/tensorflow_addons/text/crf_test.py
@@ -15,7 +15,9 @@
 """Tests for CRF."""
 
 import itertools
+import sys
 
+import pytest
 import numpy as np
 import tensorflow as tf
 

--- a/tensorflow_addons/text/parse_time_op_test.py
+++ b/tensorflow_addons/text/parse_time_op_test.py
@@ -15,7 +15,9 @@
 """Parse time op tests."""
 import unittest
 import platform
+import sys
 
+import pytest
 import tensorflow as tf
 
 from tensorflow_addons import text

--- a/tensorflow_addons/text/parse_time_op_test.py
+++ b/tensorflow_addons/text/parse_time_op_test.py
@@ -89,4 +89,4 @@ class ParseTimeTest(tf.test.TestCase):
 
 
 if __name__ == "__main__":
-    tf.test.main()
+    sys.exit(pytest.main([__file__]))

--- a/tensorflow_addons/text/skip_gram_ops_test.py
+++ b/tensorflow_addons/text/skip_gram_ops_test.py
@@ -614,4 +614,4 @@ class SkipGramOpsTest(tf.test.TestCase):
 
 
 if __name__ == "__main__":
-    tf.test.main()
+    sys.exit(pytest.main([__file__]))

--- a/tensorflow_addons/text/skip_gram_ops_test.py
+++ b/tensorflow_addons/text/skip_gram_ops_test.py
@@ -17,7 +17,9 @@
 import csv
 import os
 import tempfile
+import sys
 
+import pytest
 import tensorflow as tf
 
 from tensorflow_addons import text

--- a/tensorflow_addons/utils/keras_utils_test.py
+++ b/tensorflow_addons/utils/keras_utils_test.py
@@ -14,6 +14,9 @@
 # ==============================================================================
 """Tests for Keras utils."""
 
+import sys
+
+import pytest
 import tensorflow as tf
 
 from tensorflow_addons.utils import keras_utils

--- a/tensorflow_addons/utils/keras_utils_test.py
+++ b/tensorflow_addons/utils/keras_utils_test.py
@@ -51,4 +51,4 @@ class AssertRNNCellTest(tf.test.TestCase):
 
 
 if __name__ == "__main__":
-    tf.test.main()
+    sys.exit(pytest.main([__file__]))


### PR DESCRIPTION
This will allow us to use plain asserts and pytest's features without breaking bazel.

Closes #1177