### PR TITLE
Fixed serialization and test for a learning rate scheduler.

### DIFF
--- a/tensorflow_addons/optimizers/cyclical_learning_rate.py
+++ b/tensorflow_addons/optimizers/cyclical_learning_rate.py
@@ -286,6 +286,7 @@ class ExponentialCyclicalLearningRate(CyclicalLearningRate):
         Returns:
             Updated learning rate value.
         """
+        self.gamma = gamma
         super().__init__(
             initial_learning_rate=initial_learning_rate,
             maximal_learning_rate=maximal_learning_rate,
@@ -294,3 +295,6 @@ class ExponentialCyclicalLearningRate(CyclicalLearningRate):
             scale_mode=scale_mode,
             name=name,
         )
+
+    def get_config(self):
+        return {"gamma": self.gamma, **super().get_config()}

--- a/tensorflow_addons/optimizers/tests/cyclical_learning_rate_test.py
+++ b/tensorflow_addons/optimizers/tests/cyclical_learning_rate_test.py
@@ -83,39 +83,35 @@ def test_triangular2_cyclical_learning_rate(serialize):
         np.testing.assert_allclose(triangular2_lr(step).numpy(), expected_value, 1e-6)
 
 
+@pytest.mark.parametrize("serialize", [True, False])
+def test_exponential_cyclical_learning_rate(serialize):
+    initial_learning_rate = 0.1
+    maximal_learning_rate = 1
+    step_size = 2000
+    gamma = 0.996
+
+    step = 0
+    exponential_cyclical_lr = cyclical_learning_rate.ExponentialCyclicalLearningRate(
+        initial_learning_rate=initial_learning_rate,
+        maximal_learning_rate=maximal_learning_rate,
+        step_size=step_size,
+        gamma=gamma,
+    )
+    exponential_cyclical_lr = _maybe_serialized(exponential_cyclical_lr, serialize)
+
+    for i in range(0, 8001):
+        non_bounded_value = np.abs(i / 2000.0 - 2 * np.floor(1 + i / (2 * 2000)) + 1)
+        expected = initial_learning_rate + (
+            maximal_learning_rate - initial_learning_rate
+        ) * np.maximum(0, (1 - non_bounded_value)) * (gamma ** i)
+        computed = exponential_cyclical_lr(step).numpy()
+        np.testing.assert_allclose(computed, expected, 1e-6)
+        step += 1
+
+
 @test_utils.run_all_in_graph_and_eager_modes
 @parameterized.named_parameters(("NotSerialized", False), ("Serialized", True))
 class CyclicalLearningRateTest(tf.test.TestCase, parameterized.TestCase):
-    def testExponentialCyclicalLearningRate(self, serialize):
-        self.skipTest("Failing. See https://github.com/tensorflow/addons/issues/1203")
-        initial_learning_rate = 0.1
-        maximal_learning_rate = 1
-        step_size = 4000
-        gamma = 0.996
-
-        step = tf.resource_variable_ops.ResourceVariable(0)
-        exponential_cyclical_lr = cyclical_learning_rate.ExponentialCyclicalLearningRate(
-            initial_learning_rate=initial_learning_rate,
-            maximal_learning_rate=maximal_learning_rate,
-            step_size=step_size,
-            gamma=gamma,
-        )
-        exponential_cyclical_lr = _maybe_serialized(exponential_cyclical_lr, serialize)
-
-        self.evaluate(tf.compat.v1.global_variables_initializer())
-
-        for i in range(1, 8001):
-            non_bounded_value = np.abs(
-                i / 2000.0 - 2 * np.floor(1 + i / (2 * 2000)) + 1
-            )
-            expected = initial_learning_rate + (
-                maximal_learning_rate - initial_learning_rate
-            ) * np.maximum(0, (1 - non_bounded_value)) * (gamma ** i)
-            self.assertAllClose(
-                self.evaluate(exponential_cyclical_lr(step)), expected, 1e-6
-            )
-            self.evaluate(step.assign_add(1))
-
     def testCustomCyclicalLearningRate(self, serialize):
         self.skipTest("Failing. See https://github.com/tensorflow/addons/issues/1203")
         initial_learning_rate = 0.1


### PR DESCRIPTION
The gamma parameter was not saved. Causing the new object to behave differently from the original.