### PR TITLE
Multivariate r2

### DIFF
--- a/tensorflow_addons/metrics/r_square.py
+++ b/tensorflow_addons/metrics/r_square.py
@@ -32,7 +32,7 @@ def _reduce_average(
     """Computes the (weighted) mean of elements across dimensions of a tensor.
   """
     if weights is None:
-        return tf.reduce_mean(input_tensor, axis=None, keepdims=False)
+        return tf.reduce_mean(input_tensor, axis=axis, keepdims=keepdims)
 
     weighted_sum = tf.reduce_sum(weights * input_tensor, axis=axis, keepdims=keepdims)
     sum_of_weights = tf.reduce_sum(weights, axis=axis, keepdims=keepdims)

--- a/tensorflow_addons/metrics/r_square.py
+++ b/tensorflow_addons/metrics/r_square.py
@@ -131,7 +131,11 @@ class RSquare(Metric):
         elif self.multioutput == "variance_weighted":
             return _reduce_average(raw_scores, weights=total)
         else:
-            raise NotImplementedError("lol")
+            raise RuntimeError(
+                "The multioutput attribute must be one of {}, but was: {}".format(
+                    VALID_MULTIOUTPUT, self.multioutput
+                )
+            )
 
     def reset_states(self) -> None:
         # The state of the metric will be reset at the start of each epoch.

--- a/tensorflow_addons/metrics/r_square_test.py
+++ b/tensorflow_addons/metrics/r_square_test.py
@@ -35,8 +35,8 @@ class RSquareTest(tf.test.TestCase):
         self.assertEqual(r2_obj2.name, "r_square")
         self.assertEqual(r2_obj2.dtype, tf.float32)
 
-    def initialize_vars(self):
-        r2_obj = RSquare()
+    def initialize_vars(self, y_shape=()):
+        r2_obj = RSquare(y_shape=y_shape)
         self.evaluate(tf.compat.v1.variables_initializer(r2_obj.variables))
         return r2_obj
 
@@ -88,8 +88,8 @@ class RSquareTest(tf.test.TestCase):
         implementation of the same metric, given random input.
         """
         for i in range(10):
-            actuals = np.random.rand(64, 1)
-            preds = np.random.rand(64, 1)
+            actuals = np.random.rand(64, 3)
+            preds = np.random.rand(64, 3)
             sample_weight = np.random.rand(64, 1)
             tensor_actuals = tf.constant(actuals, dtype=tf.float32)
             tensor_preds = tf.constant(preds, dtype=tf.float32)
@@ -98,14 +98,14 @@ class RSquareTest(tf.test.TestCase):
             tensor_preds = tf.cast(tensor_preds, dtype=tf.float32)
             tensor_sample_weight = tf.cast(tensor_sample_weight, dtype=tf.float32)
             # Initialize
-            r2_obj = self.initialize_vars()
+            r2_obj = self.initialize_vars(y_shape=(3,))
             # Update
             self.update_obj_states(
                 r2_obj, tensor_actuals, tensor_preds, sample_weight=tensor_sample_weight
             )
             # Check results by comparing to results of scikit-learn r2 implementation
             sklearn_result = sklearn_r2_score(
-                actuals, preds, sample_weight=sample_weight
+                actuals, preds, sample_weight=sample_weight, multioutput="raw_values",
             )
             self.check_results(r2_obj, sklearn_result)
 

--- a/tensorflow_addons/metrics/r_square_test.py
+++ b/tensorflow_addons/metrics/r_square_test.py
@@ -21,6 +21,7 @@ import pytest
 import tensorflow as tf
 from sklearn.metrics import r2_score as sklearn_r2_score
 from tensorflow_addons.metrics import RSquare
+from tensorflow_addons.metrics.r_square import VALID_MULTIOUTPUT
 from tensorflow_addons.utils import test_utils
 
 
@@ -35,8 +36,8 @@ class RSquareTest(tf.test.TestCase):
         self.assertEqual(r2_obj2.name, "r_square")
         self.assertEqual(r2_obj2.dtype, tf.float32)
 
-    def initialize_vars(self, y_shape=()):
-        r2_obj = RSquare(y_shape=y_shape)
+    def initialize_vars(self, y_shape=(), multioutput: str = "uniform_average"):
+        r2_obj = RSquare(y_shape=y_shape, multioutput=multioutput)
         self.evaluate(tf.compat.v1.variables_initializer(r2_obj.variables))
         return r2_obj
 
@@ -87,27 +88,35 @@ class RSquareTest(tf.test.TestCase):
         """Test that RSquare behaves similarly to the scikit-learn
         implementation of the same metric, given random input.
         """
-        for i in range(10):
-            actuals = np.random.rand(64, 3)
-            preds = np.random.rand(64, 3)
-            sample_weight = np.random.rand(64, 1)
-            tensor_actuals = tf.constant(actuals, dtype=tf.float32)
-            tensor_preds = tf.constant(preds, dtype=tf.float32)
-            tensor_sample_weight = tf.constant(sample_weight, dtype=tf.float32)
-            tensor_actuals = tf.cast(tensor_actuals, dtype=tf.float32)
-            tensor_preds = tf.cast(tensor_preds, dtype=tf.float32)
-            tensor_sample_weight = tf.cast(tensor_sample_weight, dtype=tf.float32)
-            # Initialize
-            r2_obj = self.initialize_vars(y_shape=(3,))
-            # Update
-            self.update_obj_states(
-                r2_obj, tensor_actuals, tensor_preds, sample_weight=tensor_sample_weight
-            )
-            # Check results by comparing to results of scikit-learn r2 implementation
-            sklearn_result = sklearn_r2_score(
-                actuals, preds, sample_weight=sample_weight, multioutput="raw_values",
-            )
-            self.check_results(r2_obj, sklearn_result)
+        for multioutput in VALID_MULTIOUTPUT:
+            for i in range(10):
+                actuals = np.random.rand(64, 3)
+                preds = np.random.rand(64, 3)
+                sample_weight = np.random.rand(64, 1)
+                tensor_actuals = tf.constant(actuals, dtype=tf.float32)
+                tensor_preds = tf.constant(preds, dtype=tf.float32)
+                tensor_sample_weight = tf.constant(sample_weight, dtype=tf.float32)
+                tensor_actuals = tf.cast(tensor_actuals, dtype=tf.float32)
+                tensor_preds = tf.cast(tensor_preds, dtype=tf.float32)
+                tensor_sample_weight = tf.cast(tensor_sample_weight, dtype=tf.float32)
+                # Initialize
+                r2_obj = self.initialize_vars(y_shape=(3,), multioutput=multioutput)
+                # Update
+                self.update_obj_states(
+                    r2_obj,
+                    tensor_actuals,
+                    tensor_preds,
+                    sample_weight=tensor_sample_weight,
+                )
+                # Check results by comparing to results of scikit-learn r2 implementation
+                sklearn_result = sklearn_r2_score(
+                    actuals, preds, sample_weight=sample_weight, multioutput=multioutput
+                )
+                self.check_results(r2_obj, sklearn_result)
+
+    def test_unrecognized_multioutput(self):
+        with pytest.raises(ValueError):
+            self.initialize_vars(multioutput="meadian")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
I noticed that the `RSquared` metric does not behave in the same way as the `scikit-learn` implementation of the same metric for multivariate regression (in `scikit-learn` known as "multioutput"). First I thought I should mend it to align with the `scikit-learn` implementation that calculates separate scores for each label element and aggregates the scores. Then I started asking myself whether there might be other ways of interpreting R<sup>2</sup> in higher dimensions. Looking at the definition presented in https://en.wikipedia.org/wiki/Coefficient_of_determination, it does look like it might make sense to extend it to higher rank data types, but this can be done in different ways, and I am unsure what would make sense mathematically. The `scikit-learn` approach at least makes some sense to me as it just treats the model as a model for n separate dependent variables at the same time.

I would really like a discussion on how R<sup>2</sup> should be understood in higher dimensions, but if we are to go with the `scikit-learn` interpretation, this PR is one way to go about it. It is slightly annoying that you have to specify the shape of y when initializing the metric object. This could be solved by dynamically setting the shape like it is done in the [MeanTensor metric](https://github.com/tensorflow/tensorflow/blob/v2.1.0/tensorflow/python/keras/metrics.py#L2618-L2628). Although more user friendly, I don't think the code is as clean, so there is a trade-off.

I modified a test to show how this acts for higher dimensional data, currently matching the `multioutput="raw_values"` flavour of the `scikit-learn` implementation.