### PR TITLE
Added code to get the slowest test functions, test files and sum of all durations.

### DIFF
--- a/tensorflow_addons/conftest.py
+++ b/tensorflow_addons/conftest.py
@@ -6,3 +6,35 @@ from tensorflow_addons.utils.test_utils import set_seeds  # noqa: F401
 # fixtures present in this file will be available
 # when running tests and can be referenced with strings
 # https://docs.pytest.org/en/latest/fixture.html#conftest-py-sharing-fixture-functions
+
+from collections import defaultdict
+
+
+def pytest_terminal_summary(terminalreporter):
+    durations = 17
+    tr = terminalreporter
+    dlist = []
+    for replist in tr.stats.values():
+        for rep in replist:
+            if hasattr(rep, "duration"):
+                dlist.append(rep)
+    if not dlist:
+        return
+
+    # group by file
+    durations_by_file = defaultdict(float)
+    for test_report in dlist:
+        durations_by_file[test_report.fspath] += test_report.duration
+
+    dlist = list(durations_by_file.items())
+
+    dlist.sort(key=lambda x: x[1])
+    dlist.reverse()
+    if not durations:
+        tr.write_sep("=", "slowest file durations")
+    else:
+        tr.write_sep("=", "slowest %s file durations" % durations)
+        dlist = dlist[:durations]
+
+    for filename, test_time in dlist:
+        tr.write_line("{:02.2f}s {:<8} {}".format(test_time, " ", filename))

--- a/tensorflow_addons/conftest.py
+++ b/tensorflow_addons/conftest.py
@@ -10,14 +10,18 @@ from tensorflow_addons.utils.test_utils import set_seeds  # noqa: F401
 from collections import defaultdict
 
 
-def pytest_terminal_summary(terminalreporter):
-    durations = 17
-    tr = terminalreporter
+def get_test_reports(terminalreporter):
     dlist = []
-    for replist in tr.stats.values():
+    for replist in terminalreporter.stats.values():
         for rep in replist:
             if hasattr(rep, "duration"):
                 dlist.append(rep)
+    return dlist
+
+
+def report_file_durations(terminalreporter):
+    durations = 17
+    dlist = get_test_reports(terminalreporter)
     if not dlist:
         return
 
@@ -31,10 +35,54 @@ def pytest_terminal_summary(terminalreporter):
     dlist.sort(key=lambda x: x[1])
     dlist.reverse()
     if not durations:
-        tr.write_sep("=", "slowest file durations")
+        terminalreporter.write_sep("=", "slowest file durations")
     else:
-        tr.write_sep("=", "slowest %s file durations" % durations)
+        terminalreporter.write_sep("=", "slowest %s file durations" % durations)
         dlist = dlist[:durations]
 
     for filename, test_time in dlist:
-        tr.write_line("{:02.2f}s {:<8} {}".format(test_time, " ", filename))
+        terminalreporter.write_line("{:02.2f}s {}".format(test_time, filename))
+
+
+def report_funtions_durations(terminalreporter):
+    durations = 17
+    dlist = get_test_reports(terminalreporter)
+    if not dlist:
+        return
+
+    # group by file
+    durations_by_file = defaultdict(float)
+    for test_report in dlist:
+        if "[" in test_report.nodeid:
+            file_and_function = test_report.nodeid[:test_report.nodeid.index("[")]
+        else:
+            file_and_function = test_report.nodeid
+        durations_by_file[file_and_function] += test_report.duration
+
+    dlist = list(durations_by_file.items())
+
+    dlist.sort(key=lambda x: x[1])
+    dlist.reverse()
+    if not durations:
+        terminalreporter.write_sep("=", "slowest test functions durations")
+    else:
+        terminalreporter.write_sep("=", "slowest %s test functions" % durations)
+        dlist = dlist[:durations]
+
+    for filename, test_time in dlist:
+        terminalreporter.write_line("{:02.2f}s {}".format(test_time, filename))
+
+
+def report_sum_durations(terminalreporter):
+    """Print the sum of durations of all the tests."""
+    dlist = get_test_reports(terminalreporter)
+    if not dlist:
+        return
+
+    terminalreporter.write_sep("=", "Sum of all tests durations")
+    terminalreporter.write_line("{:02.2f}s".format(sum(x.duration for x in dlist)))
+
+def pytest_terminal_summary(terminalreporter):
+    report_file_durations(terminalreporter)
+    report_funtions_durations(terminalreporter)
+    report_sum_durations(terminalreporter)

--- a/tensorflow_addons/conftest.py
+++ b/tensorflow_addons/conftest.py
@@ -54,7 +54,7 @@ def report_funtions_durations(terminalreporter):
     durations_by_file = defaultdict(float)
     for test_report in dlist:
         if "[" in test_report.nodeid:
-            file_and_function = test_report.nodeid[:test_report.nodeid.index("[")]
+            file_and_function = test_report.nodeid[: test_report.nodeid.index("[")]
         else:
             file_and_function = test_report.nodeid
         durations_by_file[file_and_function] += test_report.duration
@@ -81,6 +81,7 @@ def report_sum_durations(terminalreporter):
 
     terminalreporter.write_sep("=", "Sum of all tests durations")
     terminalreporter.write_line("{:02.2f}s".format(sum(x.duration for x in dlist)))
+
 
 def pytest_terminal_summary(terminalreporter):
     report_file_durations(terminalreporter)


### PR DESCRIPTION
Related to #1655 and #1316

This should give us useful information. 

the --durations option gives us the slowest tests, but it's not useful because one function may result in multiple tests. With this, it's easier to target what we need to optimize.

The question is do we want that code here or should we make a separate repo that will act as a pytest plugin? I don't have a strong opinion on that.

Note that the code is not clean, I should add some command line arguments to control that. It's just a POC.