### PR TITLE
Fix the flaky test in wrapper_test.py

### DIFF
--- a/tensorflow_addons/layers/wrappers_test.py
+++ b/tensorflow_addons/layers/wrappers_test.py
@@ -172,7 +172,7 @@ def test_forward_pass(base_layer, input_shape):
     base_output = base_layer(sample_data)
     wn_layer = wrappers.WeightNormalization(base_layer, False)
     wn_output = wn_layer(sample_data)
-    np.testing.assert_allclose(base_output, wn_output)
+    np.testing.assert_allclose(base_output, wn_output, rtol=1e-6, atol=1e-6)
 
 
 @pytest.mark.usefixtures("maybe_run_functions_eagerly")


### PR DESCRIPTION
One of our test has become flaky after we increased the precision required. The default `atol` and `rtol` of `tf.test.TestCase.assertAllClose` and `np.testing.assert_allclose` are not the same. This  pull request fixes this.