### PR TITLE
Run the tests on the wheel, not the source files in the CI

### DIFF
--- a/.github/workflows/make_wheel_Windows.sh
+++ b/.github/workflows/make_wheel_Windows.sh
@@ -7,6 +7,7 @@ python -m pip install wheel setuptools tensorflow==$TF_VERSION
 curl -sSOL https://github.com/bazelbuild/bazel/releases/download/${BAZEL_VERSION}/bazel-${BAZEL_VERSION}-windows-x86_64.exe
 export BAZEL_PATH=/d/a/addons/addons/bazel-${BAZEL_VERSION}-windows-x86_64.exe
 
+python configure.py
 ./bazel-${BAZEL_VERSION}-windows-x86_64.exe build \
   -c opt \
   --enable_runfiles \

--- a/.github/workflows/make_wheel_Windows.sh
+++ b/.github/workflows/make_wheel_Windows.sh
@@ -6,7 +6,6 @@ export BAZEL_VC="C:/Program Files (x86)/Microsoft Visual Studio/2019/Enterprise/
 python -m pip install wheel setuptools tensorflow==$TF_VERSION
 curl -sSOL https://github.com/bazelbuild/bazel/releases/download/${BAZEL_VERSION}/bazel-${BAZEL_VERSION}-windows-x86_64.exe
 export BAZEL_PATH=/d/a/addons/addons/bazel-${BAZEL_VERSION}-windows-x86_64.exe
-bash ./tools/testing/build_and_run_tests.sh
 
 ./bazel-${BAZEL_VERSION}-windows-x86_64.exe build \
   -c opt \
@@ -17,3 +16,6 @@ bash ./tools/testing/build_and_run_tests.sh
   --test_output=errors \
   build_pip_pkg
 bazel-bin/build_pip_pkg wheelhouse $NIGHTLY_FLAG
+
+pip install wheelhouse/*.whl
+bash ./tools/testing/build_and_run_tests.sh

--- a/.github/workflows/make_wheel_macOS.sh
+++ b/.github/workflows/make_wheel_macOS.sh
@@ -8,6 +8,7 @@ python -m pip install delocate wheel setuptools tensorflow==$TF_VERSION
 bash tools/install_deps/bazel_macos.sh $BAZEL_VERSION
 
 export CC_OPT_FLAGS='-mavx'
+python configure.py
 bazel build \
   -c opt \
   --copt -mmacosx-version-min=10.13 \

--- a/.github/workflows/make_wheel_macOS.sh
+++ b/.github/workflows/make_wheel_macOS.sh
@@ -6,8 +6,8 @@ python --version
 python -m pip install delocate wheel setuptools tensorflow==$TF_VERSION
 
 bash tools/install_deps/bazel_macos.sh $BAZEL_VERSION
-bash tools/testing/build_and_run_tests.sh
 
+export CC_OPT_FLAGS='-mavx'
 bazel build \
   -c opt \
   --copt -mmacosx-version-min=10.13 \
@@ -21,3 +21,5 @@ bazel build \
 bazel-bin/build_pip_pkg artifacts $NIGHTLY_FLAG
 delocate-wheel -w wheelhouse artifacts/*.whl
 
+pip install wheelhouse/*.whl
+bash tools/testing/build_and_run_tests.sh

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -78,46 +78,9 @@ jobs:
         with:
           name: ${{ runner.os }}-${{ matrix.py-version }}-tf${{ matrix.tf-version }}-wheel
           path: wheelhouse
-  test-release-wheel:
-    name: Test release wheels
-    runs-on: ${{ matrix.os }}
-    needs: [release-wheel]
-    strategy:
-      matrix:
-        os: ['macos-latest', 'windows-latest', 'ubuntu-18.04']
-        py-version: ['3.5', '3.6', '3.7']
-        tf-version: ['2.1.0', '2.2.0rc2']
-      fail-fast: false
-    steps:
-      - uses: actions/setup-python@v1
-        with:
-          python-version: ${{ matrix.py-version }}
-      - uses: actions/download-artifact@v1
-        if: |
-          (matrix.os != 'macos-latest' || matrix.py-version != '3.8')
-          && (matrix.py-version != '3.8' || matrix.tf-version != '2.1.0')
-          && (matrix.os != 'ubuntu-18.04' || matrix.tf-version != '2.2.0rc2')
-          && (github.event_name != 'pull_request' || matrix.py-version == env.OLDEST_PY_VERSION)
-        with:
-          name: ${{ runner.os }}-${{ matrix.py-version }}-tf${{ matrix.tf-version }}-wheel
-          path: ./wheel
-      - name: Test wheel
-        if: |
-          (matrix.os != 'macos-latest' || matrix.py-version != '3.8')
-          && (matrix.py-version != '3.8' || matrix.tf-version != '2.1.0')
-          && (matrix.os != 'ubuntu-18.04' || matrix.tf-version != '2.2.0rc2')
-          && (github.event_name != 'pull_request' || matrix.py-version == env.OLDEST_PY_VERSION)
-        env:
-          TF_VERSION: ${{ matrix.tf-version }}
-        shell: bash
-        run: |
-          pip install tensorflow==$TF_VERSION
-          pip install wheel/*.whl
-          python -c "import tensorflow_addons as tfa; print(tfa.activations.lisht(0.2))"
-
   upload-wheels:
     name: Publish wheels to PyPi
-    needs: [release-wheel, test-release-wheel, test-with-bazel]
+    needs: [release-wheel, test-with-bazel]
     runs-on: ubuntu-18.04
     strategy:
       matrix:

--- a/tools/docker/build_wheel.Dockerfile
+++ b/tools/docker/build_wheel.Dockerfile
@@ -28,6 +28,8 @@ RUN python -m pip install -r requirements.txt
 COPY ./ /addons
 WORKDIR /addons
 
+RUN python configure.py
+
 ARG NIGHTLY_FLAG
 ARG NIGHTLY_TIME
 RUN --mount=type=cache,id=cache_bazel,target=/root/.cache/bazel \

--- a/tools/testing/build_and_run_tests.sh
+++ b/tools/testing/build_and_run_tests.sh
@@ -18,9 +18,11 @@
 
 set -x -e
 
-export CC_OPT_FLAGS='-mavx'
+python -m pip install -r tools/install_deps/pytest.txt
 
-python -m pip install -r tools/install_deps/pytest.txt -e ./
-python ./configure.py
-bash tools/install_so_files.sh
-python -m pytest -v --durations=25 ./tensorflow_addons
+# we make sure that the "import tensorflow_addons" uses the wheel
+# from the python installation and not the source files.
+# This is to make sure the wheel is working.
+CWD=$(pwd)
+cd /tmp
+python -m pytest -v --durations=25 "${CWD}"/tensorflow_addons


### PR DESCRIPTION
This will speed up the tests by a lot, because we don't need to build twice and we don't need to test the wheels in another job anymore.

#1655

Well it seems it's not possible, it's incompatible with the import system for the tests, which is to be expected with the structure in the directory. I'm also afraid that it would bring some more issues down the road. Let's drop it.