### PR TITLE
Added multiple useful fixtures.

### DIFF
--- a/tensorflow_addons/conftest.py
+++ b/tensorflow_addons/conftest.py
@@ -1,4 +1,6 @@
 from tensorflow_addons.utils.test_utils import maybe_run_functions_eagerly  # noqa: F401
+from tensorflow_addons.utils.test_utils import cpu_and_gpu  # noqa: F401
+from tensorflow_addons.utils.test_utils import data_format  # noqa: F401
 
 # fixtures present in this file will be available
 # when running tests and can be referenced with strings

--- a/tensorflow_addons/utils/test_utils.py
+++ b/tensorflow_addons/utils/test_utils.py
@@ -177,6 +177,23 @@ def maybe_run_functions_eagerly(request):
     request.addfinalizer(finalizer)
 
 
+@pytest.fixture(scope="function", params=["CPU", "GPU"])
+def cpu_and_gpu(request):
+    if request.param == "CPU":
+        with tf.device("/device:CPU:0"):
+            yield
+    else:
+        if not tf.test.is_gpu_available():
+            pytest.skip("GPU is not available.")
+        with tf.device("/device:GPU:0"):
+            yield
+
+
+@pytest.fixture(scope="function", params=["channels_first", "channels_last"])
+def data_format(request):
+    return request.param
+
+
 def assert_allclose_according_to_type(
     a,
     b,


### PR DESCRIPTION
I added two fixtures, one to run the test two times, one with CPU and one with GPU.

The other fixure I added is when a test is needed to run multiple times with `channels_first` and `channels_last`.

To use fixtures, either use `@pytest.mark.usefixture` for fixtures that don't provide parameters (like gpu and cpu) or you can use directly the name of the function as parameter for the test. Here `data_format`.

More about fixtures: https://docs.pytest.org/en/latest/fixture.html