### PR TITLE
Added float16 and bfloat16 support for TripletSemiHardLoss, TripletHardLoss and LiftedStructLoss

### DIFF
--- a/tensorflow_addons/losses/tests/lifted_test.py
+++ b/tensorflow_addons/losses/tests/lifted_test.py
@@ -58,7 +58,6 @@ def lifted_struct_loss_np(labels, embedding, margin):
     # Reshape labels to compute adjacency matrix.
     labels_reshaped = np.reshape(labels, (labels.shape[0], 1))
 
-    # Compute the loss in NP
     adjacency = np.equal(labels_reshaped, labels_reshaped.T)
     pdist_matrix = pairwise_distance_np(embedding)
     loss_np = 0.0
@@ -100,6 +99,7 @@ def test_lifted_struct(dtype):
     embedding = np.random.rand(num_data, feat_dim).astype(np.float32)
     labels = np.random.randint(0, num_classes, size=num_data).astype(np.float32)
 
+    # Compute the loss in NP
     loss_np = lifted_struct_loss_np(labels, embedding, margin)
 
     # Compute the loss in TF.

--- a/tensorflow_addons/losses/tests/triplet_test.py
+++ b/tensorflow_addons/losses/tests/triplet_test.py
@@ -56,9 +56,8 @@ def triplet_semihard_loss_np(labels, embedding, margin):
     num_data = embedding.shape[0]
     # Reshape labels to compute adjacency matrix.
     labels_reshaped = np.reshape(labels.astype(np.float32), (labels.shape[0], 1))
-    # Compute the loss in NP.
-    adjacency = np.equal(labels_reshaped, labels_reshaped.T)
 
+    adjacency = np.equal(labels_reshaped, labels_reshaped.T)
     pdist_matrix = pairwise_distance_np(embedding, squared=True)
     loss_np = 0.0
     num_positives = 0.0
@@ -94,9 +93,8 @@ def triplet_hard_loss_np(labels, embedding, margin, soft=False):
     num_data = embedding.shape[0]
     # Reshape labels to compute adjacency matrix.
     labels_reshaped = np.reshape(labels.astype(np.float32), (labels.shape[0], 1))
-    # Compute the loss in NP.
-    adjacency = np.equal(labels_reshaped, labels_reshaped.T)
 
+    adjacency = np.equal(labels_reshaped, labels_reshaped.T)
     pdist_matrix = pairwise_distance_np(embedding, squared=True)
     loss_np = 0.0
     for i in range(num_data):
@@ -137,6 +135,7 @@ def test_semihard_tripled_loss(dtype):
     embedding = np.random.rand(num_data, feat_dim).astype(np.float32)
     labels = np.random.randint(0, num_classes, size=(num_data))
 
+    # Compute the loss in NP.
     loss_np = triplet_semihard_loss_np(labels, embedding, margin)
 
     # Compute the loss in TF.
@@ -170,6 +169,7 @@ def test_hard_tripled_loss(dtype, soft):
     embedding = np.random.rand(num_data, feat_dim).astype(np.float32)
     labels = np.random.randint(0, num_classes, size=(num_data))
 
+    # Compute the loss in NP.
     loss_np = triplet_hard_loss_np(labels, embedding, margin, soft)
 
     # Compute the loss in TF.

--- a/tensorflow_addons/losses/tests/triplet_test.py
+++ b/tensorflow_addons/losses/tests/triplet_test.py
@@ -188,6 +188,44 @@ def test_unweighted_soft():
     np.testing.assert_allclose(loss, loss_np, rtol=1e-6, atol=1e-6)
 
 
+def test_dtypes_float16():
+    num_data = 20
+    feat_dim = 6
+    margin = 1.0
+    num_classes = 4
+
+    embedding = np.random.rand(num_data, feat_dim).astype(np.float16)
+    labels = np.random.randint(0, num_classes, size=(num_data))
+
+    loss_np = triplet_hard_loss_np(labels, embedding, margin)
+
+    # Compute the loss in TF.
+    y_true = tf.constant(labels)
+    y_pred = tf.constant(embedding, dtype=tf.float16)
+    cce_obj = triplet.TripletHardLoss()
+    loss = cce_obj(y_true, y_pred)
+    np.testing.assert_allclose(loss, loss_np, rtol=1e-5, atol=1e-5)
+
+
+def test_dtypes_bfloat16():
+    num_data = 20
+    feat_dim = 6
+    margin = 1.0
+    num_classes = 4
+
+    embedding = np.random.rand(num_data, feat_dim).astype(np.float16)
+    labels = np.random.randint(0, num_classes, size=(num_data))
+
+    loss_np = triplet_hard_loss_np(labels, embedding, margin)
+
+    # Compute the loss in TF.
+    y_true = tf.constant(labels)
+    y_pred = tf.constant(embedding, dtype=tf.bfloat16)
+    cce_obj = triplet.TripletHardLoss()
+    loss = cce_obj(y_true, y_pred)
+    np.testing.assert_allclose(loss.numpy(), loss_np, rtol=1e-2, atol=1e-2)
+
+
 def test_keras_model_compile_hard():
     model = tf.keras.models.Sequential(
         [tf.keras.layers.Input(shape=(784,)), tf.keras.layers.Dense(10),]


### PR DESCRIPTION
**System information**

- OS Platform and Distribution (e.g., Linux Ubuntu 16.04): Colab
- TensorFlow version and how it was installed (source or binary): 2.2.0-r3
- TensorFlow-Addons version and how it was installed (source or binary): 0.10.0-dev
- Python version: 3.6
- Is GPU used? (yes/no): yes

**Describe the bug**

When I build a model with mixed precision the input to TripletSemiHardLoss, TripletHardLoss and LiftedStructLoss should accept: float32, float16 or bfloat16.

float32 works fine, but float16 and bfloat16 are not supported by these losses.

**Code to reproduce the issue**
https://colab.research.google.com/drive/1BvOBlBcWnzvKKM5vp8RhYTOK-KMeygWy

```
        loss = tfa.losses.triplet_hard_loss(labels, logits)
    /usr/local/lib/python3.6/dist-packages/tensorflow_addons/losses/triplet.py:174 triplet_hard_loss  *
        pdist_matrix = metric_learning.pairwise_distance(embeddings, squared=True)
    /usr/local/lib/python3.6/dist-packages/tensorflow_addons/losses/metric_learning.py:55 pairwise_distance  *
        pairwise_distances = tf.math.multiply(
    /usr/local/lib/python3.6/dist-packages/tensorflow/python/util/dispatch.py:180 wrapper  **
        return target(*args, **kwargs)
    /usr/local/lib/python3.6/dist-packages/tensorflow/python/ops/math_ops.py:381 multiply
        return gen_math_ops.mul(x, y, name)
    /usr/local/lib/python3.6/dist-packages/tensorflow/python/ops/gen_math_ops.py:6092 mul
        "Mul", x=x, y=y, name=name)
    /usr/local/lib/python3.6/dist-packages/tensorflow/python/framework/op_def_library.py:506 _apply_op_helper
        inferred_from[input_arg.type_attr]))

    TypeError: Input 'y' of 'Mul' Op has type float32 that does not match type float16 of argument 'x'.
```

**Changed Files**

Added support for float16 and bfloat16 the same way as it is done for tf.nn.softmax_cross_entropy_with_logits:

https://github.com/tensorflow/tensorflow/blob/master/tensorflow/python/ops/nn_ops.py#L3507-L3510
