### PR TITLE
add dtypes to blend

### DIFF
--- a/tensorflow_addons/image/compose_ops.py
+++ b/tensorflow_addons/image/compose_ops.py
@@ -30,12 +30,16 @@ def blend(image1: TensorLike, image2: TensorLike, factor: Number) -> tf.Tensor:
   between 0 and 255.
 
   Args:
-    image1: An image Tensor of type uint8.
-    image2: An image Tensor of type uint8.
-    factor: A floating point value above 0.0.
+    image1: An image Tensor of shape (num_rows, num_columns,
+        num_channels) (HWC), or (num_rows, num_columns) (HW),
+        or (num_channels, num_rows, num_columns).
+    image2: An image Tensor of shape (num_rows, num_columns,
+        num_channels) (HWC), or (num_rows, num_columns) (HW),
+        or (num_channels, num_rows, num_columns).
+    factor: A floating point value or Tensor of type tf.float32 above 0.0.
 
   Returns:
-    A blended image Tensor of type uint8.
+    A blended image Tensor of tf.float32.
 
   """
     with tf.name_scope("blend"):

--- a/tensorflow_addons/image/compose_ops.py
+++ b/tensorflow_addons/image/compose_ops.py
@@ -16,10 +16,10 @@
 
 import tensorflow as tf
 
-from tensorflow_addons.utils.types import TensorLike
+from tensorflow_addons.utils.types import TensorLike, Number
 
 
-def blend(image1: TensorLike, image2: TensorLike, factor: float) -> TensorLike:
+def blend(image1: TensorLike, image2: TensorLike, factor: Number) -> tf.Tensor:
     """Blend image1 and image2 using 'factor'.
 
   Factor can be above 0.0.  A value of 0.0 means only image1 is used.
@@ -39,8 +39,6 @@ def blend(image1: TensorLike, image2: TensorLike, factor: float) -> TensorLike:
 
   """
     with tf.name_scope("blend"):
-        if image1.dtype != tf.uint8 or image2.dtype != tf.uint8:
-            raise ValueError("Images must have dtype tf.uint8")
 
         if factor == 0.0:
             return tf.convert_to_tensor(image1)
@@ -60,10 +58,10 @@ def blend(image1: TensorLike, image2: TensorLike, factor: float) -> TensorLike:
         if factor > 0.0 and factor < 1.0:
             # Interpolation means we always stay within 0 and 255.
             temp = tf.round(temp)
-            return tf.cast(temp, tf.dtypes.uint8)
+            return temp
 
         # Extrapolate:
         #
         # We need to clip and then cast.
         temp = tf.round(tf.clip_by_value(temp, 0.0, 255.0))
-        return tf.cast(temp, tf.dtypes.uint8)
+        return temp

--- a/tensorflow_addons/image/compose_ops_test.py
+++ b/tensorflow_addons/image/compose_ops_test.py
@@ -44,6 +44,7 @@ def blend_np(image1, image2, factor):
     return temp
 
 
+@pytest.mark.usefixtures("maybe_run_functions_eagerly")
 @pytest.mark.parametrize("dtype", _DTYPES)
 def test_blend(dtype):
     image1 = tf.constant(

--- a/tensorflow_addons/image/compose_ops_test.py
+++ b/tensorflow_addons/image/compose_ops_test.py
@@ -73,6 +73,7 @@ def test_blend(dtype):
     np.random.seed(0)
     image1 = np.random.randint(0, 255, (3, 5, 5), np.uint8)
     image2 = np.random.randint(0, 255, (3, 5, 5), np.uint8)
+    tf.random.set_seed(0)
     factor = tf.random.uniform(shape=[], maxval=1, dtype=tf.dtypes.float32, seed=0)
     blended = compose_ops.blend(
         tf.convert_to_tensor(image1), tf.convert_to_tensor(image2), factor

--- a/tensorflow_addons/image/compose_ops_test.py
+++ b/tensorflow_addons/image/compose_ops_test.py
@@ -23,6 +23,11 @@ from tensorflow_addons.image import compose_ops
 
 _DTYPES = {
     tf.dtypes.uint8,
+    tf.dtypes.int32,
+    tf.dtypes.int64,
+    tf.dtypes.float16,
+    tf.dtypes.float32,
+    tf.dtypes.float64,
 }
 
 
@@ -34,9 +39,9 @@ def blend_np(image1, image2, factor):
     temp = image1 + scaled
     if factor >= 0.0 and factor <= 1.0:
         temp = np.round(temp)
-        return temp.astype("uint8")
+        return temp
     temp = np.round(np.clip(temp, 0.0, 255.0))
-    return temp.astype("uint8")
+    return temp
 
 
 @pytest.mark.parametrize("dtype", _DTYPES)
@@ -64,12 +69,14 @@ def test_blend(dtype):
         ],
     )
 
+    np.random.seed(0)
     image1 = np.random.randint(0, 255, (4, 4, 3), np.uint8)
     image2 = np.random.randint(0, 255, (4, 4, 3), np.uint8)
+    factor = tf.random.uniform(shape=[], maxval=1, dtype=tf.dtypes.float32, seed=0)
     blended = compose_ops.blend(
-        tf.convert_to_tensor(image1), tf.convert_to_tensor(image2), 0.35
+        tf.convert_to_tensor(image1), tf.convert_to_tensor(image2), factor
     ).numpy()
-    expected = blend_np(image1, image2, 0.35)
+    expected = blend_np(image1, image2, factor.numpy())
     np.testing.assert_equal(blended, expected)
 
 

--- a/tensorflow_addons/image/compose_ops_test.py
+++ b/tensorflow_addons/image/compose_ops_test.py
@@ -71,14 +71,15 @@ def test_blend(dtype):
     )
 
     np.random.seed(0)
-    image1 = np.random.randint(0, 255, (4, 4, 3), np.uint8)
-    image2 = np.random.randint(0, 255, (4, 4, 3), np.uint8)
+    image1 = np.random.randint(0, 255, (3, 5, 5), np.uint8)
+    image2 = np.random.randint(0, 255, (3, 5, 5), np.uint8)
     factor = tf.random.uniform(shape=[], maxval=1, dtype=tf.dtypes.float32, seed=0)
     blended = compose_ops.blend(
         tf.convert_to_tensor(image1), tf.convert_to_tensor(image2), factor
     ).numpy()
     expected = blend_np(image1, image2, factor.numpy())
     np.testing.assert_equal(blended, expected)
+    assert blended.dtype == expected.dtype
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Small change so operations using `blend` don't have to cast their results to `tf.uint8` before using it. (#1452)