### PR TITLE
Better error reporting in the CI

### DIFF
--- a/pytest.ini
+++ b/pytest.ini
@@ -1,0 +1,2 @@
+[pytest]
+addopts = -rfEx


### PR DESCRIPTION
By default, pytest doesn't make a list of all tests that have failed (only the traceback). It's useful to have it though, especially in the CI when a lot of tests are failing. 

This pull request changes the default options for pytest. `-r` is for creating a small report at the end. `f` is for failed, `E` is for errors, `x` is for xfail, the tests we know are failing (see #1303 for an example). I didn't include the skipped tests, because tf.test.TestCase has a `test_session` that is skipped for every class and that would be a too much to display all of them at the end.