### PR TITLE
Partially fix for gpus in kokoro

### DIFF
--- a/tools/run_gpu_tests.sh
+++ b/tools/run_gpu_tests.sh
@@ -9,4 +9,4 @@ docker build \
        --build-arg TF_VERSION=2.1.0 \
        --build-arg PY_VERSION=3.5 \
        -t tfa_gpu_tests ./
-docker run --rm -t -v cache_bazel:/root/.cache/bazel --runtime=nvidia tfa_gpu_tests
+docker run --rm -t -v cache_bazel:/root/.cache/bazel --gpus=all tfa_gpu_tests

--- a/tools/testing/build_and_run_tests.sh
+++ b/tools/testing/build_and_run_tests.sh
@@ -23,4 +23,6 @@ export CC_OPT_FLAGS='-mavx'
 python -m pip install -r tools/install_deps/pytest.txt -e ./
 python ./configure.py
 bash tools/install_so_files.sh
+python -c "import tensorflow as tf; print(tf.config.list_physical_devices())"
+python -c "import tensorflow as tf; print(tf.config.list_logical_devices())"
 python -m pytest -v --durations=25 ./tensorflow_addons


### PR DESCRIPTION
Currently, our tests are not running with gpu in kokoro. There seems to have multiple reasons:

* `--runtime=nvidia` doesn't work anymore for some reason. Meaning that `nvidia-smi` doesn't work in the container. The fix is to use `--gpus=all`. This is the fix here.
* There is an issue when opening the cuda lib. That's not fixed yet. But it seems strange since the compilation of CUDA files works. See the kokoro log.


```
+ python -c 'import tensorflow as tf; print(tf.config.list_physical_devices())'
2020-04-15 10:42:28.368032: I tensorflow/stream_executor/platform/default/dso_loader.cc:44] Successfully opened dynamic library libnvinfer.so.6
2020-04-15 10:42:28.369637: I tensorflow/stream_executor/platform/default/dso_loader.cc:44] Successfully opened dynamic library libnvinfer_plugin.so.6
2020-04-15 10:42:29.061284: W tensorflow/stream_executor/platform/default/dso_loader.cc:55] Could not load dynamic library 'libcuda.so.1'; dlerror: libcuda.so.1: cannot open shared object file: No such file or directory
2020-04-15 10:42:29.061327: E tensorflow/stream_executor/cuda/cuda_driver.cc:351] failed call to cuInit: UNKNOWN ERROR (303)
2020-04-15 10:42:29.061350: I tensorflow/stream_executor/cuda/cuda_diagnostics.cc:169] retrieving CUDA diagnostic information for host: 9ba5093b8bc9
2020-04-15 10:42:29.061368: I tensorflow/stream_executor/cuda/cuda_diagnostics.cc:176] hostname: 9ba5093b8bc9
2020-04-15 10:42:29.061405: I tensorflow/stream_executor/cuda/cuda_diagnostics.cc:200] libcuda reported version is: Not found: was unable to find libcuda.so DSO loaded into this program
2020-04-15 10:42:29.061449: I tensorflow/stream_executor/cuda/cuda_diagnostics.cc:204] kernel reported version is: 440.64.0
[PhysicalDevice(name='/physical_device:CPU:0', device_type='CPU'), PhysicalDevice(name='/physical_device:XLA_CPU:0', device_type='XLA_CPU')]
+ python -c 'import tensorflow as tf; print(tf.config.list_logical_devices())'
2020-04-15 10:42:30.367048: I tensorflow/stream_executor/platform/default/dso_loader.cc:44] Successfully opened dynamic library libnvinfer.so.6
2020-04-15 10:42:30.368651: I tensorflow/stream_executor/platform/default/dso_loader.cc:44] Successfully opened dynamic library libnvinfer_plugin.so.6
2020-04-15 10:42:31.054318: W tensorflow/stream_executor/platform/default/dso_loader.cc:55] Could not load dynamic library 'libcuda.so.1'; dlerror: libcuda.so.1: cannot open shared object file: No such file or directory
2020-04-15 10:42:31.054365: E tensorflow/stream_executor/cuda/cuda_driver.cc:351] failed call to cuInit: UNKNOWN ERROR (303)
2020-04-15 10:42:31.054395: I tensorflow/stream_executor/cuda/cuda_diagnostics.cc:169] retrieving CUDA diagnostic information for host: 9ba5093b8bc9
2020-04-15 10:42:31.054458: I tensorflow/stream_executor/cuda/cuda_diagnostics.cc:176] hostname: 9ba5093b8bc9
2020-04-15 10:42:31.054509: I tensorflow/stream_executor/cuda/cuda_diagnostics.cc:200] libcuda reported version is: Not found: was unable to find libcuda.so DSO loaded into this program
2020-04-15 10:42:31.054566: I tensorflow/stream_executor/cuda/cuda_diagnostics.cc:204] kernel reported version is: 440.64.0
2020-04-15 10:42:31.054842: I tensorflow/core/platform/cpu_feature_guard.cc:142] Your CPU supports instructions that this TensorFlow binary was not compiled to use: AVX2 FMA
2020-04-15 10:42:31.064424: I tensorflow/core/platform/profile_utils/cpu_utils.cc:94] CPU Frequency: 2300000000 Hz
2020-04-15 10:42:31.066331: I tensorflow/compiler/xla/service/service.cc:168] XLA service 0x57d4b80 initialized for platform Host (this does not guarantee that XLA will be used). Devices:
2020-04-15 10:42:31.066376: I tensorflow/compiler/xla/service/service.cc:176]   StreamExecutor device (0): Host, Default Version
[LogicalDevice(name='/device:CPU:0', device_type='CPU'), LogicalDevice(name='/device:XLA_CPU:0', device_type='XLA_CPU')]
```

I think we can merge this pull reqest as it's already an improvement. We can see later on how to fix the cuda libs.