### PR TITLE
Update compatibility matrix

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,8 +71,8 @@ what it was tested against.
 #### Python-Op Compatibility Matrix
 | TFA Version    | TensorFlow | Python  |
 |:----------------------- |:---|:---------- |
-| tfa-nightly | 2.1, 2.2 | 3.5, 3.6, 3.7, 3.8 | 
-| tensorflow-addons-0.8.3 | 2.1 |3.5, 3.6, 3.7 |
+| tfa-nightly | 2.1, 2.2 | 3.5, 3.6, 3.7 | 
+| tensorflow-addons-0.9.1 | 2.1 |3.5, 3.6, 3.7 |
 | tensorflow-addons-0.7.1 | 2.1 | 2.7, 3.5, 3.6, 3.7 | 
 | tensorflow-addons-0.6.0 | 2.0 | 2.7, 3.5, 3.6, 3.7 |
 
@@ -95,7 +95,7 @@ compiled differently. A typical reason for this would be conda installed TensorF
 | TFA Version    | TensorFlow | Compiler  | cuDNN | CUDA | 
 |:----------------------- |:---- |:---------|:---------|:---------|
 | tfa-nightly | 2.1 | GCC 7.3.1 | 7.6 | 10.1 |
-| tensorflow-addons-0.8.3 | 2.1  | GCC 7.3.1 | 7.6 | 10.1 |
+| tensorflow-addons-0.9.1 | 2.1  | GCC 7.3.1 | 7.6 | 10.1 |
 | tensorflow-addons-0.7.1 | 2.1  | GCC 7.3.1 | 7.6 | 10.1 |
 | tensorflow-addons-0.6.0 | 2.0  | GCC 7.3.1 | 7.4 | 10.0 |
 

--- a/README.md
+++ b/README.md
@@ -71,11 +71,18 @@ what it was tested against.
 #### Python-Op Compatibility Matrix
 | TFA Version    | TensorFlow | Python  |
 |:----------------------- |:---|:---------- |
-| tfa-nightly | 2.1, 2.2 | 3.5, 3.6, 3.7 | 
-| tensorflow-addons-0.9.1 | 2.1 |3.5, 3.6, 3.7 |
+| tfa-nightly | 2.1, 2.2 | 3.5, 3.6, 3.7, 3.8 | 
+| tensorflow-addons-0.9.1 | 2.1 |3.5, 3.6, 3.7, 3.8 |
 | tensorflow-addons-0.8.3 | 2.1 |3.5, 3.6, 3.7 |
 | tensorflow-addons-0.7.1 | 2.1 | 2.7, 3.5, 3.6, 3.7 | 
 | tensorflow-addons-0.6.0 | 2.0 | 2.7, 3.5, 3.6, 3.7 |
+
+While we wait for a TF2.2 stable release if you would like to use TFA with 
+python3.8 run: 
+```
+pip install tensorflow~=2.2
+pip install git+https://github.com/tensorflow/addons.git@r0.9
+```
 
 ### C++ Custom Op Compatibility
 TensorFlow C++ APIs are not stable and thus we can only guarentee compatibility with the 

--- a/README.md
+++ b/README.md
@@ -73,6 +73,7 @@ what it was tested against.
 |:----------------------- |:---|:---------- |
 | tfa-nightly | 2.1, 2.2 | 3.5, 3.6, 3.7 | 
 | tensorflow-addons-0.9.1 | 2.1 |3.5, 3.6, 3.7 |
+| tensorflow-addons-0.8.3 | 2.1 |3.5, 3.6, 3.7 |
 | tensorflow-addons-0.7.1 | 2.1 | 2.7, 3.5, 3.6, 3.7 | 
 | tensorflow-addons-0.6.0 | 2.0 | 2.7, 3.5, 3.6, 3.7 |
 
@@ -96,6 +97,7 @@ compiled differently. A typical reason for this would be conda installed TensorF
 |:----------------------- |:---- |:---------|:---------|:---------|
 | tfa-nightly | 2.1 | GCC 7.3.1 | 7.6 | 10.1 |
 | tensorflow-addons-0.9.1 | 2.1  | GCC 7.3.1 | 7.6 | 10.1 |
+| tensorflow-addons-0.8.3 | 2.1  | GCC 7.3.1 | 7.6 | 10.1 |
 | tensorflow-addons-0.7.1 | 2.1  | GCC 7.3.1 | 7.6 | 10.1 |
 | tensorflow-addons-0.6.0 | 2.0  | GCC 7.3.1 | 7.4 | 10.0 |
 


### PR DESCRIPTION
So wanted to discuss a couple of things here before merging:

1. Do we want to show all minor versions or just the ones that have changes to compatibility. For example 0.8.3 here is the same compatibility as 0.9.1 so it may be sufficient to just show 0.9.1. Cons I see is that documentation may have to be inferred, but otherwise this list may blow up in size through the years.

2. Regarding 3.8 compatibility on tf-nightly. We are compatible with code but don't publish a py38 package (until 2.2 released). Any thoughts on what to report there?