### PR TITLE
Using buildkit all the time when building docker images.

### DIFF
--- a/tensorflow_addons/losses/contrastive_test.py
+++ b/tensorflow_addons/losses/contrastive_test.py
@@ -113,7 +113,7 @@ def test_scalar_weighted():
     # Reduced loss = (0.81 + 0.49 + 1.69 + 0.49 + 0 + 0.25) * 6 / 6
     #              = 3.73
 
-    np.testing.assert_allclose(loss, 3.73)
+    np.testing.assert_allclose(loss, 3.73, atol=1e-6, rtol=1e-6)
 
 
 def test_zero_weighted():

--- a/tools/pre-commit.sh
+++ b/tools/pre-commit.sh
@@ -7,10 +7,7 @@
 
 set -e
 
-if [ "$DOCKER_BUILDKIT" == "" ]; then
-  export DOCKER_BUILDKIT=1
-fi
-
+export DOCKER_BUILDKIT=1
 docker build -t tf_addons_formatting -f tools/docker/pre-commit.Dockerfile .
 
 export MSYS_NO_PATHCONV=1

--- a/tools/run_build.sh
+++ b/tools/run_build.sh
@@ -4,8 +4,5 @@
 # DOCKER_BUILDKIT=0 bash tools/run_build.sh
 set -e
 
-if [ "$DOCKER_BUILDKIT" == "" ]; then
-  export DOCKER_BUILDKIT=1
-fi
-
+export DOCKER_BUILDKIT=1
 docker build -f tools/docker/sanity_check.Dockerfile --target=${1} ./

--- a/tools/run_cpu_tests.sh
+++ b/tools/run_cpu_tests.sh
@@ -1,11 +1,6 @@
 # usage: bash tools/run_cpu_tests.sh
-# by default uses docker buildkit.
-# to disable it:
-# DOCKER_BUILDKIT=0 bash tools/run_cpu_tests.sh
+
 set -e
 
-if [ "$DOCKER_BUILDKIT" == "" ]; then
-  export DOCKER_BUILDKIT=1
-fi
-
+export DOCKER_BUILDKIT=1
 docker build --progress=plain -f tools/docker/cpu_tests.Dockerfile ./

--- a/tools/run_google_cloud_tests.sh
+++ b/tools/run_google_cloud_tests.sh
@@ -1,3 +1,4 @@
 set -x -e
 
+
 DOCKER_BUILDKIT=0 bash tools/run_gpu_tests.sh

--- a/tools/run_google_cloud_tests.sh
+++ b/tools/run_google_cloud_tests.sh
@@ -1,4 +1,3 @@
 set -x -e
 
-
-DOCKER_BUILDKIT=1 bash tools/run_gpu_tests.sh
+bash tools/run_gpu_tests.sh

--- a/tools/run_google_cloud_tests.sh
+++ b/tools/run_google_cloud_tests.sh
@@ -1,4 +1,4 @@
 set -x -e
 
 
-DOCKER_BUILDKIT=0 bash tools/run_gpu_tests.sh
+DOCKER_BUILDKIT=1 bash tools/run_gpu_tests.sh

--- a/tools/run_gpu_tests.sh
+++ b/tools/run_gpu_tests.sh
@@ -1,13 +1,7 @@
 # usage: bash tools/run_gpu_tests.sh
-# by default uses docker buildkit.
-# to disable it:
-# DOCKER_BUILDKIT=0 bash tools/run_gpu_tests.sh
 
 set -x -e
 
-if [ "$DOCKER_BUILDKIT" == "" ]; then
-  export DOCKER_BUILDKIT=1
-fi
-
+export DOCKER_BUILDKIT=1
 docker build -f tools/docker/gpu_tests.Dockerfile -t tfa_gpu_tests ./
 docker run --rm -t --runtime=nvidia tfa_gpu_tests

--- a/tools/run_sanity_check.sh
+++ b/tools/run_sanity_check.sh
@@ -1,11 +1,6 @@
 # usage: bash tools/run_sanity_check.sh
-# by default uses docker buildkit.
-# to disable it:
-# DOCKER_BUILDKIT=0 bash tools/run_sanity_check.sh
+
 set -e
 
-if [ "$DOCKER_BUILDKIT" == "" ]; then
-  export DOCKER_BUILDKIT=1
-fi
-
+export DOCKER_BUILDKIT=1
 docker build -f tools/docker/sanity_check.Dockerfile ./


### PR DESCRIPTION
The Kokoro team has upgraded docker. We can now use buildkit. This should come in handy to merge the CI code for CPU and gpu.