### PR TITLE
Fix TQDM Progress bar in TF 2.2.0

### DIFF
--- a/tensorflow_addons/callbacks/tests/tqdm_progress_bar_test.py
+++ b/tensorflow_addons/callbacks/tests/tqdm_progress_bar_test.py
@@ -1,4 +1,3 @@
-from distutils.version import LooseVersion
 import re
 
 import numpy as np

--- a/tensorflow_addons/callbacks/tests/tqdm_progress_bar_test.py
+++ b/tensorflow_addons/callbacks/tests/tqdm_progress_bar_test.py
@@ -8,12 +8,6 @@ import tensorflow as tf
 import tensorflow_addons as tfa
 
 
-pytestmark = pytest.mark.xfail(
-    LooseVersion(tf.__version__) >= LooseVersion("2.2.0"),
-    reason="TODO: Fixeme See #1495",
-)
-
-
 def get_data_and_model():
     x = np.random.random((5, 1))
     y = np.random.randint(0, 2, (5, 1), dtype=np.int)

--- a/tensorflow_addons/callbacks/tests/tqdm_progress_bar_test.py
+++ b/tensorflow_addons/callbacks/tests/tqdm_progress_bar_test.py
@@ -70,7 +70,7 @@ def test_tqdm_progress_bar_epoch_bar_format_missing_parameter(capsys):
     capsys.readouterr()  # flush the buffer
     model.fit(x, y, batch_size=4, epochs=2, verbose=0, callbacks=[pb])
     fit_stderr = capsys.readouterr().err
-    assert "/5" not in fit_stderr
+    assert "/3" not in fit_stderr
 
 
 def test_tqdm_progress_bar_metrics_format(capsys):

--- a/tensorflow_addons/callbacks/tests/tqdm_progress_bar_test.py
+++ b/tensorflow_addons/callbacks/tests/tqdm_progress_bar_test.py
@@ -9,8 +9,8 @@ import tensorflow_addons as tfa
 
 
 def get_data_and_model():
-    x = np.random.random((5, 1))
-    y = np.random.randint(0, 2, (5, 1), dtype=np.int)
+    x = np.random.random((12, 1))
+    y = np.random.randint(0, 2, (12, 1), dtype=np.int)
 
     inputs = tf.keras.layers.Input(shape=(1,))
     outputs = tf.keras.layers.Dense(1)(inputs)
@@ -68,7 +68,7 @@ def test_tqdm_progress_bar_epoch_bar_format_missing_parameter(capsys):
         epoch_bar_format=epoch_bar_format, show_overall_progress=False
     )
     capsys.readouterr()  # flush the buffer
-    model.fit(x, y, epochs=1, verbose=0, callbacks=[pb])
+    model.fit(x, y, batch_size=4, epochs=2, verbose=0, callbacks=[pb])
     fit_stderr = capsys.readouterr().err
     assert "/5" not in fit_stderr
 
@@ -98,11 +98,18 @@ def test_tqdm_progress_bar_show(capsys, show_epoch_progress, show_overall_progre
         show_overall_progress=show_overall_progress,
     )
     capsys.readouterr()  # flush the buffer
-    model.fit(x, y, epochs=1, verbose=0, callbacks=[pb])
+    model.fit(x, y, batch_size=4, epochs=2, verbose=0, callbacks=[pb])
     fit_stderr = capsys.readouterr().err
 
-    assert ("/5" in fit_stderr) is show_epoch_progress
+    assert ("/3" in fit_stderr) is show_epoch_progress
     assert ("epochs/s" in fit_stderr) is show_overall_progress
+
+    if show_epoch_progress and not show_overall_progress:
+        # in 2.1.0, they are present in the logs
+        # in 2.2.0+, they're not
+        # in any case, they shouldn't appear.
+        assert "size" not in fit_stderr
+        assert "batch" not in fit_stderr
 
 
 def test_tqdm_progress_bar_validation(capsys):

--- a/tensorflow_addons/callbacks/tqdm_progress_bar.py
+++ b/tensorflow_addons/callbacks/tqdm_progress_bar.py
@@ -19,7 +19,7 @@ import tensorflow as tf
 from collections import defaultdict
 from typeguard import typechecked
 
-from tensorflow.keras.callbacks import Callback, ProgbarLogger
+from tensorflow.keras.callbacks import Callback
 
 
 @tf.keras.utils.register_keras_serializable(package="Addons")

--- a/tensorflow_addons/callbacks/tqdm_progress_bar.py
+++ b/tensorflow_addons/callbacks/tqdm_progress_bar.py
@@ -19,7 +19,7 @@ import tensorflow as tf
 from collections import defaultdict
 from typeguard import typechecked
 
-from tensorflow.keras.callbacks import Callback
+from tensorflow.keras.callbacks import Callback, ProgbarLogger
 
 
 @tf.keras.utils.register_keras_serializable(package="Addons")
@@ -95,11 +95,10 @@ class TQDMProgressBar(Callback):
         self.epoch_progress_tqdm = None
         self.num_epochs = None
         self.logs = None
-        self.metrics = None
+        super().__init__()
 
     def on_train_begin(self, logs=None):
         self.num_epochs = self.params["epochs"]
-        self.metrics = self.params["metrics"]
 
         if self.show_overall_progress:
             self.overall_progress_tqdm = self.tqdm(
@@ -208,11 +207,11 @@ class TQDMProgressBar(Callback):
         """
 
         metric_value_pairs = []
-        for metric in self.metrics:
-            if metric in logs:
-                value = logs[metric] / factor
-                pair = self.metrics_format.format(name=metric, value=value)
-                metric_value_pairs.append(pair)
+        for key, value in logs.items():
+            if key in ["batch", "size"]:
+                continue
+            pair = self.metrics_format.format(name=key, value=value / factor)
+            metric_value_pairs.append(pair)
         metrics_string = self.metrics_separator.join(metric_value_pairs)
         return metrics_string
 

--- a/tensorflow_addons/callbacks/tqdm_progress_bar.py
+++ b/tensorflow_addons/callbacks/tqdm_progress_bar.py
@@ -111,12 +111,8 @@ class TQDMProgressBar(Callback):
             )
 
         # set counting mode
-        if "samples" in self.params:
-            self.mode = "samples"
-            self.total_steps = self.params["samples"]
-        else:
-            self.mode = "steps"
-            self.total_steps = self.params["steps"]
+        self.mode = "steps"
+        self.total_steps = self.params["steps"]
 
     def on_train_end(self, logs={}):
         if self.show_overall_progress:


### PR DESCRIPTION
Follow-up on #1365

The samples mode is not available anymore. It was causing some issues. It makes the code quite complex to support both, in the future, a refactor to remove all other pieces of code supporting "samples" mode should be removed.

I also made the tests more complex to be sure that it works with the right numbers.

@bjtho08 
@lminer

Please take a look, I used your inputs about the `self.params` and the validation metrics and now it should work out. try it locally with 
```
pip install git+https://github.com/gabrieldemarmiesse/addons.git@fix_progress_bar
```
and report if it works for you. 

Closes #1495