### PR TITLE
Build the linux wheel in a dockerfile.

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -4,3 +4,4 @@
 .coverage*
 # C extensions
 *.so
+wheelhouse/

--- a/.github/workflows/make_wheel_Linux.sh
+++ b/.github/workflows/make_wheel_Linux.sh
@@ -1,13 +1,7 @@
 set -e -x
-
-docker run -e TF_NEED_CUDA=1 -v ${PWD}:/addons -w /addons \
-  tensorflow/tensorflow:2.1.0-custom-op-gpu-ubuntu16 \
-  bash tools/releases/release_linux.sh $PY_VERSION $NIGHTLY_FLAG
-
-sudo apt-get install patchelf
-python3 -m pip install -U auditwheel==2.0.0
-bash tools/releases/tf_auditwheel_patch.sh
-
-auditwheel repair --plat manylinux2010_x86_64 artifacts/*.whl
-
-ls -al wheelhouse/
+DOCKER_BUILDKIT=1 docker build \
+    -f tools/docker/build_wheel.Dockerfile \
+    --output type=local,dest=wheelhouse \
+    --build-arg PY_VERSION \
+    --build-arg NIGHTLY_FLAG \
+    ./

--- a/.gitignore
+++ b/.gitignore
@@ -40,3 +40,5 @@ wheels/
 
 .coverage*
 htmlcov
+
+wheelhouse/

--- a/tools/docker/build_wheel.Dockerfile
+++ b/tools/docker/build_wheel.Dockerfile
@@ -1,0 +1,30 @@
+FROM tensorflow/tensorflow:2.1.0-custom-op-gpu-ubuntu16 as make_wheel
+
+RUN apt-get update && apt-get install patchelf
+
+ARG PY_VERSION
+RUN python$PY_VERSION -m pip install --upgrade pip setuptools auditwheel==2.0.0
+
+COPY tools/install_deps/ /install_deps
+RUN python$PY_VERSION -m pip install \
+        -r /install_deps/tensorflow.txt \
+        -r /install_deps/pytest.txt
+
+COPY requirements.txt .
+RUN python$PY_VERSION -m pip install -r requirements.txt
+
+COPY tools/docker/finish_bazel_install.sh .
+RUN bash finish_bazel_install.sh
+
+COPY ./ /addons
+WORKDIR /addons
+ARG NIGHTLY_FLAG
+RUN bash tools/releases/release_linux.sh $PY_VERSION $NIGHTLY_FLAG
+
+RUN bash tools/releases/tf_auditwheel_patch.sh
+RUN auditwheel repair --plat manylinux2010_x86_64 artifacts/*.whl
+RUN ls -al wheelhouse/
+
+FROM scratch as output
+
+COPY --from=make_wheel /addons/wheelhouse/ .


### PR DESCRIPTION
This makes the process easily reproducible locally.

The output argument can feel a bit strange. It's used in docker buildkit when the result of the build should be something else than docker images (eg compiled binaries). See https://github.com/moby/buildkit#local-directory

Later on, in the same dockerfile, we can integrate the test of the wheel in a fresh environement. It's going to be faster than to pop a new github action runner just for that.