### PR TITLE
fix giou loss test

### DIFF
--- a/tensorflow_addons/losses/giou_loss.py
+++ b/tensorflow_addons/losses/giou_loss.py
@@ -73,7 +73,6 @@ class GIoULoss(tf.keras.losses.Loss):
 
 
 @tf.keras.utils.register_keras_serializable(package="Addons")
-@tf.function
 def giou_loss(y_true: TensorLike, y_pred: TensorLike, mode: str = "giou") -> tf.Tensor:
     """
     Args:
@@ -92,7 +91,7 @@ def giou_loss(y_true: TensorLike, y_pred: TensorLike, mode: str = "giou") -> tf.
     if not y_pred.dtype.is_floating:
         y_pred = tf.cast(y_pred, tf.float32)
     y_true = tf.cast(y_true, y_pred.dtype)
-    giou = _calculate_giou(y_pred, y_true, mode)
+    giou = tf.squeeze(_calculate_giou(y_pred, y_true, mode))
 
     return 1 - giou
 

--- a/tensorflow_addons/losses/giou_loss_test.py
+++ b/tensorflow_addons/losses/giou_loss_test.py
@@ -83,10 +83,10 @@ class GIoULossTest(tf.test.TestCase, parameterized.TestCase):
 
         boxes1 = tf.constant([[4.0, 3.0, 7.0, 5.0], [5.0, 6.0, 10.0, 7.0]], dtype=dtype)
         boxes2 = tf.constant([[3.0, 4.0, 6.0, 8.0]], dtype=dtype)
-        tf.expand_dims(boxes1, 0)
-        tf.expand_dims(boxes2, -2)
+        expand_boxes1 = tf.expand_dims(boxes1, -2)
+        expand_boxes2 = tf.expand_dims(boxes2, 0)
         expected_result = tf.constant([1.07500000298023224, 1.366071], dtype=dtype)
-        loss = giou_loss(boxes1, boxes2)
+        loss = giou_loss(expand_boxes1, expand_boxes2)
         self.assertAllCloseAccordingToType(loss, expected_result)
 
     @parameterized.named_parameters(
@@ -102,18 +102,16 @@ class GIoULossTest(tf.test.TestCase, parameterized.TestCase):
     @parameterized.named_parameters(
         ("float16", np.float16), ("float32", np.float32), ("float64", np.float64)
     )
-    @pytest.mark.xfail(tf.__version__ == "2.2.0-rc0", reason="TODO: Fix this test")
     def test_keras_model(self, dtype):
         boxes1 = tf.constant([[4.0, 3.0, 7.0, 5.0], [5.0, 6.0, 10.0, 7.0]], dtype=dtype)
         boxes2 = tf.constant(
             [[3.0, 4.0, 6.0, 8.0], [14.0, 14.0, 15.0, 15.0]], dtype=dtype
         )
-        expected_result = tf.constant(
-            [1.07500000298023224, 1.9333333373069763], dtype=dtype
-        )
+        expected_result = tf.constant(1.5041667222976685, dtype=dtype)
         model = tf.keras.Sequential()
         model.compile(
-            optimizer="adam", loss=GIoULoss(reduction=tf.keras.losses.Reduction.NONE)
+            optimizer="adam",
+            loss=GIoULoss(reduction=tf.keras.losses.Reduction.SUM_OVER_BATCH_SIZE),
         )
         loss = model.evaluate(boxes1, boxes2, batch_size=2, steps=1)
         self.assertAllCloseAccordingToType(loss, expected_result)


### PR DESCRIPTION
Related #1320.
As [Reduction.NONE](https://www.tensorflow.org/versions/r2.2/api_docs/python/tf/keras/losses/Reduction) has changed. Change reduction mode to Reduction.SUM_OVER_BATCH_SIZE for unifying graph and eager reduction behavior.