### PR TITLE
Test gather tree in eager mode only because it's a custom op

### DIFF
--- a/tensorflow_addons/seq2seq/beam_search_ops_test.py
+++ b/tensorflow_addons/seq2seq/beam_search_ops_test.py
@@ -28,29 +28,27 @@ def _transpose_batch_time(x):
     return np.transpose(x, [1, 0, 2]).astype(np.int32)
 
 
-class GatherTreeTest(tf.test.TestCase):
-    def testGatherTreeOne(self):
-        # (max_time = 4, batch_size = 1, beams = 3)
-        end_token = 10
-        step_ids = _transpose_batch_time(
-            [[[1, 2, 3], [4, 5, 6], [7, 8, 9], [-1, -1, -1]]]
-        )
-        parent_ids = _transpose_batch_time(
-            [[[0, 0, 0], [0, 1, 1], [2, 1, 2], [-1, -1, -1]]]
-        )
-        max_sequence_lengths = [3]
-        expected_result = _transpose_batch_time(
-            [[[2, 2, 2], [6, 5, 6], [7, 8, 9], [10, 10, 10]]]
-        )
-        beams = gather_tree(
-            step_ids=step_ids,
-            parent_ids=parent_ids,
-            max_sequence_lengths=max_sequence_lengths,
-            end_token=end_token,
-        )
-        with self.cached_session(use_gpu=True):
-            self.assertAllEqual(expected_result, self.evaluate(beams))
+def test_gather_tree_one():
+    # (max_time = 4, batch_size = 1, beams = 3)
+    end_token = 10
+    step_ids = _transpose_batch_time([[[1, 2, 3], [4, 5, 6], [7, 8, 9], [-1, -1, -1]]])
+    parent_ids = _transpose_batch_time(
+        [[[0, 0, 0], [0, 1, 1], [2, 1, 2], [-1, -1, -1]]]
+    )
+    max_sequence_lengths = [3]
+    expected_result = _transpose_batch_time(
+        [[[2, 2, 2], [6, 5, 6], [7, 8, 9], [10, 10, 10]]]
+    )
+    beams = gather_tree(
+        step_ids=step_ids,
+        parent_ids=parent_ids,
+        max_sequence_lengths=max_sequence_lengths,
+        end_token=end_token,
+    )
+    np.testing.assert_equal(expected_result, beams.numpy())
 
+
+class GatherTreeTest(tf.test.TestCase):
     def testBadParentValuesOnCPU(self):
         # (batch_size = 1, max_time = 4, beams = 3)
         # bad parent in beam 1 time 1


### PR DESCRIPTION
We only need to run this test in eager mode, it makes it more readable too.