### PR TITLE
Pin pypi github action

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -126,7 +126,7 @@ jobs:
           set -e -x
           ls -la dist/
           sha256sum dist/*.whl
-      - uses: pypa/gh-action-pypi-publish@master
+      - uses: pypa/gh-action-pypi-publish@v1.1.0
         if: (github.event_name == 'push' && github.ref == 'refs/heads/master') || github.event_name == 'release'
         with:
           user: __token__


### PR DESCRIPTION
We've been getting a lot of intermittent failures from our nightly publishing:
https://github.com/tensorflow/addons/runs/553687744?check_suite_focus=true

I'm not sure this is the cause since we're getting a 502 error, but still a better practice to pin this action version.