### PR TITLE
Alternative to run_all_in_graph_and_eager_mode

### DIFF
--- a/tensorflow_addons/BUILD
+++ b/tensorflow_addons/BUILD
@@ -11,6 +11,7 @@ py_library(
     name = "tensorflow_addons",
     data = [
         "__init__.py",
+        "conftest.py",
         "options.py",
         "register.py",
         "version.py",

--- a/tensorflow_addons/conftest.py
+++ b/tensorflow_addons/conftest.py
@@ -1,16 +1,5 @@
-import tensorflow as tf
-import pytest
+from tensorflow_addons.utils.test_utils import maybe_run_functions_eagerly  # noqa: F401
 
-
-def finalizer():
-    tf.config.experimental_run_functions_eagerly(False)
-
-
-@pytest.fixture(scope="function", params=["eager_mode", "tf_function"])
-def maybe_run_functions_eagerly(request):
-    if request.param == "eager_mode":
-        tf.config.experimental_run_functions_eagerly(True)
-    elif request.param == "tf_function":
-        tf.config.experimental_run_functions_eagerly(False)
-
-    request.addfinalizer(finalizer)
+# fixtures present in this file will be available
+# when running tests and can be referenced with strings
+# https://docs.pytest.org/en/latest/fixture.html#conftest-py-sharing-fixture-functions

--- a/tensorflow_addons/conftest.py
+++ b/tensorflow_addons/conftest.py
@@ -1,0 +1,15 @@
+import tensorflow as tf
+import pytest
+
+
+@pytest.fixture(scope="function", params=["eager_mode", "tf_function"])
+def maybe_run_functions_eagerly(request):
+    if request.param == "eager_mode":
+        tf.config.experimental_run_functions_eagerly(True)
+    elif request.param == "tf_function":
+        tf.config.experimental_run_functions_eagerly(False)
+
+    def finalizer():
+        tf.config.experimental_run_functions_eagerly(False)
+
+    request.addfinalizer(finalizer)

--- a/tensorflow_addons/conftest.py
+++ b/tensorflow_addons/conftest.py
@@ -2,14 +2,15 @@ import tensorflow as tf
 import pytest
 
 
+def finalizer():
+    tf.config.experimental_run_functions_eagerly(False)
+
+
 @pytest.fixture(scope="function", params=["eager_mode", "tf_function"])
 def maybe_run_functions_eagerly(request):
     if request.param == "eager_mode":
         tf.config.experimental_run_functions_eagerly(True)
     elif request.param == "tf_function":
-        tf.config.experimental_run_functions_eagerly(False)
-
-    def finalizer():
         tf.config.experimental_run_functions_eagerly(False)
 
     request.addfinalizer(finalizer)

--- a/tensorflow_addons/metrics/cohens_kappa_test.py
+++ b/tensorflow_addons/metrics/cohens_kappa_test.py
@@ -170,17 +170,6 @@ class CohenKappaTest(tf.test.TestCase):
         self.evaluate(obj.update_state(y_true, y_pred))
         self.assertAllClose(0.19999999, obj.result())
 
-    def test_with_ohe_labels(self):
-        y_true = np.array([4, 4, 3, 4], dtype=np.int32)
-        y_true = tf.keras.utils.to_categorical(y_true, num_classes=5)
-        y_pred = np.array([4, 4, 1, 2], dtype=np.int32)
-
-        obj = CohenKappa(num_classes=5, sparse_labels=False)
-        self.evaluate(tf.compat.v1.variables_initializer(obj.variables))
-
-        self.evaluate(obj.update_state(y_true, y_pred))
-        self.assertAllClose(0.19999999, obj.result())
-
     def test_keras_binary_reg_model(self):
         kp = CohenKappa(num_classes=2)
         inputs = tf.keras.layers.Input(shape=(10,))
@@ -229,6 +218,28 @@ class CohenKappaTest(tf.test.TestCase):
         y = tf.keras.utils.to_categorical(y, num_classes=5)
 
         model.fit(x, y, epochs=1, verbose=0, batch_size=32)
+
+
+@pytest.fixture(scope="function", params=[True, False])
+def maybe_run_functions_eagerly(request):
+    tf.config.experimental_run_functions_eagerly(request.param)
+
+    def finalizer():
+        tf.config.experimental_run_functions_eagerly(False)
+
+    request.addfinalizer(finalizer)
+
+
+@pytest.mark.usefixtures("maybe_run_functions_eagerly")
+def test_with_ohe_labels():
+    y_true = np.array([4, 4, 3, 4], dtype=np.int32)
+    y_true = tf.keras.utils.to_categorical(y_true, num_classes=5)
+    y_pred = np.array([4, 4, 1, 2], dtype=np.int32)
+
+    obj = CohenKappa(num_classes=5, sparse_labels=False)
+
+    obj.update_state(y_true, y_pred)
+    np.testing.assert_allclose(0.19999999, obj.result().numpy())
 
 
 if __name__ == "__main__":

--- a/tensorflow_addons/metrics/cohens_kappa_test.py
+++ b/tensorflow_addons/metrics/cohens_kappa_test.py
@@ -220,9 +220,12 @@ class CohenKappaTest(tf.test.TestCase):
         model.fit(x, y, epochs=1, verbose=0, batch_size=32)
 
 
-@pytest.fixture(scope="function", params=[True, False])
+@pytest.fixture(scope="function", params=["eager_mode", "tf_function"])
 def maybe_run_functions_eagerly(request):
-    tf.config.experimental_run_functions_eagerly(request.param)
+    if request.param == "eager_mode":
+        tf.config.experimental_run_functions_eagerly(True)
+    elif request.param == "tf_function":
+        tf.config.experimental_run_functions_eagerly(False)
 
     def finalizer():
         tf.config.experimental_run_functions_eagerly(False)

--- a/tensorflow_addons/metrics/cohens_kappa_test.py
+++ b/tensorflow_addons/metrics/cohens_kappa_test.py
@@ -220,19 +220,6 @@ class CohenKappaTest(tf.test.TestCase):
         model.fit(x, y, epochs=1, verbose=0, batch_size=32)
 
 
-@pytest.fixture(scope="function", params=["eager_mode", "tf_function"])
-def maybe_run_functions_eagerly(request):
-    if request.param == "eager_mode":
-        tf.config.experimental_run_functions_eagerly(True)
-    elif request.param == "tf_function":
-        tf.config.experimental_run_functions_eagerly(False)
-
-    def finalizer():
-        tf.config.experimental_run_functions_eagerly(False)
-
-    request.addfinalizer(finalizer)
-
-
 @pytest.mark.usefixtures("maybe_run_functions_eagerly")
 def test_with_ohe_labels():
     y_true = np.array([4, 4, 3, 4], dtype=np.int32)

--- a/tensorflow_addons/utils/BUILD
+++ b/tensorflow_addons/utils/BUILD
@@ -12,6 +12,9 @@ py_library(
         "resource_loader.py",
         "types.py",
     ]),
+    data = [
+        "//tensorflow_addons:conftest.py",
+    ],
 )
 
 py_test(

--- a/tensorflow_addons/utils/test_utils.py
+++ b/tensorflow_addons/utils/test_utils.py
@@ -19,6 +19,7 @@ import inspect
 import time
 import unittest
 
+import pytest
 import tensorflow as tf
 
 # TODO: find public API alternative to these
@@ -182,3 +183,17 @@ def time_all_functions(cls):
         ):
             setattr(cls, name, time_function(method))
     return cls
