### PR TITLE
Removed usage of keras_parametrized.

### DIFF
--- a/tensorflow_addons/seq2seq/basic_decoder_test.py
+++ b/tensorflow_addons/seq2seq/basic_decoder_test.py
@@ -24,11 +24,9 @@ import tensorflow as tf
 from tensorflow_addons.seq2seq import attention_wrapper
 from tensorflow_addons.seq2seq import basic_decoder
 from tensorflow_addons.seq2seq import sampler as sampler_py
-from tensorflow_addons.utils import test_utils
 
 
-@test_utils.keras_parameterized.run_all_keras_modes
-class BasicDecoderTest(test_utils.keras_parameterized.TestCase):
+class BasicDecoderTest(tf.test.TestCase, parameterized.TestCase):
     """Unit test for basic_decoder.BasicDecoder."""
 
     @parameterized.named_parameters(

--- a/tensorflow_addons/seq2seq/decoder_test.py
+++ b/tensorflow_addons/seq2seq/decoder_test.py
@@ -20,13 +20,11 @@ import pytest
 import numpy as np
 import tensorflow as tf
 
-from tensorflow_addons.utils import test_utils
 from tensorflow_addons.seq2seq import basic_decoder
 from tensorflow_addons.seq2seq import sampler as sampler_py
 
 
-@test_utils.keras_parameterized.run_all_keras_modes
-class DecodeRNNTest(test_utils.keras_parameterized.TestCase, tf.test.TestCase):
+class DecodeRNNTest(tf.test.TestCase):
     """Tests for Decoder."""
 
     def _testDecodeRNN(self, time_major, maximum_iterations=None):

--- a/tensorflow_addons/utils/test_utils.py
+++ b/tensorflow_addons/utils/test_utils.py
@@ -30,7 +30,6 @@ from tensorflow.python.framework.test_util import (  # noqa: F401
     run_in_graph_and_eager_modes,
 )
 from tensorflow.python.keras.testing_utils import layer_test  # noqa: F401
-from tensorflow.python.keras import keras_parameterized  # noqa: F401
 
 
 @contextlib.contextmanager


### PR DESCRIPTION
The class `keras_parametrized.TestCase` is used for its parameter `should_run_eagerly` to be passed to a compile function. This was not used. This class was useful only to parametrize the tests but we can use a public class instead.

See https://github.com/tensorflow/tensorflow/blob/3fcd7f5978149dcce229c3d203543c61c9645599/tensorflow/python/keras/keras_parameterized.py#L303