### PR TITLE
Fix cohen kappa when using tf 2.2.0rc1

### DIFF
--- a/tensorflow_addons/metrics/cohens_kappa.py
+++ b/tensorflow_addons/metrics/cohens_kappa.py
@@ -120,7 +120,6 @@ class CohenKappa(Metric):
             dtype=tf.float32,
         )
 
-    @tf.function
     def update_state(self, y_true, y_pred, sample_weight=None):
         """Accumulates the confusion matrix condition statistics.
 
@@ -152,6 +151,12 @@ class CohenKappa(Metric):
         else:
             y_true = tf.cast(y_true, dtype=tf.int64)
 
+        y_pred = self._cast_ypred(y_pred)
+
+        return self._update_confusion_matrix(y_true, y_pred, sample_weight)
+
+    @tf.function
+    def _cast_ypred(self, y_pred):
         if tf.rank(y_pred) > 1:
             if not self.regression:
                 y_pred = tf.cast(tf.argmax(y_pred, axis=-1), dtype=tf.int64)
@@ -160,8 +165,7 @@ class CohenKappa(Metric):
                 y_pred = tf.cast(y_pred, dtype=tf.int64)
         else:
             y_pred = tf.cast(y_pred, dtype=tf.int64)
-
-        return self._update_confusion_matrix(y_true, y_pred, sample_weight)
+        return y_pred
 
     def _update_confusion_matrix(self, y_true, y_pred, sample_weight):
         y_true = tf.squeeze(y_true)

--- a/tensorflow_addons/metrics/cohens_kappa.py
+++ b/tensorflow_addons/metrics/cohens_kappa.py
@@ -120,6 +120,7 @@ class CohenKappa(Metric):
             dtype=tf.float32,
         )
 
+    @tf.function
     def update_state(self, y_true, y_pred, sample_weight=None):
         """Accumulates the confusion matrix condition statistics.
 

--- a/tensorflow_addons/metrics/cohens_kappa_test.py
+++ b/tensorflow_addons/metrics/cohens_kappa_test.py
@@ -182,7 +182,6 @@ class CohenKappaTest(tf.test.TestCase):
 
         model.fit(x, y, epochs=1, verbose=0, batch_size=32)
 
-    @pytest.mark.xfail(tf.__version__ == "2.2.0-rc1", reason="TODO: Fix this test")
     def test_keras_multiclass_reg_model(self):
         kp = CohenKappa(num_classes=5, regression=True, sparse_labels=True)
         inputs = tf.keras.layers.Input(shape=(10,))

--- a/tensorflow_addons/metrics/cohens_kappa_test.py
+++ b/tensorflow_addons/metrics/cohens_kappa_test.py
@@ -210,7 +210,6 @@ def test_keras_binary_clasasification_model():
     model.fit(x, y, epochs=1, verbose=0, batch_size=32)
 
 
-@pytest.mark.xfail(tf.__version__ == "2.2.0-rc1", reason="TODO: Fix this test")
 @pytest.mark.usefixtures("maybe_run_functions_eagerly")
 def test_keras_multiclass_classification_model():
     kp = CohenKappa(num_classes=5)