+
+
+def finalizer():
+    tf.config.experimental_run_functions_eagerly(False)
+
+
+@pytest.fixture(scope="function", params=["eager_mode", "tf_function"])
+def maybe_run_functions_eagerly(request):
+    if request.param == "eager_mode":
+        tf.config.experimental_run_functions_eagerly(True)
+    elif request.param == "tf_function":
+        tf.config.experimental_run_functions_eagerly(False)
+
+    request.addfinalizer(finalizer)


### PR DESCRIPTION
So, replacing this `run_all_in_graph_and_eager_mode` is quite difficult but it's worth it for two reasons:
* It's not a public API, so it can go away at any time. The behavior can change silently.
* We don't need to execute the test methods in graph mode. We only need to execute a small part of the test in graph mode (for the layers, it's the `call` method, for the metrics/losses, it's the `update_state`...). It allows us to enjoy the eager mode outside those selected functions and we don't have to do `self.session` `self.evaluate(tf.compat.v1.initialize_global_variables(...))`. We can just do `.numpy()` to get results. This has the benefit to make testing much easier and bring new contributors who might be put off by this testing which looks like coding in tensorflow 1.x.
* It does not run `tf.function` in eager mode. So it's not actually helping us at all. I think it's just a TF 1.x relict and is useful only to force graph mode when tf.function is not present. See #1289 


So how to do that, in a clean way? Well that's more or less difficult.

From the discussion in #13 , all public functions should have the `@tf.functions` decorator. #807  shows that it's a problem when using python variables, but in this case, we should just use the `input_signature` to convert automatically scalars to tensorflow tensors. See https://www.tensorflow.org/api_docs/python/tf/function . We can even add tests to ensure we don't draw the graph multiple times with the method `get_concrete_function`.

We already use tf.function many time in the codebase, and even when we don't use it, keras enforce it with black magic when subclassing `Metric` or even `Layer`.

Let's then assume that all public functions have the `tf.function` decorator.

Here is my proposal. It uses pytest features and it won't work when subclassing tf.test.TestCase. But I believe we don't need subclassing anyway for most of the tests present in tf.addons. Worst case scenario we can code it again for `tf.test.TestCase` with the absl parametrize decorator.

`conftest.py` must be present when running the tests which means that we need to make bazel aware of it. This is why I linked it to `tensorflow_addons/utils` which is present all the time in the tests.

Some reference:
https://docs.pytest.org/en/latest/fixture.html
 