### PR TITLE
Silence memset warning

### DIFF
--- a/tensorflow_addons/custom_ops/image/cc/kernels/resampler_ops.cc
+++ b/tensorflow_addons/custom_ops/image/cc/kernels/resampler_ops.cc
@@ -217,8 +217,8 @@ struct ResamplerGrad2DFunctor<CPUDevice, T> {
     const int grad_warp_size = resampler_output_size / data_channels * 2;
     const int grad_data_size =
         data_height * data_width * data_channels * batch_size;
-    memset(grad_data, 0, sizeof(T) * grad_data_size);
-    memset(grad_warp, 0, sizeof(T) * grad_warp_size);
+    memset(static_cast<void*>(grad_data), 0, sizeof(T) * grad_data_size);
+    memset(static_cast<void*>(grad_warp), 0, sizeof(T) * grad_warp_size);
 
     const auto&& data_batch_stride = data_height * data_width * data_channels;
     const auto&& warp_batch_stride = num_sampling_points * 2;


### PR DESCRIPTION
For gcc >= 8.0 (our docker uses 8.3), using `memset` to clearing non-trivial object will throw the following warning.

![image](https://user-images.githubusercontent.com/11615393/79603263-d7b04e80-80a0-11ea-87cf-6eec13bf04fb.png)

To silence it, we can explicitly cast the first argument with type (T*) to (void*).