### PR TITLE
 Create accuracy_stopping.py callback 

### DIFF
--- a/tensorflow_addons/callbacks/BUILD
+++ b/tensorflow_addons/callbacks/BUILD
@@ -6,6 +6,7 @@ py_library(
     name = "callbacks",
     srcs = [
         "__init__.py",
+        "accuracy_stopping.py",
         "average_model_checkpoint.py",
         "time_stopping.py",
         "tqdm_progress_bar.py",

--- a/tensorflow_addons/callbacks/__init__.py
+++ b/tensorflow_addons/callbacks/__init__.py
@@ -14,6 +14,7 @@
 # ==============================================================================
 """Additional callbacks that conform to Keras API."""
 
+from tensorflow_addons.callbacks.accuracy_stopping import AccuracyStopping
 from tensorflow_addons.callbacks.average_model_checkpoint import AverageModelCheckpoint
 from tensorflow_addons.callbacks.time_stopping import TimeStopping
 from tensorflow_addons.callbacks.tqdm_progress_bar import TQDMProgressBar

--- a/tensorflow_addons/callbacks/accuracy_stopping.py
+++ b/tensorflow_addons/callbacks/accuracy_stopping.py
@@ -24,7 +24,7 @@ class AccuracyStopping(Callback):
     """Stop training when a specified accuracy is reached.
     Args:
         Acc: Maximum accuracy before stopping.
-            Defaults to 0.9999 %.
+            Defaults to 0.9999 %. It takes value in between 0 - 1. 
     """
 
     @typechecked

--- a/tensorflow_addons/callbacks/accuracy_stopping.py
+++ b/tensorflow_addons/callbacks/accuracy_stopping.py
@@ -27,15 +27,15 @@ class AccuracyStopping(Callback):
             Defaults to 0.9999. It takes value in between 0 - 1."""
     
     @typechecked
-    def __init__(self, Acc: float = 0.9999):
+    def __init__(self, accuracy: float = 0.9999):
         super().__init__()
-        self.Acc = Acc
+        self.accuracy = accuracy
    
 
     def on_epoch_end(self, epoch, logs={}):
         print(self.Acc)
         print(logs.get('accuracy'))
-        if (logs.get('accuracy') >= self.Acc):
+        if (logs.get('accuracy') >= self.accuracy):
             self.model.stop_training = True
             self.stopped_epoch = epoch
             
@@ -43,7 +43,7 @@ class AccuracyStopping(Callback):
     def on_train_end(self, logs=None):
         if self.stopped_epoch is not None:
             msg = "Reached {} % accuracy on {} epochs so cancelling training!" .format(
-                self.Acc*100, self.stopped_epoch + 1)
+                self.accuracy*100, self.stopped_epoch + 1)
             print(msg)
             
 

--- a/tensorflow_addons/callbacks/accuracy_stopping.py
+++ b/tensorflow_addons/callbacks/accuracy_stopping.py
@@ -56,3 +56,4 @@ class AccuracyStopping(Callback):
 
         base_config = super().get_config()
         return {**base_config, **config}
+    

--- a/tensorflow_addons/callbacks/accuracy_stopping.py
+++ b/tensorflow_addons/callbacks/accuracy_stopping.py
@@ -23,8 +23,8 @@ from typeguard import typechecked
 class AccuracyStopping(Callback):
     """Stop training when a specified accuracy is reached.
     Args:
-        Acc: Maximum accuracy before stopping.
-            Defaults to 0.9999 %. It takes value in between 0 - 1."""
+        Acc: Minimum accuracy before stopping.
+            Defaults to 0.9999. It takes value in between 0 - 1."""
     
     @typechecked
     def __init__(self, Acc: float = 0.9999):

--- a/tensorflow_addons/callbacks/accuracy_stopping.py
+++ b/tensorflow_addons/callbacks/accuracy_stopping.py
@@ -1,0 +1,58 @@
+# Copyright 2019 The TensorFlow Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ==============================================================================
+"""Callback that stops training when a specified amount of accuracy has achieved."""
+
+
+import tensorflow as tf
+from tensorflow.keras.callbacks import Callback
+from typeguard import typechecked
+
+@tf.keras.utils.register_keras_serializable(package="Addons")
+class AccuracyStopping(Callback):
+    """Stop training when a specified accuracy is reached.
+    Args:
+        Acc: Maximum accuracy before stopping.
+            Defaults to 0.9999 %.
+    """
+
+    @typechecked
+    def __init__(self, Acc: float = 0.9999):
+        super().__init__()
+        self.Acc = Acc
+   
+
+    def on_epoch_end(self, epoch, logs={}):
+        print(self.Acc)
+        print(logs.get('accuracy'))
+        if (logs.get('accuracy') >= self.Acc):
+            self.model.stop_training = True
+            self.stopped_epoch = epoch
+            
+
+    def on_train_end(self, logs=None):
+        if self.stopped_epoch is not None:
+            msg = "Reached {} % accuracy on {} epochs so cancelling training!" .format(
+                self.Acc*100, self.stopped_epoch + 1)
+            print(msg)
+            
+
+    def get_config(self):
+        config = {
+            "Acc": self.Acc,
+            "verbose": self.verbose,
+        }
+
+        base_config = super().get_config()
+        return {**base_config, **config}

--- a/tensorflow_addons/callbacks/accuracy_stopping.py
+++ b/tensorflow_addons/callbacks/accuracy_stopping.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 # ==============================================================================
-"""Callback that stops training when a specified amount of accuracy has achieved."""
+"""Callback that stops training when a specified accuracy has been achieved."""
 
 
 import tensorflow as tf

--- a/tensorflow_addons/callbacks/accuracy_stopping.py
+++ b/tensorflow_addons/callbacks/accuracy_stopping.py
@@ -24,9 +24,8 @@ class AccuracyStopping(Callback):
     """Stop training when a specified accuracy is reached.
     Args:
         Acc: Maximum accuracy before stopping.
-            Defaults to 0.9999 %. It takes value in between 0 - 1. 
-    """
-
+            Defaults to 0.9999 %. It takes value in between 0 - 1."""
+    
     @typechecked
     def __init__(self, Acc: float = 0.9999):
         super().__init__()
@@ -53,7 +52,6 @@ class AccuracyStopping(Callback):
             "Acc": self.Acc,
             "verbose": self.verbose,
         }
-
         base_config = super().get_config()
         return {**base_config, **config}
     

--- a/tensorflow_addons/callbacks/accuracy_stopping.py
+++ b/tensorflow_addons/callbacks/accuracy_stopping.py
@@ -24,12 +24,15 @@ class AccuracyStopping(Callback):
     """Stop training when a specified accuracy is reached.
     Args:
         Acc: Minimum accuracy before stopping.
-            Defaults to 0.9999. It takes value in between 0 - 1."""
+            Defaults to 0.9999. It takes value in between 0 - 1.
+        verbose: verbosity mode. Defaults to 0.
+    """
     
     @typechecked
-    def __init__(self, accuracy: float = 0.9999):
+    def __init__(self, accuracy: float = 0.9999, verbose: int = 0):
         super().__init__()
         self.accuracy = accuracy
+        self.verbose = verbose
    
 
     def on_epoch_end(self, epoch, logs={}):
@@ -41,15 +44,15 @@ class AccuracyStopping(Callback):
             
 
     def on_train_end(self, logs=None):
-        if self.stopped_epoch is not None:
-            msg = "Reached {} % accuracy on {} epochs so cancelling training!" .format(
+        if self.stopped_epoch is not None and self.verbose > 0:
+            msg = "Reached {} % accuracy on {} epochs so stopping  training!" .format(
                 self.accuracy*100, self.stopped_epoch + 1)
             print(msg)
             
 
     def get_config(self):
         config = {
-            "Acc": self.Acc,
+            "accuracy": self.accuracy,
             "verbose": self.verbose,
         }
         base_config = super().get_config()


### PR DESCRIPTION
Created `accuracy_stopping.py`, which is a Callback function. When specified accuracy is achieved it stops training further. By default it stops when accuracy achieved is .9999. It contains one parameter `Acc` whose range is from 0 to 1. 

I can create tutorial for how to use it one its merge. 

@shun-lin  & @Squadrick  please have a look, if it requires any correction let me know.