### PR TITLE
Use a minimal docker image to build wheels. Fix the master branch build.

### DIFF
--- a/tools/docker/build_wheel.Dockerfile
+++ b/tools/docker/build_wheel.Dockerfile
@@ -9,8 +9,9 @@ RUN python$PY_VERSION -m pip install --upgrade pip setuptools auditwheel==2.0.0
 
 COPY tools/install_deps/ /install_deps
 ARG TF_VERSION
-RUN python$PY_VERSION -m pip install tensorflow==$TF_VERSION && \
-    python$PY_VERSION -m pip install -r /install_deps/pytest.txt
+RUN python$PY_VERSION -m pip install \
+        tensorflow==$TF_VERSION \
+        -r /install_deps/pytest.txt
 
 COPY requirements.txt .
 RUN python$PY_VERSION -m pip install -r requirements.txt

--- a/tools/docker/build_wheel.Dockerfile
+++ b/tools/docker/build_wheel.Dockerfile
@@ -2,6 +2,9 @@
 ARG TF_VERSION
 FROM tensorflow/tensorflow:2.1.0-custom-op-gpu-ubuntu16 as make_wheel
 
+# Remove pre-installed packages on python2 to free up disk space
+RUN pip uninstall -y tensorflow tensorflow scipy pandas numpy scikit-learn
+
 RUN apt-get update && apt-get install patchelf
 
 ARG PY_VERSION

--- a/tools/docker/build_wheel.Dockerfile
+++ b/tools/docker/build_wheel.Dockerfile
@@ -1,9 +1,6 @@
 #syntax=docker/dockerfile:1.1.5-experimental
 ARG TF_VERSION
-FROM tensorflow/tensorflow:2.1.0-custom-op-gpu-ubuntu16 as make_wheel
-
-# Remove pre-installed packages on python2 to free up disk space
-RUN python2 -m pip uninstall -y tensorflow tensorboard scipy pandas numpy scikit-learn
+FROM seanpmorgan/tensorflow:2.1.0-custom-op-gpu-ubuntu16-minimal as make_wheel
 
 RUN apt-get update && apt-get install patchelf
 
@@ -12,8 +9,8 @@ RUN python$PY_VERSION -m pip install --upgrade pip setuptools auditwheel==2.0.0
 
 COPY tools/install_deps/ /install_deps
 ARG TF_VERSION
-RUN python$PY_VERSION -m pip install --no-cache-dir tensorflow==$TF_VERSION && \
-    python$PY_VERSION -m pip install --no-cache-dir -r /install_deps/pytest.txt
+RUN python$PY_VERSION -m pip install tensorflow==$TF_VERSION && \
+    python$PY_VERSION -m pip install -r /install_deps/pytest.txt
 
 COPY requirements.txt .
 RUN python$PY_VERSION -m pip install -r requirements.txt

--- a/tools/docker/build_wheel.Dockerfile
+++ b/tools/docker/build_wheel.Dockerfile
@@ -3,7 +3,7 @@ ARG TF_VERSION
 FROM tensorflow/tensorflow:2.1.0-custom-op-gpu-ubuntu16 as make_wheel
 
 # Remove pre-installed packages on python2 to free up disk space
-RUN pip uninstall -y tensorflow tensorflow scipy pandas numpy scikit-learn
+RUN python2 -m pip uninstall -y tensorflow tensorboard scipy pandas numpy scikit-learn
 
 RUN apt-get update && apt-get install patchelf
 

--- a/tools/docker/build_wheel.Dockerfile
+++ b/tools/docker/build_wheel.Dockerfile
@@ -9,9 +9,8 @@ RUN python$PY_VERSION -m pip install --upgrade pip setuptools auditwheel==2.0.0
 
 COPY tools/install_deps/ /install_deps
 ARG TF_VERSION
-RUN python$PY_VERSION -m pip install --no-cache-dir \
-        tensorflow==$TF_VERSION \
-        -r /install_deps/pytest.txt
+RUN python$PY_VERSION -m pip install --no-cache-dir tensorflow==$TF_VERSION && \
+    python$PY_VERSION -m pip install --no-cache-dir -r /install_deps/pytest.txt
 
 COPY requirements.txt .
 RUN python$PY_VERSION -m pip install -r requirements.txt

--- a/tools/docker/build_wheel.Dockerfile
+++ b/tools/docker/build_wheel.Dockerfile
@@ -9,7 +9,7 @@ RUN python$PY_VERSION -m pip install --upgrade pip setuptools auditwheel==2.0.0
 
 COPY tools/install_deps/ /install_deps
 ARG TF_VERSION
-RUN python$PY_VERSION -m pip install \
+RUN python$PY_VERSION -m pip install --no-cache-dir \
         tensorflow==$TF_VERSION \
         -r /install_deps/pytest.txt
 


### PR DESCRIPTION
@seanpmorgan 

That's still annoying because I wanted to add a `--mount=type=cache,dest=/root/.cache/pip` but It seems like it won't be possible.