### PR TITLE
Fixing the master branch.

### DIFF
--- a/configure.py
+++ b/configure.py
@@ -69,7 +69,7 @@ def generate_shared_lib_name(namespec):
         return namespec[1][3:]
 
 
-def install_dependencies(quiet: bool):
+def install_dependencies(quiet):
     install_cmd = [sys.executable, "-m", "pip", "install", "--upgrade"]
     if quiet:
         install_cmd.append("--quiet")

--- a/tools/install_deps/finish_bazel_install.sh
+++ b/tools/install_deps/finish_bazel_install.sh
@@ -4,9 +4,9 @@ set -e
 # can be removed once docker buildx/buildkit is stable
 # and we'll use "RUN --mount=cache ..." instead
 cd /tmp
-git clone https://github.com/tensorflow/addons.git
+git clone -b v0.8.3 https://github.com/tensorflow/addons.git
 cd addons
-python3 ./configure.py --no-deps
+python ./configure.py --no-deps
 bazel build --nobuild -- //tensorflow_addons/...
 cd ..
 rm -rf ./addons

--- a/tools/install_deps/finish_bazel_install.sh
+++ b/tools/install_deps/finish_bazel_install.sh
@@ -6,7 +6,7 @@ set -e
 cd /tmp
 git clone https://github.com/tensorflow/addons.git
 cd addons
-python ./configure.py --no-deps
+python3 ./configure.py --no-deps
 bazel build --nobuild -- //tensorflow_addons/...
 cd ..
 rm -rf ./addons


### PR DESCRIPTION
We need to clone a specific commit to avoid making our CI depend on a moving target. Even when using a hack like in this case.

Hopefully one day we can get rid of this hack. I wish there was a bazel command like `bazel download-jdk`