### PR TITLE
Moved run_all_in_graph_and_eager_mode in basic decoder

### DIFF
--- a/tensorflow_addons/seq2seq/tests/basic_decoder_test.py
+++ b/tensorflow_addons/seq2seq/tests/basic_decoder_test.py
@@ -25,7 +25,8 @@ from tensorflow_addons.seq2seq import basic_decoder
 from tensorflow_addons.seq2seq import sampler as sampler_py
 
 
-def test_step_with_training_helper_output_layer(use_output_layer=True):
+@pytest.mark.parametrize("use_output_layer", [True, False])
+def test_step_with_training_helper_output_layer(use_output_layer):
     sequence_length = [3, 4, 3, 1, 0]
     batch_size = 5
     max_time = 8

--- a/tensorflow_addons/seq2seq/tests/basic_decoder_test.py
+++ b/tensorflow_addons/seq2seq/tests/basic_decoder_test.py
@@ -25,7 +25,6 @@ from tensorflow_addons.seq2seq import basic_decoder
 from tensorflow_addons.seq2seq import sampler as sampler_py
 
 
-# @pytest.mark.parametrize("use_output_layer", True)
 def test_step_with_training_helper_output_layer(use_output_layer=True):
     sequence_length = [3, 4, 3, 1, 0]
     batch_size = 5

--- a/tensorflow_addons/seq2seq/tests/basic_decoder_test.py
+++ b/tensorflow_addons/seq2seq/tests/basic_decoder_test.py
@@ -105,7 +105,7 @@ def test_step_with_training_helper_output_layer(use_output_layer=True):
     )
 
 
-@pytest.mark.parametrize("use_mask", [True, False])
+@pytest.mark.parametrize("use_mask", [True, False, None])
 def test_step_with_training_helper_masked_input(use_mask):
     batch_size = 5
     max_time = 8

--- a/tensorflow_addons/seq2seq/tests/basic_decoder_test.py
+++ b/tensorflow_addons/seq2seq/tests/basic_decoder_test.py
@@ -16,6 +16,7 @@
 
 from absl.testing import parameterized
 import numpy as np
+import pytest
 
 import tensorflow as tf
 
@@ -24,372 +25,302 @@ from tensorflow_addons.seq2seq import basic_decoder
 from tensorflow_addons.seq2seq import sampler as sampler_py
 
 
