### PR TITLE
Enable ppc64le build

### DIFF
--- a/build_deps/toolchains/gpu/crosstool/BUILD.tpl
+++ b/build_deps/toolchains/gpu/crosstool/BUILD.tpl
@@ -24,6 +24,7 @@ cc_toolchain_suite(
     toolchains = {
         "local|compiler": ":cc-compiler-local",
         "k8": ":cc-compiler-local",
+        "ppc": ":cc-compiler-local",
     },
 )
 


### PR DESCRIPTION
Build fails on ppc64le, with this minor change build is successful. Tested with following environment variables:
```
export TF_NEED_CUDA="1"
export TF_CUDA_VERSION="10.2"
export TF_CUDNN_VERSION="7"
export CUDA_TOOLKIT_PATH="/usr/local/cuda"
export CUDNN_INSTALL_PATH="/usr/lib/powerpc64le-linux-gnu"

```