### PR TITLE
Fix unhashable decay_var_list

### DIFF
--- a/tensorflow_addons/optimizers/weight_decay_optimizers.py
+++ b/tensorflow_addons/optimizers/weight_decay_optimizers.py
@@ -26,7 +26,7 @@ def _ref(var):
     if release < "2.0.0":
         return var
     else:
-        return var.ref() if hasattr(var,"ref") else var.experimental_ref()
+        return var.ref() if hasattr(var, "ref") else var.experimental_ref()
 
 
 class DecoupledWeightDecayExtension:
@@ -125,7 +125,9 @@ class DecoupledWeightDecayExtension:
         Raises:
             ValueError: If some of the variables are not `Variable` objects.
         """
-        self._decay_var_list = set([_ref(v) for v in decay_var_list]) if decay_var_list else False
+        self._decay_var_list = (
+            set([_ref(v) for v in decay_var_list]) if decay_var_list else False
+        )
         return super().minimize(loss, var_list=var_list, grad_loss=grad_loss, name=name)
 
     def apply_gradients(self, grads_and_vars, name=None, decay_var_list=None):
@@ -146,7 +148,9 @@ class DecoupledWeightDecayExtension:
             TypeError: If `grads_and_vars` is malformed.
             ValueError: If none of the variables have gradients.
         """
-        self._decay_var_list = set([_ref(v) for v in decay_var_list]) if decay_var_list else False
+        self._decay_var_list = (
+            set([_ref(v) for v in decay_var_list]) if decay_var_list else False
+        )
         return super().apply_gradients(grads_and_vars, name=name)
 
     def _decay_weights_op(self, var):

--- a/tensorflow_addons/optimizers/weight_decay_optimizers.py
+++ b/tensorflow_addons/optimizers/weight_decay_optimizers.py
@@ -22,11 +22,7 @@ from typing import Union, Callable, Type
 
 
 def _ref(var):
-    release = tf.__version__[:5]
-    if release < "2.0.0":
-        return var
-    else:
-        return var.ref() if hasattr(var, "ref") else var.experimental_ref()
+    return var.ref() if hasattr(var, "ref") else var.experimental_ref()
 
 
 class DecoupledWeightDecayExtension:

--- a/tensorflow_addons/optimizers/weight_decay_optimizers_test.py
+++ b/tensorflow_addons/optimizers/weight_decay_optimizers_test.py
@@ -35,7 +35,14 @@ class OptimizerTestBase(tf.test.TestCase):
     weight_decay_optimizers_test for an example.
     """
 
-    def doTest(self, optimizer, update_fn, do_sparse=False, do_decay_var_list=False, **optimizer_kwargs):
+    def doTest(
+        self,
+        optimizer,
+        update_fn,
+        do_sparse=False,
+        do_decay_var_list=False,
+        **optimizer_kwargs
+    ):
         """The major test function.
 
         Args:
@@ -90,7 +97,9 @@ class OptimizerTestBase(tf.test.TestCase):
             # Validate initial values.
             if not tf.executing_eagerly():
                 if do_decay_var_list:
-                    update = opt.apply_gradients(zip([grads0, grads1], [var0, var1]), decay_var_list=[var0, var1])
+                    update = opt.apply_gradients(
+                        zip([grads0, grads1], [var0, var1]), decay_var_list=[var0, var1]
+                    )
                 else:
                     update = opt.apply_gradients(zip([grads0, grads1], [var0, var1]))
                 self.evaluate(tf.compat.v1.global_variables_initializer())
@@ -101,7 +110,10 @@ class OptimizerTestBase(tf.test.TestCase):
             for _ in range(3):
                 if tf.executing_eagerly():
                     if do_decay_var_list:
-                        opt.apply_gradients(zip([grads0, grads1], [var0, var1]), decay_var_list=[var0, var1])
+                        opt.apply_gradients(
+                            zip([grads0, grads1], [var0, var1]),
+                            decay_var_list=[var0, var1],
+                        )
                     else:
                         opt.apply_gradients(zip([grads0, grads1], [var0, var1]))
                 else:


### PR DESCRIPTION
Fixes an error where the list of decay variables is unhashable because they are compared without var.ref() or var.experimental_ref(). This patch is forward compatible with TF 2.2.0.