### PR TITLE
Took some functions outside the run_all_in_eager_and_graph_mode in distance_transform

### DIFF
--- a/tensorflow_addons/image/distance_transform_test.py
+++ b/tensorflow_addons/image/distance_transform_test.py
@@ -118,19 +118,21 @@ class DistanceOpsTest(tf.test.TestCase):
         with self.assertRaisesRegex(ValueError, "`images` must have only one channel"):
             _ = dist_ops.euclidean_dist_transform(image)
 
-    def test_all_zeros(self):
-        image = tf.zeros([10, 10], tf.uint8)
-        expected_output = np.zeros([10, 10])
 
-        for output_dtype in [tf.float16, tf.float32, tf.float64]:
-            output = dist_ops.euclidean_dist_transform(image, dtype=output_dtype)
-            self.assertAllClose(output, expected_output)
+def test_all_zeros():
+    image = tf.zeros([10, 10], tf.uint8)
+    expected_output = np.zeros([10, 10])
 
-    def test_all_ones(self):
-        image = tf.ones([10, 10, 1], tf.uint8)
-        output = dist_ops.euclidean_dist_transform(image)
-        expected_output = np.full([10, 10, 1], tf.float32.max)
-        self.assertAllClose(output, expected_output)
+    for output_dtype in [tf.float16, tf.float32, tf.float64]:
+        output = dist_ops.euclidean_dist_transform(image, dtype=output_dtype)
+        np.testing.assert_allclose(output, expected_output)
+
+
+def test_all_ones():
+    image = tf.ones([10, 10, 1], tf.uint8)
+    output = dist_ops.euclidean_dist_transform(image)
+    expected_output = np.full([10, 10, 1], tf.float32.max)
+    np.testing.assert_allclose(output, expected_output)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
I don't think it needs to be tested twice in graph and eager mode. We have here a simple custom op, so graph or eager mode wouldn't change anything.

The gpu failures look unrelated.