### PR TITLE
Add **kwargs to apply_gradients in weight_decay_optimizers.

### DIFF
--- a/tensorflow_addons/optimizers/weight_decay_optimizers.py
+++ b/tensorflow_addons/optimizers/weight_decay_optimizers.py
@@ -126,7 +126,7 @@ class DecoupledWeightDecayExtension:
         )
         return super().minimize(loss, var_list=var_list, grad_loss=grad_loss, name=name)
 
-    def apply_gradients(self, grads_and_vars, name=None, decay_var_list=None):
+    def apply_gradients(self, grads_and_vars, name=None, decay_var_list=None, **kwargs):
         """Apply gradients to variables.
 
         This is the second part of `minimize()`. It returns an `Operation` that
@@ -138,6 +138,9 @@ class DecoupledWeightDecayExtension:
                 name passed to the `Optimizer` constructor.
             decay_var_list: Optional list of variables to be decayed. Defaults
                 to all variables in var_list.
+            **kwargs: Additional arguments to pass to the base optimizer's
+                apply_gradient method, e.g., TF2.2 added an argument
+                `all_reduce_sum_gradients`.
         Returns:
             An `Operation` that applies the specified gradients.
         Raises:
@@ -147,7 +150,7 @@ class DecoupledWeightDecayExtension:
         self._decay_var_list = (
             set([_ref(v) for v in decay_var_list]) if decay_var_list else False
         )
-        return super().apply_gradients(grads_and_vars, name=name)
+        return super().apply_gradients(grads_and_vars, name=name, **kwargs)
 
     def _decay_weights_op(self, var):
         if not self._decay_var_list or _ref(var) in self._decay_var_list:

--- a/tensorflow_addons/optimizers/weight_decay_optimizers_test.py
+++ b/tensorflow_addons/optimizers/weight_decay_optimizers_test.py
@@ -273,6 +273,15 @@ class AdamWTest(OptimizerTestBase):
             weight_decay=WEIGHT_DECAY,
         )
 
+    def testKerasFit(self):
+        """Check if calling model.fit works."""
+        model = tf.keras.models.Sequential([tf.keras.layers.Dense(2)])
+        loss = tf.keras.losses.SparseCategoricalCrossentropy(from_logits=True)
+        optimizer = self.optimizer(learning_rate=1e-4, weight_decay=1e-4)
+        model.compile(optimizer=optimizer, loss=loss, metrics=["accuracy"])
+        X, y = np.random.uniform(size=(2, 4, 1))
+        model.fit(X, y, epochs=1)
+
 
 @test_utils.run_all_in_graph_and_eager_modes
 class SGDWTest(OptimizerTestBase):


### PR DESCRIPTION
This is a quick fix to restore compatibility with TF 2.2 which adds a new keyword argument.
See #1267 for the discussion.

@gabrieldemarmiesse, @seanpmorgan  :)

Closes #1267