+# @pytest.mark.parametrize("use_output_layer", True)
+def test_step_with_training_helper_output_layer(use_output_layer=True):
+    sequence_length = [3, 4, 3, 1, 0]
+    batch_size = 5
+    max_time = 8
+    input_depth = 7
+    cell_depth = 10
+    output_layer_depth = 3
+
+    inputs = np.random.randn(batch_size, max_time, input_depth).astype(np.float32)
+    input_t = tf.constant(inputs)
+    cell = tf.keras.layers.LSTMCell(cell_depth)
+    sampler = sampler_py.TrainingSampler(time_major=False)
+    if use_output_layer:
+        output_layer = tf.keras.layers.Dense(output_layer_depth, use_bias=False)
+        expected_output_depth = output_layer_depth
+    else:
+        output_layer = None
+        expected_output_depth = cell_depth
+    initial_state = cell.get_initial_state(batch_size=batch_size, dtype=tf.float32)
+    my_decoder = basic_decoder.BasicDecoder(
+        cell=cell, sampler=sampler, output_layer=output_layer
+    )
+
+    (first_finished, first_inputs, first_state) = my_decoder.initialize(
+        input_t, initial_state=initial_state, sequence_length=sequence_length
+    )
+    output_size = my_decoder.output_size
+    output_dtype = my_decoder.output_dtype
+    assert (
+        basic_decoder.BasicDecoderOutput(expected_output_depth, tf.TensorShape([]))
+        == output_size
+    )
+
+    assert basic_decoder.BasicDecoderOutput(tf.float32, tf.int32) == output_dtype
+
+    (step_outputs, step_state, step_next_inputs, step_finished,) = my_decoder.step(
+        tf.constant(0), first_inputs, first_state
+    )
+    batch_size_t = my_decoder.batch_size
+
+    assert len(first_state) == 2
+    assert len(step_state) == 2
+    assert type(step_outputs) is basic_decoder.BasicDecoderOutput
+    assert (batch_size, expected_output_depth) == step_outputs[0].get_shape()
+    assert (batch_size,) == step_outputs[1].get_shape()
+    assert (batch_size, cell_depth) == first_state[0].get_shape()
+    assert (batch_size, cell_depth) == first_state[1].get_shape()
+    assert (batch_size, cell_depth) == step_state[0].get_shape()
+    assert (batch_size, cell_depth) == step_state[1].get_shape()
+
+    if use_output_layer:
+        # The output layer was accessed
+        assert len(output_layer.variables) == 1
+
+    eval_result = {
+        "batch_size": batch_size_t,
+        "first_finished": first_finished,
+        "first_inputs": first_inputs,
+        "first_state": first_state,
+        "step_outputs": step_outputs,
+        "step_state": step_state,
+        "step_next_inputs": step_next_inputs,
+        "step_finished": step_finished,
+    }
+
+    np.testing.assert_equal(
+        np.asanyarray([False, False, False, False, True]),
+        eval_result["first_finished"].numpy(),
+    )
+    np.testing.assert_equal(
+        np.asanyarray([False, False, False, True, True]),
+        eval_result["step_finished"].numpy(),
+    )
+    assert output_dtype.sample_id == eval_result["step_outputs"].sample_id.dtype
+    np.testing.assert_equal(
+        np.argmax(eval_result["step_outputs"].rnn_output, -1),
+        eval_result["step_outputs"].sample_id,
+    )
+
+
+@pytest.mark.parametrize("use_mask", [True, False])
+def test_step_with_training_helper_masked_input(use_mask):
+    batch_size = 5
+    max_time = 8
+    sequence_length = [max_time] * batch_size if use_mask is None else [3, 4, 3, 1, 0]
+    sequence_length = np.array(sequence_length, dtype=np.int32)
+    mask = [[True] * l + [False] * (max_time - l) for l in sequence_length]
+    input_depth = 7
+    cell_depth = 10
+    output_layer_depth = 3
+
+    inputs = np.random.randn(batch_size, max_time, input_depth).astype(np.float32)
+    input_t = tf.constant(inputs)
+    cell = tf.keras.layers.LSTMCell(cell_depth)
+    sampler = sampler_py.TrainingSampler(time_major=False)
+    output_layer = tf.keras.layers.Dense(output_layer_depth, use_bias=False)
+    expected_output_depth = output_layer_depth
+    initial_state = cell.get_initial_state(batch_size=batch_size, dtype=tf.float32)
+    my_decoder = basic_decoder.BasicDecoder(
+        cell=cell, sampler=sampler, output_layer=output_layer
+    )
+
+    if use_mask is None:
+        (first_finished, first_inputs, first_state) = my_decoder.initialize(
+            input_t, initial_state=initial_state
+        )
+    elif use_mask:
+        (first_finished, first_inputs, first_state) = my_decoder.initialize(
+            input_t, initial_state=initial_state, mask=mask
+        )
+    else:
+        (first_finished, first_inputs, first_state) = my_decoder.initialize(
+            input_t, initial_state=initial_state, sequence_length=sequence_length,
+        )
+
+    output_size = my_decoder.output_size
+    output_dtype = my_decoder.output_dtype
+    assert (
+        basic_decoder.BasicDecoderOutput(expected_output_depth, tf.TensorShape([]))
+        == output_size
+    )
+
+    assert basic_decoder.BasicDecoderOutput(tf.float32, tf.int32) == output_dtype
+
+    (step_outputs, step_state, step_next_inputs, step_finished,) = my_decoder.step(
+        tf.constant(0), first_inputs, first_state
+    )
+    batch_size_t = my_decoder.batch_size
+
+    assert len(first_state) == 2
+    assert len(step_state) == 2
+    assert type(step_outputs) is basic_decoder.BasicDecoderOutput
+    assert (batch_size, expected_output_depth) == step_outputs[0].get_shape()
+    assert (batch_size,) == step_outputs[1].get_shape()
+    assert (batch_size, cell_depth) == first_state[0].get_shape()
+    assert (batch_size, cell_depth) == first_state[1].get_shape()
+    assert (batch_size, cell_depth) == step_state[0].get_shape()
+    assert (batch_size, cell_depth) == step_state[1].get_shape()
+
+    assert len(output_layer.variables) == 1
+
+    eval_result = {
+        "batch_size": batch_size_t,
+        "first_finished": first_finished,
+        "first_inputs": first_inputs,
+        "first_state": first_state,
+        "step_outputs": step_outputs,
+        "step_state": step_state,
+        "step_next_inputs": step_next_inputs,
+        "step_finished": step_finished,
+    }
+
+    np.testing.assert_equal(sequence_length == 0, eval_result["first_finished"])
+    np.testing.assert_equal(
+        (np.maximum(sequence_length - 1, 0) == 0), eval_result["step_finished"]
+    )
+    assert output_dtype.sample_id == eval_result["step_outputs"].sample_id.dtype
+    np.testing.assert_equal(
+        np.argmax(eval_result["step_outputs"].rnn_output, -1),
+        eval_result["step_outputs"].sample_id,
+    )
+
+
+def test_step_with_greedy_embedding_helper():
+    batch_size = 5
+    vocabulary_size = 7
+    cell_depth = vocabulary_size  # cell's logits must match vocabulary size
+    input_depth = 10
+    start_tokens = np.random.randint(0, vocabulary_size, size=batch_size)
+    end_token = 1
+
+    embeddings = np.random.randn(vocabulary_size, input_depth).astype(np.float32)
+    embeddings_t = tf.constant(embeddings)
+    cell = tf.keras.layers.LSTMCell(vocabulary_size)
+    sampler = sampler_py.GreedyEmbeddingSampler()
+    initial_state = cell.get_initial_state(batch_size=batch_size, dtype=tf.float32)
+    my_decoder = basic_decoder.BasicDecoder(cell=cell, sampler=sampler)
+    (first_finished, first_inputs, first_state) = my_decoder.initialize(
+        embeddings_t,
+        start_tokens=start_tokens,
+        end_token=end_token,
+        initial_state=initial_state,
+    )
+    output_size = my_decoder.output_size
+    output_dtype = my_decoder.output_dtype
+    assert (
+        basic_decoder.BasicDecoderOutput(cell_depth, tf.TensorShape([])) == output_size
+    )
+    assert basic_decoder.BasicDecoderOutput(tf.float32, tf.int32) == output_dtype
+
+    (step_outputs, step_state, step_next_inputs, step_finished,) = my_decoder.step(
+        tf.constant(0), first_inputs, first_state
+    )
+    batch_size_t = my_decoder.batch_size
+
+    assert len(first_state) == 2
+    assert len(step_state) == 2
+    assert isinstance(step_outputs, basic_decoder.BasicDecoderOutput)
+    assert (batch_size, cell_depth) == step_outputs[0].get_shape()
+    assert (batch_size,) == step_outputs[1].get_shape()
+    assert (batch_size, cell_depth) == first_state[0].get_shape()
+    assert (batch_size, cell_depth) == first_state[1].get_shape()
+    assert (batch_size, cell_depth) == step_state[0].get_shape()
+    assert (batch_size, cell_depth) == step_state[1].get_shape()
+
+    eval_result = {
+        "batch_size": batch_size_t,
+        "first_finished": first_finished,
+        "first_inputs": first_inputs,
+        "first_state": first_state,
+        "step_outputs": step_outputs,
+        "step_state": step_state,
+        "step_next_inputs": step_next_inputs,
+        "step_finished": step_finished,
+    }
+
+    expected_sample_ids = np.argmax(eval_result["step_outputs"].rnn_output, -1)
+    expected_step_finished = expected_sample_ids == end_token
+    expected_step_next_inputs = embeddings[expected_sample_ids]
+    np.testing.assert_equal(
+        np.asanyarray([False, False, False, False, False]),
+        eval_result["first_finished"].numpy(),
+    )
+    np.testing.assert_equal(expected_step_finished, eval_result["step_finished"])
+    assert output_dtype.sample_id == eval_result["step_outputs"].sample_id.dtype
+    np.testing.assert_equal(expected_sample_ids, eval_result["step_outputs"].sample_id)
+    np.testing.assert_equal(expected_step_next_inputs, eval_result["step_next_inputs"])
+
+
+def test_step_with_sample_embedding_helper():
+    batch_size = 5
+    vocabulary_size = 7
+    cell_depth = vocabulary_size  # cell's logits must match vocabulary size
+    input_depth = 10
+    np.random.seed(0)
+    start_tokens = np.random.randint(0, vocabulary_size, size=batch_size)
+    end_token = 1
+
+    embeddings = np.random.randn(vocabulary_size, input_depth).astype(np.float32)
+    embeddings_t = tf.constant(embeddings)
+    cell = tf.keras.layers.LSTMCell(vocabulary_size)
+    sampler = sampler_py.SampleEmbeddingSampler(seed=0)
+    initial_state = cell.get_initial_state(batch_size=batch_size, dtype=tf.float32)
+    my_decoder = basic_decoder.BasicDecoder(cell=cell, sampler=sampler)
+    (first_finished, first_inputs, first_state) = my_decoder.initialize(
+        embeddings_t,
+        start_tokens=start_tokens,
+        end_token=end_token,
+        initial_state=initial_state,
+    )
+    output_size = my_decoder.output_size
+    output_dtype = my_decoder.output_dtype
+    assert (
+        basic_decoder.BasicDecoderOutput(cell_depth, tf.TensorShape([])) == output_size
+    )
+    assert basic_decoder.BasicDecoderOutput(tf.float32, tf.int32) == output_dtype
+
+    (step_outputs, step_state, step_next_inputs, step_finished,) = my_decoder.step(
+        tf.constant(0), first_inputs, first_state
+    )
+    batch_size_t = my_decoder.batch_size
+
+    assert len(first_state) == 2
+    assert len(step_state) == 2
+    assert isinstance(step_outputs, basic_decoder.BasicDecoderOutput)
+    assert (batch_size, cell_depth) == step_outputs[0].get_shape()
+    assert (batch_size,) == step_outputs[1].get_shape()
+    assert (batch_size, cell_depth) == first_state[0].get_shape()
+    assert (batch_size, cell_depth) == first_state[1].get_shape()
+    assert (batch_size, cell_depth) == step_state[0].get_shape()
+    assert (batch_size, cell_depth) == step_state[1].get_shape()
+
+    eval_result = {
+        "batch_size": batch_size_t,
+        "first_finished": first_finished,
+        "first_inputs": first_inputs,
+        "first_state": first_state,
+        "step_outputs": step_outputs,
+        "step_state": step_state,
+        "step_next_inputs": step_next_inputs,
+        "step_finished": step_finished,
+    }
+
+    sample_ids = eval_result["step_outputs"].sample_id
+    assert output_dtype.sample_id == sample_ids.dtype
+    expected_step_finished = sample_ids == end_token
+    expected_step_next_inputs = embeddings[sample_ids, :]
+    np.testing.assert_equal(
+        np.asanyarray(expected_step_finished), eval_result["step_finished"].numpy()
+    )
+    np.testing.assert_equal(expected_step_next_inputs, eval_result["step_next_inputs"])
+
+
 class BasicDecoderTest(tf.test.TestCase, parameterized.TestCase):
     """Unit test for basic_decoder.BasicDecoder."""
