### PR TITLE
Remove the cleaning of the cache to speed up the build.

### DIFF
--- a/tools/docker/build_wheel.Dockerfile
+++ b/tools/docker/build_wheel.Dockerfile
@@ -46,7 +46,6 @@ ARG NIGHTLY_FLAG
 ARG NIGHTLY_TIME
 RUN --mount=type=cache,id=cache_bazel,target=/root/.cache/bazel \
     bash tools/testing/build_and_run_tests.sh && \
-    bazel clean --expunge && \
     bazel build \
         -c opt \
         --noshow_progress \


### PR DESCRIPTION
See #1655

We cleaned the cache to make sure that the options for building the wheels were taken into account, but one could argue that it's bazel's job to invalidate the cache, not ours, so we can let bazel decide what to do.


When building the wheel, we went from 5m to 1s.