### PR TITLE
Enable pytest-xdist when nvidia-smi is not found.

### DIFF
--- a/tensorflow_addons/rnn/tests/cell_test.py
+++ b/tensorflow_addons/rnn/tests/cell_test.py
@@ -306,7 +306,7 @@ def test_cell_output():
 
 
 def test_config_layer_norm():
-    cell = rnn_cell.LayerNormLSTMCell(10)
+    cell = rnn_cell.LayerNormLSTMCell(10, name="layer_norm_lstm_cell_3")
 
     expected_config = {
         "dtype": "float32",

--- a/tools/testing/build_and_run_tests.sh
+++ b/tools/testing/build_and_run_tests.sh
@@ -27,7 +27,7 @@ python -c "import tensorflow as tf; print(tf.config.list_physical_devices())"
 
 # If there are no gpus, we can use multiple workers
 # Multiple workers will be supported with gpus later.
-if ! type "$(nvidia-smi)" > /dev/null; then
+if ! [ -x "$(command -v nvidia-smi)" ]; then
   EXTRA_ARGS="-n auto"
 fi
 

--- a/tools/testing/build_and_run_tests.sh
+++ b/tools/testing/build_and_run_tests.sh
@@ -24,4 +24,12 @@ python -m pip install -r tools/install_deps/pytest.txt -e ./
 python ./configure.py
 bash tools/install_so_files.sh
 python -c "import tensorflow as tf; print(tf.config.list_physical_devices())"
-python -m pytest -v --durations=25 ./tensorflow_addons
+
+# If there are no gpus, we can use multiple workers
+# Multiple workers will be supported with gpus later.
+if ! type "$nvidia-smi" > /dev/null; then
+  EXTRA_ARGS="-n auto"
+fi
+
+
+python -m pytest -v --durations=25 $EXTRA_ARGS ./tensorflow_addons

--- a/tools/testing/build_and_run_tests.sh
+++ b/tools/testing/build_and_run_tests.sh
@@ -27,7 +27,7 @@ python -c "import tensorflow as tf; print(tf.config.list_physical_devices())"
 
 # If there are no gpus, we can use multiple workers
 # Multiple workers will be supported with gpus later.
-if ! type "$nvidia-smi" > /dev/null; then
+if ! type "$(nvidia-smi)" > /dev/null; then
   EXTRA_ARGS="-n auto"
 fi
 


### PR DESCRIPTION
Later on, we'll have a smart distribution of gpus among the workers, but we're not there yet.

See #1655

Before: 5m10s, after 2m7s (on the linux build).

EDIT: Since the order of the tests is not deterministic, I had to make sure to fix the name of a layer in a test.