-
-    @parameterized.named_parameters(
-        ("use_output_layer", True), ("without_output_layer", False)
-    )
-    def testStepWithTrainingHelperOutputLayer(self, use_output_layer):
-        sequence_length = [3, 4, 3, 1, 0]
-        batch_size = 5
-        max_time = 8
-        input_depth = 7
-        cell_depth = 10
-        output_layer_depth = 3
-
-        with self.cached_session(use_gpu=True):
-            inputs = np.random.randn(batch_size, max_time, input_depth).astype(
-                np.float32
-            )
-            input_t = tf.constant(inputs)
-            cell = tf.keras.layers.LSTMCell(cell_depth)
-            sampler = sampler_py.TrainingSampler(time_major=False)
-            if use_output_layer:
-                output_layer = tf.keras.layers.Dense(output_layer_depth, use_bias=False)
-                expected_output_depth = output_layer_depth
-            else:
-                output_layer = None
-                expected_output_depth = cell_depth
-            initial_state = cell.get_initial_state(
-                batch_size=batch_size, dtype=tf.float32
-            )
-            my_decoder = basic_decoder.BasicDecoder(
-                cell=cell, sampler=sampler, output_layer=output_layer
-            )
-
-            (first_finished, first_inputs, first_state) = my_decoder.initialize(
-                input_t, initial_state=initial_state, sequence_length=sequence_length
-            )
-            output_size = my_decoder.output_size
-            output_dtype = my_decoder.output_dtype
-            self.assertEqual(
-                basic_decoder.BasicDecoderOutput(
-                    expected_output_depth, tf.TensorShape([])
-                ),
-                output_size,
-            )
-            self.assertEqual(
-                basic_decoder.BasicDecoderOutput(tf.float32, tf.int32), output_dtype
-            )
-
-            (
-                step_outputs,
-                step_state,
-                step_next_inputs,
-                step_finished,
-            ) = my_decoder.step(tf.constant(0), first_inputs, first_state)
-            batch_size_t = my_decoder.batch_size
-
-            self.assertLen(first_state, 2)
-            self.assertLen(step_state, 2)
-            self.assertIsInstance(step_outputs, basic_decoder.BasicDecoderOutput)
-            self.assertEqual(
-                (batch_size, expected_output_depth), step_outputs[0].get_shape()
-            )
-            self.assertEqual((batch_size,), step_outputs[1].get_shape())
-            self.assertEqual((batch_size, cell_depth), first_state[0].get_shape())
-            self.assertEqual((batch_size, cell_depth), first_state[1].get_shape())
-            self.assertEqual((batch_size, cell_depth), step_state[0].get_shape())
-            self.assertEqual((batch_size, cell_depth), step_state[1].get_shape())
-
-            if use_output_layer:
-                # The output layer was accessed
-                self.assertEqual(len(output_layer.variables), 1)
-
-            self.evaluate(tf.compat.v1.global_variables_initializer())
-            eval_result = self.evaluate(
-                {
-                    "batch_size": batch_size_t,
-                    "first_finished": first_finished,
-                    "first_inputs": first_inputs,
-                    "first_state": first_state,
-                    "step_outputs": step_outputs,
-                    "step_state": step_state,
-                    "step_next_inputs": step_next_inputs,
-                    "step_finished": step_finished,
-                }
-            )
-
-            self.assertAllEqual(
-                [False, False, False, False, True], eval_result["first_finished"]
-            )
-            self.assertAllEqual(
-                [False, False, False, True, True], eval_result["step_finished"]
-            )
-            self.assertEqual(
-                output_dtype.sample_id, eval_result["step_outputs"].sample_id.dtype
-            )
-            self.assertAllEqual(
-                np.argmax(eval_result["step_outputs"].rnn_output, -1),
-                eval_result["step_outputs"].sample_id,
-            )
-
-    @parameterized.named_parameters(
-        ("sequence_length_only", False), ("mask_only", True), ("no_mask", None)
-    )
-    def testStepWithTrainingHelperMaskedInput(self, use_mask):
-        batch_size = 5
-        max_time = 8
-        sequence_length = (
-            [max_time] * batch_size if use_mask is None else [3, 4, 3, 1, 0]
-        )
-        sequence_length = np.array(sequence_length, dtype=np.int32)
-        mask = [[True] * l + [False] * (max_time - l) for l in sequence_length]
-        input_depth = 7
-        cell_depth = 10
-        output_layer_depth = 3
-
-        with self.cached_session(use_gpu=True):
-            inputs = np.random.randn(batch_size, max_time, input_depth).astype(
-                np.float32
-            )
-            input_t = tf.constant(inputs)
-            cell = tf.keras.layers.LSTMCell(cell_depth)
-            sampler = sampler_py.TrainingSampler(time_major=False)
-            output_layer = tf.keras.layers.Dense(output_layer_depth, use_bias=False)
-            expected_output_depth = output_layer_depth
-            initial_state = cell.get_initial_state(
-                batch_size=batch_size, dtype=tf.float32
-            )
-            my_decoder = basic_decoder.BasicDecoder(
-                cell=cell, sampler=sampler, output_layer=output_layer
-            )
-
-            if use_mask is None:
-                (first_finished, first_inputs, first_state) = my_decoder.initialize(
-                    input_t, initial_state=initial_state
-                )
-            elif use_mask:
-                (first_finished, first_inputs, first_state) = my_decoder.initialize(
-                    input_t, initial_state=initial_state, mask=mask
-                )
-            else:
-                (first_finished, first_inputs, first_state) = my_decoder.initialize(
-                    input_t,
-                    initial_state=initial_state,
-                    sequence_length=sequence_length,
-                )
-
-            output_size = my_decoder.output_size
-            output_dtype = my_decoder.output_dtype
-            self.assertEqual(
-                basic_decoder.BasicDecoderOutput(
-                    expected_output_depth, tf.TensorShape([])
-                ),
-                output_size,
-            )
-            self.assertEqual(
-                basic_decoder.BasicDecoderOutput(tf.float32, tf.int32), output_dtype
-            )
-
-            (
-                step_outputs,
-                step_state,
-                step_next_inputs,
-                step_finished,
-            ) = my_decoder.step(tf.constant(0), first_inputs, first_state)
-            batch_size_t = my_decoder.batch_size
-
-            self.assertLen(first_state, 2)
-            self.assertLen(step_state, 2)
-            assert isinstance(step_outputs, basic_decoder.BasicDecoderOutput)
-            self.assertEqual(
-                (batch_size, expected_output_depth), step_outputs[0].get_shape()
-            )
-            self.assertEqual((batch_size,), step_outputs[1].get_shape())
-            self.assertEqual((batch_size, cell_depth), first_state[0].get_shape())
-            self.assertEqual((batch_size, cell_depth), first_state[1].get_shape())
-            self.assertEqual((batch_size, cell_depth), step_state[0].get_shape())
-            self.assertEqual((batch_size, cell_depth), step_state[1].get_shape())
-
-            self.assertLen(output_layer.variables, 1)
-
-            eval_result = self.evaluate(
-                {
-                    "batch_size": batch_size_t,
-                    "first_finished": first_finished,
-                    "first_inputs": first_inputs,
-                    "first_state": first_state,
-                    "step_outputs": step_outputs,
-                    "step_state": step_state,
-                    "step_next_inputs": step_next_inputs,
-                    "step_finished": step_finished,
-                }
-            )
-
-            self.assertAllEqual(sequence_length == 0, eval_result["first_finished"])
-            self.assertAllEqual(
-                (np.maximum(sequence_length - 1, 0) == 0), eval_result["step_finished"]
-            )
-            self.assertEqual(
-                output_dtype.sample_id, eval_result["step_outputs"].sample_id.dtype
-            )
-            self.assertAllEqual(
-                np.argmax(eval_result["step_outputs"].rnn_output, -1),
-                eval_result["step_outputs"].sample_id,
-            )
-
-    def testStepWithGreedyEmbeddingHelper(self):
-        batch_size = 5
-        vocabulary_size = 7
-        cell_depth = vocabulary_size  # cell's logits must match vocabulary size
-        input_depth = 10
-        start_tokens = np.random.randint(0, vocabulary_size, size=batch_size)
-        end_token = 1
-
-        with self.cached_session(use_gpu=True):
-            embeddings = np.random.randn(vocabulary_size, input_depth).astype(
-                np.float32
-            )
-            embeddings_t = tf.constant(embeddings)
-            cell = tf.keras.layers.LSTMCell(vocabulary_size)
-            sampler = sampler_py.GreedyEmbeddingSampler()
-            initial_state = cell.get_initial_state(
-                batch_size=batch_size, dtype=tf.float32
-            )
-            my_decoder = basic_decoder.BasicDecoder(cell=cell, sampler=sampler)
-            (first_finished, first_inputs, first_state) = my_decoder.initialize(
-                embeddings_t,
-                start_tokens=start_tokens,
-                end_token=end_token,
-                initial_state=initial_state,
-            )
-            output_size = my_decoder.output_size
-            output_dtype = my_decoder.output_dtype
-            self.assertEqual(
-                basic_decoder.BasicDecoderOutput(cell_depth, tf.TensorShape([])),
-                output_size,
-            )
-            self.assertEqual(
-                basic_decoder.BasicDecoderOutput(tf.float32, tf.int32), output_dtype
-            )
-
-            (
-                step_outputs,
-                step_state,
-                step_next_inputs,
-                step_finished,
-            ) = my_decoder.step(tf.constant(0), first_inputs, first_state)
-            batch_size_t = my_decoder.batch_size
-
-            self.assertLen(first_state, 2)
-            self.assertLen(step_state, 2)
-            self.assertTrue(isinstance(step_outputs, basic_decoder.BasicDecoderOutput))
-            self.assertEqual((batch_size, cell_depth), step_outputs[0].get_shape())
-            self.assertEqual((batch_size,), step_outputs[1].get_shape())
-            self.assertEqual((batch_size, cell_depth), first_state[0].get_shape())
-            self.assertEqual((batch_size, cell_depth), first_state[1].get_shape())
-            self.assertEqual((batch_size, cell_depth), step_state[0].get_shape())
-            self.assertEqual((batch_size, cell_depth), step_state[1].get_shape())
-
-            self.evaluate(tf.compat.v1.global_variables_initializer())
-            eval_result = self.evaluate(
-                {
-                    "batch_size": batch_size_t,
-                    "first_finished": first_finished,
-                    "first_inputs": first_inputs,
-                    "first_state": first_state,
-                    "step_outputs": step_outputs,
-                    "step_state": step_state,
-                    "step_next_inputs": step_next_inputs,
-                    "step_finished": step_finished,
-                }
-            )
-
-            expected_sample_ids = np.argmax(eval_result["step_outputs"].rnn_output, -1)
-            expected_step_finished = expected_sample_ids == end_token
-            expected_step_next_inputs = embeddings[expected_sample_ids]
-            self.assertAllEqual(
-                [False, False, False, False, False], eval_result["first_finished"]
-            )
-            self.assertAllEqual(expected_step_finished, eval_result["step_finished"])
-            self.assertEqual(
-                output_dtype.sample_id, eval_result["step_outputs"].sample_id.dtype
-            )
-            self.assertAllEqual(
-                expected_sample_ids, eval_result["step_outputs"].sample_id
-            )
-            self.assertAllEqual(
-                expected_step_next_inputs, eval_result["step_next_inputs"]
-            )
-
-    def testStepWithSampleEmbeddingHelper(self):
-        batch_size = 5
-        vocabulary_size = 7
-        cell_depth = vocabulary_size  # cell's logits must match vocabulary size
-        input_depth = 10
-        np.random.seed(0)
-        start_tokens = np.random.randint(0, vocabulary_size, size=batch_size)
-        end_token = 1
-
-        with self.cached_session(use_gpu=True):
-            embeddings = np.random.randn(vocabulary_size, input_depth).astype(
-                np.float32
-            )
-            embeddings_t = tf.constant(embeddings)
-            cell = tf.keras.layers.LSTMCell(vocabulary_size)
-            sampler = sampler_py.SampleEmbeddingSampler(seed=0)
-            initial_state = cell.get_initial_state(
-                batch_size=batch_size, dtype=tf.float32
-            )
-            my_decoder = basic_decoder.BasicDecoder(cell=cell, sampler=sampler)
-            (first_finished, first_inputs, first_state) = my_decoder.initialize(
-                embeddings_t,
-                start_tokens=start_tokens,
-                end_token=end_token,
-                initial_state=initial_state,
-            )
-            output_size = my_decoder.output_size
-            output_dtype = my_decoder.output_dtype
-            self.assertEqual(
-                basic_decoder.BasicDecoderOutput(cell_depth, tf.TensorShape([])),
-                output_size,
-            )
-            self.assertEqual(
-                basic_decoder.BasicDecoderOutput(tf.float32, tf.int32), output_dtype
-            )
-
-            (
-                step_outputs,
-                step_state,
-                step_next_inputs,
-                step_finished,
-            ) = my_decoder.step(tf.constant(0), first_inputs, first_state)
-            batch_size_t = my_decoder.batch_size
-
-            self.assertLen(first_state, 2)
-            self.assertTrue(step_state, 2)
-            self.assertTrue(isinstance(step_outputs, basic_decoder.BasicDecoderOutput))
-            self.assertEqual((batch_size, cell_depth), step_outputs[0].get_shape())
-            self.assertEqual((batch_size,), step_outputs[1].get_shape())
-            self.assertEqual((batch_size, cell_depth), first_state[0].get_shape())
-            self.assertEqual((batch_size, cell_depth), first_state[1].get_shape())
-            self.assertEqual((batch_size, cell_depth), step_state[0].get_shape())
-            self.assertEqual((batch_size, cell_depth), step_state[1].get_shape())
-
-            self.evaluate(tf.compat.v1.global_variables_initializer())
-            eval_result = self.evaluate(
-                {
-                    "batch_size": batch_size_t,
-                    "first_finished": first_finished,
-                    "first_inputs": first_inputs,
-                    "first_state": first_state,
-                    "step_outputs": step_outputs,
-                    "step_state": step_state,
-                    "step_next_inputs": step_next_inputs,
-                    "step_finished": step_finished,
-                }
-            )
-
-            sample_ids = eval_result["step_outputs"].sample_id
-            self.assertEqual(output_dtype.sample_id, sample_ids.dtype)
-            expected_step_finished = sample_ids == end_token
-            expected_step_next_inputs = embeddings[sample_ids]
-            self.assertAllEqual(expected_step_finished, eval_result["step_finished"])
-            self.assertAllEqual(
-                expected_step_next_inputs, eval_result["step_next_inputs"]
-            )
 
     def testStepWithScheduledEmbeddingTrainingHelper(self):
         sequence_length = [3, 4, 3, 1, 0]


### PR DESCRIPTION
cc @gabrieldemarmiesse. Dividing into several parts since it's large, and not sure if removing `use_gpu` is a good idea. The reason is using gpu seems not helping a lot in LSTM, only if it's self-attention(transformer) based. May need your suggestions. 