### PR TITLE
Fixing the flaky cell test.

### DIFF
--- a/tensorflow_addons/conftest.py
+++ b/tensorflow_addons/conftest.py
@@ -1,6 +1,7 @@
 from tensorflow_addons.utils.test_utils import maybe_run_functions_eagerly  # noqa: F401
 from tensorflow_addons.utils.test_utils import cpu_and_gpu  # noqa: F401
 from tensorflow_addons.utils.test_utils import data_format  # noqa: F401
+from tensorflow_addons.utils.test_utils import set_seeds  # noqa: F401
 
 # fixtures present in this file will be available
 # when running tests and can be referenced with strings

--- a/tensorflow_addons/rnn/tests/cell_test.py
+++ b/tensorflow_addons/rnn/tests/cell_test.py
@@ -223,7 +223,7 @@ def test_keras_rnn():
 
 
 def test_config_nas():
-    cell = rnn_cell.NASCell(10, projection=5, use_bias=True)
+    cell = rnn_cell.NASCell(10, projection=5, use_bias=True, name="nas_cell_3")
 
     expected_config = {
         "dtype": "float32",

--- a/tensorflow_addons/utils/test_utils.py
+++ b/tensorflow_addons/utils/test_utils.py
@@ -17,6 +17,7 @@
 import contextlib
 import inspect
 import unittest
+import random
 
 import numpy as np
 import pytest
@@ -192,6 +193,13 @@ def cpu_and_gpu(request):
 @pytest.fixture(scope="function", params=["channels_first", "channels_last"])
 def data_format(request):
     return request.param
+
+
+@pytest.fixture(scope="function", autouse=True)
+def set_seeds():
+    random.seed(0)
+    np.random.seed(0)
+    tf.random.set_seed(0)
 
 
 def assert_allclose_according_to_type(

--- a/tensorflow_addons/utils/tests/test_utils_test.py
+++ b/tensorflow_addons/utils/tests/test_utils_test.py
@@ -1,0 +1,10 @@
+import random
+
+import numpy as np
+import tensorflow as tf
+
+
+def test_seed_is_set():
+    assert random.randint(0, 10000) == 6311
+    assert np.random.randint(0, 10000) == 2732
+    assert tf.random.uniform([], 0, 10000, dtype=tf.int64).numpy() == 9457


### PR DESCRIPTION
Depending on the orders of the tests, this one could or could not pass. Notably, 

```
pytest -v ./tensorflow_addons/rnn/tests/cell_test.py::test_config_nas
```

is enough to reproduce it because names of keras objects depends on which objects have already been created in the global context.