### PR TITLE
support bfloat16 for assert_allclose_according_to_type

### DIFF
--- a/tensorflow_addons/utils/test_utils.py
+++ b/tensorflow_addons/utils/test_utils.py
@@ -227,6 +227,8 @@ def assert_allclose_according_to_type(
     float_atol=1e-6,
     half_rtol=1e-3,
     half_atol=1e-3,
+    bfloat16_rtol=1e-2,
+    bfloat16_atol=1e-2,
 ):
     """
     Similar to tf.test.TestCase.assertAllCloseAccordingToType()
@@ -246,5 +248,8 @@ def assert_allclose_according_to_type(
     if a.dtype == np.float16 or b.dtype == np.float16:
         rtol = max(rtol, half_rtol)
         atol = max(atol, half_atol)
+    if a.dtype == tf.bfloat16.as_numpy_dtype or b.dtype == tf.bfloat16.as_numpy_dtype:
+        rtol = max(rtol, bfloat16_rtol)
+        atol = max(atol, bfloat16_atol)
 
     np.testing.assert_allclose(a, b, rtol=rtol, atol=atol)


### PR DESCRIPTION
Just port something from TF. TF extends bfloat dtype for numpy. So we can also check it for `assert_allclose_according_to_type`

https://colab.research.google.com/drive/1BbGWrbM_q02LykGoDTcW9YR93DXTgNug
https://github.com/tensorflow/tensorflow/blob/master/tensorflow/python/framework/test_util.py#L2562