### PR TITLE
Select correct OS for python wheel uploads

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -120,7 +120,7 @@ jobs:
       - uses: actions/download-artifact@v1
         if: github.event_name != 'pull_request' || matrix.py-version == env.OLDEST_PY_VERSION
         with:
-          name: ${{ runner.os }}-${{ matrix.py-version }}-tf2.1.0-wheel
+          name: ${{ matrix.os }}-${{ matrix.py-version }}-tf2.1.0-wheel
           path: ./dist
       - if: github.event_name != 'pull_request' || matrix.py-version == env.OLDEST_PY_VERSION
         run: |


### PR DESCRIPTION
Since the runner is always ubuntu this only pulled down linux wheels. Likely the cause of the 502 errors from pypi.

https://test.pypi.org/manage/project/tensorflow-addons/release/0.9.0.dev2/
vs
https://test.pypi.org/manage/project/tensorflow-addons/release/0.9.0.dev0/