### PR TITLE
Added code coverage to tools/run_cpu_tests.sh

### DIFF
--- a/tools/docker/cpu_tests.Dockerfile
+++ b/tools/docker/cpu_tests.Dockerfile
@@ -13,9 +13,15 @@ RUN pip install -r requirements.txt
 COPY tools/install_deps/finish_bazel_install.sh ./
 RUN bash finish_bazel_install.sh
 
+COPY tools/install_deps/pytest.txt ./
+RUN pip install -r pytest.txt pytest-cov
+
 COPY ./ /addons
 WORKDIR addons
-RUN bash tools/testing/addons_cpu.sh --no-deps
+RUN python configure.py --no-deps
+RUN pip install -e ./
+RUN bash tools/install_so_files.sh
+RUN pytest -v -n auto --durations=25 --cov=tensorflow_addons ./tensorflow_addons/
 
 RUN bazel build --enable_runfiles build_pip_pkg
 RUN bazel-bin/build_pip_pkg artifacts

--- a/tools/run_cpu_tests.sh
+++ b/tools/run_cpu_tests.sh
@@ -8,4 +8,4 @@ if [ "$DOCKER_BUILDKIT" == "" ]; then
   export DOCKER_BUILDKIT=1
 fi
 
-docker build -f tools/docker/cpu_tests.Dockerfile ./
+docker build --progress=plain -f tools/docker/cpu_tests.Dockerfile ./


### PR DESCRIPTION
So the `No module named _sqllite3` that we had before was an issue of python not being compiled with sqllite support. So nothing we can do about it in the custom-ops image. 

Something we can do though is running it in the standard python3.5 docker image since the python used here supports it. So now, if we want to look at the code coverage in the master branch, we just need to look at the logs of the minimal cpu build.

Also the progress plain is used to have the full output when building the image locally. By default buildkit swallow the output. I tried and it also worked when `DOCKER_BUILDKIT=0` so my hope is that this option won't break the script for people who don't have a version of docker recent enough.

See https://github.com/tensorflow/addons/pull/1243#issuecomment-596510466 
and https://stackoverflow.com/questions/1210664/no-module-named-sqlite3