### PR TITLE
Update SequenceLoss for TensorFlow 2.2 compatibility

### DIFF
--- a/tensorflow_addons/seq2seq/loss.py
+++ b/tensorflow_addons/seq2seq/loss.py
@@ -196,8 +196,9 @@ class SequenceLoss(tf.keras.losses.Loss):
         # However, prior to TensorFlow 2.2 tf.keras will actually invokes "call"
         # when the loss object has the "reduction" attribute. So we remove it in
         # this case.
-        if (LooseVersion(tf.__version__) < LooseVersion("2.2.0")
-            and hasattr(self, "reduction")):
+        if LooseVersion(tf.__version__) < LooseVersion("2.2.0") and hasattr(
+            self, "reduction"
+        ):
             delattr(self, "reduction")
 
     def __call__(self, y_true, y_pred, sample_weight=None):

--- a/tensorflow_addons/seq2seq/loss.py
+++ b/tensorflow_addons/seq2seq/loss.py
@@ -14,6 +14,8 @@
 # ==============================================================================
 """Seq2seq loss operations for use in sequence models."""
 
+from distutils.version import LooseVersion
+
 import tensorflow as tf
 from tensorflow_addons.utils.types import TensorLike
 
@@ -182,16 +184,20 @@ class SequenceLoss(tf.keras.losses.Loss):
         softmax_loss_function: Optional[Callable] = None,
         name: Optional[str] = None,
     ):
-        super().__init__(name=name)
+        super().__init__(reduction=tf.keras.losses.Reduction.NONE, name=name)
         self.average_across_timesteps = average_across_timesteps
         self.average_across_batch = average_across_batch
         self.sum_over_timesteps = sum_over_timesteps
         self.sum_over_batch = sum_over_batch
         self.softmax_loss_function = softmax_loss_function
 
-        # Delete the reduction attribute to inform Keras that it
-        # should call this class by the __call__(...) method.
-        if hasattr(self, "reduction"):
+        # We want tf.keras to call the "__call__" method so that we have access
+        # to "sample_weight" and can implement the custom loss reduction.
+        # However, prior to TensorFlow 2.2 tf.keras will actually invokes "call"
+        # when the loss object has the "reduction" attribute. So we remove it in
+        # this case.
+        if (LooseVersion(tf.__version__) < LooseVersion("2.2.0")
+            and hasattr(self, "reduction")):
             delattr(self, "reduction")
 
     def __call__(self, y_true, y_pred, sample_weight=None):

--- a/tensorflow_addons/seq2seq/loss_test.py
+++ b/tensorflow_addons/seq2seq/loss_test.py
@@ -267,7 +267,6 @@ def test_ambiguous_order():
         seq_loss(targets, logits, weights).numpy()
 
 
-@pytest.mark.xfail(tf.__version__ == "2.2.0-rc1", reason="TODO: Fix this test")
 @pytest.mark.usefixtures("maybe_run_functions_eagerly")
 def test_keras_compatibility():
     """To test the compatibility of SequenceLoss with Keras's built-in


### PR DESCRIPTION
For previous versions, we removed the `reduction` attribute to force tf.keras to call the main `__call__` method. Otherwise, it calls the `call` method where we have no way of controlling the reduction logic.

In 2.2, tf.keras has a new way of dealing with loss objects (see the `LossContainer` class). It now always calls `__call__` and requires the `reduction` attribute to exist.

This new logic is only enabled for V2 execution mode so this commit also disables the deprecated V1 graph mode for this test.

Related to #1320.

Note: this change is only compatible with TensorFlow 2.2 so I'm opening a draft PR for now.