### PR TITLE
Do not fail fast for pypi upload

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -115,6 +115,7 @@ jobs:
       matrix:
         os: ['macOS', 'Windows', 'Linux']
         py-version: ['3.5', '3.6', '3.7']
+        fail-fast: false
     steps:
       - uses: actions/download-artifact@v1
         if: github.event_name != 'pull_request' || matrix.py-version == env.OLDEST_PY_VERSION

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -115,7 +115,7 @@ jobs:
       matrix:
         os: ['macOS', 'Windows', 'Linux']
         py-version: ['3.5', '3.6', '3.7']
-        fail-fast: false
+      fail-fast: false
     steps:
       - uses: actions/download-artifact@v1
         if: github.event_name != 'pull_request' || matrix.py-version == env.OLDEST_PY_VERSION


### PR DESCRIPTION
Given #1536 and the non-zero chance that there is a network issue when we make a release I believe this is a good thing to add. 

For example if we make a release and one or more uploads fails. We'd be unable to simply re-run the job because whatever uploads did work the first time would fail for the package already existing on pypi. The only other work around I would see for this is bumping a patch version or commenting out some of the uploads.