### PR TITLE
Specify CUDA information within docker for GPU tests

### DIFF
--- a/tools/docker/gpu_tests.Dockerfile
+++ b/tools/docker/gpu_tests.Dockerfile
@@ -1,5 +1,9 @@
 FROM tensorflow/tensorflow:2.1.0-custom-op-gpu-ubuntu16
 ENV TF_NEED_CUDA="1"
+ENV TF_CUDA_VERSION="10.1"
+ENV CUDA_TOOLKIT_PATH="/usr/local/cuda"
+ENV TF_CUDNN_VERSION="7"
+ENV CUDNN_INSTALL_PATH="/usr/lib/x86_64-linux-gnu"
 
 RUN python3 -m pip install --upgrade pip setuptools auditwheel==2.0.0
 


### PR DESCRIPTION
Looks like the GPU tests were truly hanging:
https://source.cloud.google.com/results/invocations/67100f67-5a71-431b-952a-4efb61e8d1b8/targets/tensorflow_addons%2Fubuntu%2Fgpu%2Fpy3%2Fcontinuous/log

Interested to know why the release call to `build_and_release` somehow picked up default values:
https://github.com/tensorflow/addons/blob/master/tools/releases/release_linux.sh#L40
https://github.com/tensorflow/addons/runs/575305456?check_suite_focus=true#step:6:433

While the same call in the Dockerfile hangs waiting for a response:
https://github.com/tensorflow/addons/blob/master/tools/docker/gpu_tests.Dockerfile#L15