### PR TITLE
Relax gradient assertion for mish activation

### DIFF
--- a/tensorflow_addons/activations/mish_test.py
+++ b/tensorflow_addons/activations/mish_test.py
@@ -49,8 +49,6 @@ class MishTest(tf.test.TestCase, parameterized.TestCase):
 
 @pytest.mark.parametrize("dtype", [np.float32, np.float64])
 def test_same_as_py_func(dtype):
-    if dtype == np.float32 and tf.__version__ == "2.2.0-rc1":
-        pytest.skip("TODO: fix for tf 2.2.0")
     np.random.seed(1234)
     for _ in range(20):
         verify_funcs_are_equivalent(dtype)
@@ -70,7 +68,7 @@ def verify_funcs_are_equivalent(dtype):
     grad_native = t.gradient(y_native, x)
     grad_py = t.gradient(y_py, x)
 
-    test_utils.assert_allclose_according_to_type(grad_native, grad_py)
+    test_utils.assert_allclose_according_to_type(grad_native, grad_py, atol=1e-5)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Dug into this a bit and found that this check could conceivably fail for TF2.1. It does empirically appear more common on TF2.2, and I don't have an answer about what could have changed. As previously discussed we have no guarantee the py gradient should behave the exact same at this precision:
https://github.com/tensorflow/addons/issues/1220#issuecomment-595871107

Part of #1320 