### PR DESCRIPTION
The errors were:
```
================================================================================================================== FAILURES ==================================================================================================================
_______________________________________________________________________________________________ CohenKappaTest.test_keras_multiclass_reg_model _______________________________________________________________________________________________
[gw3] linux -- Python 3.7.4 /opt/conda/bin/python

self = <tensorflow_addons.metrics.cohens_kappa_test.CohenKappaTest testMethod=test_keras_multiclass_reg_model>

    def test_keras_multiclass_reg_model(self):
        kp = CohenKappa(num_classes=5, regression=True, sparse_labels=True)
        inputs = tf.keras.layers.Input(shape=(10,))
        outputs = tf.keras.layers.Dense(1)(inputs)
        model = tf.keras.models.Model(inputs, outputs)
        model.compile(optimizer="sgd", loss="mse", metrics=[kp])

        x = np.random.rand(1000, 10).astype(np.float32)
        y = np.random.randint(5, size=(1000,)).astype(np.float32)

>       model.fit(x, y, epochs=1, verbose=0, batch_size=32)

tensorflow_addons/metrics/cohens_kappa_test.py:195:
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _
/opt/conda/lib/python3.7/site-packages/tensorflow/python/keras/engine/training.py:65: in _method_wrapper
    return method(self, *args, **kwargs)
/opt/conda/lib/python3.7/site-packages/tensorflow/python/keras/engine/training.py:783: in fit
    tmp_logs = train_function(iterator)
/opt/conda/lib/python3.7/site-packages/tensorflow/python/eager/def_function.py:580: in __call__
    result = self._call(*args, **kwds)
/opt/conda/lib/python3.7/site-packages/tensorflow/python/eager/def_function.py:627: in _call
    self._initialize(args, kwds, add_initializers_to=initializers)
/opt/conda/lib/python3.7/site-packages/tensorflow/python/eager/def_function.py:506: in _initialize
    *args, **kwds))
/opt/conda/lib/python3.7/site-packages/tensorflow/python/eager/function.py:2446: in _get_concrete_function_internal_garbage_collected
    graph_function, _, _ = self._maybe_define_function(args, kwargs)
/opt/conda/lib/python3.7/site-packages/tensorflow/python/eager/function.py:2777: in _maybe_define_function
    graph_function = self._create_graph_function(args, kwargs)
/opt/conda/lib/python3.7/site-packages/tensorflow/python/eager/function.py:2667: in _create_graph_function
    capture_by_value=self._capture_by_value),
/opt/conda/lib/python3.7/site-packages/tensorflow/python/framework/func_graph.py:981: in func_graph_from_py_func
    func_outputs = python_func(*func_args, **func_kwargs)
/opt/conda/lib/python3.7/site-packages/tensorflow/python/eager/def_function.py:441: in wrapped_fn
    return weak_wrapped_fn().__wrapped__(*args, **kwds)
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _

args = (<tensorflow.python.data.ops.iterator_ops.OwnedIterator object at 0x7f5e0c349b90>,), kwargs = {}

    def wrapper(*args, **kwargs):
      """Calls a converted version of original_func."""
      # TODO(mdan): Push this block higher in tf.function's call stack.
      try:
        return autograph.converted_call(
            original_func,
            args,
            kwargs,
            options=autograph.ConversionOptions(
                recursive=True,
                optional_features=autograph_options,
                user_requested=True,
            ))
      except Exception as e:  # pylint:disable=broad-except
        if hasattr(e, "ag_error_metadata"):
>         raise e.ag_error_metadata.to_exception(e)
E         tensorflow.python.framework.errors_impl.OperatorNotAllowedInGraphError: in user code:
E
E             /opt/conda/lib/python3.7/site-packages/tensorflow/python/keras/engine/training.py:503 train_function  *
E                 outputs = self.distribute_strategy.run(
E             /opt/conda/lib/python3.7/site-packages/tensorflow/python/distribute/distribute_lib.py:951 run  **
E                 return self._extended.call_for_each_replica(fn, args=args, kwargs=kwargs)
E             /opt/conda/lib/python3.7/site-packages/tensorflow/python/distribute/distribute_lib.py:2290 call_for_each_replica
E                 return self._call_for_each_replica(fn, args, kwargs)
E             /opt/conda/lib/python3.7/site-packages/tensorflow/python/distribute/distribute_lib.py:2649 _call_for_each_replica
E                 return fn(*args, **kwargs)
E             /opt/conda/lib/python3.7/site-packages/tensorflow/python/keras/engine/training.py:475 train_step  **
E                 self.compiled_metrics.update_state(y, y_pred, sample_weight)
E             /opt/conda/lib/python3.7/site-packages/tensorflow/python/keras/engine/compile_utils.py:406 update_state
E                 metric_obj.update_state(y_t, y_p)
E             /opt/conda/lib/python3.7/site-packages/tensorflow/python/keras/utils/metrics_utils.py:90 decorated
E                 update_op = update_state_fn(*args, **kwargs)
E             /projects/addons/tensorflow_addons/metrics/cohens_kappa.py:140 update_state
E                 return self._update(y_true, y_pred, sample_weight)
E             /projects/addons/tensorflow_addons/metrics/cohens_kappa.py:154 _update_multi_class_model
E                 if tf.rank(y_pred) > 1:
E             /opt/conda/lib/python3.7/site-packages/tensorflow/python/framework/ops.py:778 __bool__
E                 self._disallow_bool_casting()
E             /opt/conda/lib/python3.7/site-packages/tensorflow/python/framework/ops.py:545 _disallow_bool_casting
E                 "using a `tf.Tensor` as a Python `bool`")
E             /opt/conda/lib/python3.7/site-packages/tensorflow/python/framework/ops.py:532 _disallow_when_autograph_enabled
E                 " decorating it directly with @tf.function.".format(task))
E
E             OperatorNotAllowedInGraphError: using a `tf.Tensor` as a Python `bool` is not allowed: AutoGraph did not convert this function. Try decorating it directly with @tf.function.

/opt/conda/lib/python3.7/site-packages/tensorflow/python/framework/func_graph.py:968: OperatorNotAllowedInGraphError
__________________________________________________________________________________________ test_keras_multiclass_classification_model[tf_function] ___________________________________________________________________________________________
[gw3] linux -- Python 3.7.4 /opt/conda/bin/python

    @pytest.mark.usefixtures("maybe_run_functions_eagerly")
    def test_keras_multiclass_classification_model():
        kp = CohenKappa(num_classes=5)
        inputs = tf.keras.layers.Input(shape=(10,))
        outputs = tf.keras.layers.Dense(5, activation="softmax")(inputs)
        model = tf.keras.models.Model(inputs, outputs)
        model.compile(optimizer="sgd", loss="categorical_crossentropy", metrics=[kp])

        x = np.random.rand(1000, 10).astype(np.float32)
        y = np.random.randint(5, size=(1000,)).astype(np.float32)
        y = tf.keras.utils.to_categorical(y, num_classes=5)

>       model.fit(x, y, epochs=1, verbose=0, batch_size=32)

tensorflow_addons/metrics/cohens_kappa_test.py:224:
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _
/opt/conda/lib/python3.7/site-packages/tensorflow/python/keras/engine/training.py:65: in _method_wrapper
    return method(self, *args, **kwargs)
/opt/conda/lib/python3.7/site-packages/tensorflow/python/keras/engine/training.py:783: in fit
    tmp_logs = train_function(iterator)
/opt/conda/lib/python3.7/site-packages/tensorflow/python/eager/def_function.py:580: in __call__
    result = self._call(*args, **kwds)
/opt/conda/lib/python3.7/site-packages/tensorflow/python/eager/def_function.py:627: in _call
    self._initialize(args, kwds, add_initializers_to=initializers)
/opt/conda/lib/python3.7/site-packages/tensorflow/python/eager/def_function.py:506: in _initialize
    *args, **kwds))
/opt/conda/lib/python3.7/site-packages/tensorflow/python/eager/function.py:2446: in _get_concrete_function_internal_garbage_collected
    graph_function, _, _ = self._maybe_define_function(args, kwargs)
/opt/conda/lib/python3.7/site-packages/tensorflow/python/eager/function.py:2777: in _maybe_define_function
    graph_function = self._create_graph_function(args, kwargs)
/opt/conda/lib/python3.7/site-packages/tensorflow/python/eager/function.py:2667: in _create_graph_function
    capture_by_value=self._capture_by_value),
/opt/conda/lib/python3.7/site-packages/tensorflow/python/framework/func_graph.py:981: in func_graph_from_py_func
    func_outputs = python_func(*func_args, **func_kwargs)
/opt/conda/lib/python3.7/site-packages/tensorflow/python/eager/def_function.py:441: in wrapped_fn
    return weak_wrapped_fn().__wrapped__(*args, **kwds)
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _

args = (<tensorflow.python.data.ops.iterator_ops.OwnedIterator object at 0x7f5e0c161f90>,), kwargs = {}

    def wrapper(*args, **kwargs):
      """Calls a converted version of original_func."""
      # TODO(mdan): Push this block higher in tf.function's call stack.
      try:
        return autograph.converted_call(
            original_func,
            args,
            kwargs,
            options=autograph.ConversionOptions(
                recursive=True,
                optional_features=autograph_options,
                user_requested=True,
            ))
      except Exception as e:  # pylint:disable=broad-except
        if hasattr(e, "ag_error_metadata"):
>         raise e.ag_error_metadata.to_exception(e)
E         tensorflow.python.framework.errors_impl.OperatorNotAllowedInGraphError: in user code:
E
E             /opt/conda/lib/python3.7/site-packages/tensorflow/python/keras/engine/training.py:503 train_function  *
E                 outputs = self.distribute_strategy.run(
E             /opt/conda/lib/python3.7/site-packages/tensorflow/python/distribute/distribute_lib.py:951 run  **
E                 return self._extended.call_for_each_replica(fn, args=args, kwargs=kwargs)
E             /opt/conda/lib/python3.7/site-packages/tensorflow/python/distribute/distribute_lib.py:2290 call_for_each_replica
E                 return self._call_for_each_replica(fn, args, kwargs)
E             /opt/conda/lib/python3.7/site-packages/tensorflow/python/distribute/distribute_lib.py:2649 _call_for_each_replica
E                 return fn(*args, **kwargs)
E             /opt/conda/lib/python3.7/site-packages/tensorflow/python/keras/engine/training.py:475 train_step  **
E                 self.compiled_metrics.update_state(y, y_pred, sample_weight)
E             /opt/conda/lib/python3.7/site-packages/tensorflow/python/keras/engine/compile_utils.py:406 update_state
E                 metric_obj.update_state(y_t, y_p)
E             /opt/conda/lib/python3.7/site-packages/tensorflow/python/keras/utils/metrics_utils.py:90 decorated
E                 update_op = update_state_fn(*args, **kwargs)
E             /projects/addons/tensorflow_addons/metrics/cohens_kappa.py:140 update_state
E                 return self._update(y_true, y_pred, sample_weight)
E             /projects/addons/tensorflow_addons/metrics/cohens_kappa.py:154 _update_multi_class_model
E                 if tf.rank(y_pred) > 1:
E             /opt/conda/lib/python3.7/site-packages/tensorflow/python/framework/ops.py:778 __bool__
E                 self._disallow_bool_casting()
E             /opt/conda/lib/python3.7/site-packages/tensorflow/python/framework/ops.py:545 _disallow_bool_casting
E                 "using a `tf.Tensor` as a Python `bool`")
E             /opt/conda/lib/python3.7/site-packages/tensorflow/python/framework/ops.py:532 _disallow_when_autograph_enabled
E                 " decorating it directly with @tf.function.".format(task))
E
E             OperatorNotAllowedInGraphError: using a `tf.Tensor` as a Python `bool` is not allowed: AutoGraph did not convert this function. Try decorating it directly with @tf.function.

/opt/conda/lib/python3.7/site-packages/tensorflow/python/framework/func_graph.py:968: OperatorNotAllowedInGraphError
```




### Me fixing the bug:

![](https://i.pinimg.com/originals/f4/95/e6/f495e6e0feb102507fd548aa6d74e6f5.jpg)


There some dark forces at work. Adding the `@tf.function` to `self.update_state` make things work for tf2.2.0rc1 but not for 2.1.0. I had to use `@tf.function` only on the problematic part.