### PR TITLE
Clarify the documentation of the Sampler class

### DIFF
--- a/tensorflow_addons/seq2seq/sampler.py
+++ b/tensorflow_addons/seq2seq/sampler.py
@@ -31,23 +31,30 @@ class Sampler(metaclass=abc.ABCMeta):
 
     Sampler instances are used by `BasicDecoder`. The normal usage of a sampler
     is like below:
+
+    ```python
     sampler = Sampler(init_args)
     (initial_finished, initial_inputs) = sampler.initialize(input_tensors)
-    for time_step in range(time):
-      cell_output, cell_state = cell.call(cell_input, previous_state)
+    cell_input = initial_inputs
+    cell_state = cell.get_initial_state(...)
+    for time_step in range(max_output_length):
+      cell_output, cell_state = cell(cell_input, cell_state)
       sample_ids = sampler.sample(time_step, cell_output, cell_state)
-      (finished, next_inputs, next_state) = sampler.next_inputs(
-          time_step,cell_output, cell_state)
+      (finished, cell_input, cell_state) = sampler.next_inputs(
+          time_step, cell_output, cell_state, sample_ids)
+      if tf.reduce_all(finished):
+        break
+    ```
 
-    Note that all the tensor input should not be feed to Sampler as __init__()
-    parameters, instead, they should be feed by decoders via initialize().
+    Note that the input_tensors should not be fed to the Sampler as __init__()
+    parameters. Instead, they should be fed by decoders via initialize().
     """
 
     @abc.abstractmethod
     def initialize(self, inputs, **kwargs):
         """initialize the sampler with the input tensors.
 
-        This method suppose to be only invoke once before the calling other
+        This method must be invoked exactly once before calling other
         methods of the Sampler.
 
         Args:

--- a/tensorflow_addons/seq2seq/sampler.py
+++ b/tensorflow_addons/seq2seq/sampler.py
@@ -38,12 +38,12 @@ class Sampler(metaclass=abc.ABCMeta):
     cell_input = initial_inputs
     cell_state = cell.get_initial_state(...)
     for time_step in tf.range(max_output_length):
-      cell_output, cell_state = cell(cell_input, cell_state)
-      sample_ids = sampler.sample(time_step, cell_output, cell_state)
-      (finished, cell_input, cell_state) = sampler.next_inputs(
-        time_step, cell_output, cell_state, sample_ids)
-      if tf.reduce_all(finished):
-        break
+        cell_output, cell_state = cell(cell_input, cell_state)
+        sample_ids = sampler.sample(time_step, cell_output, cell_state)
+        (finished, cell_input, cell_state) = sampler.next_inputs(
+            time_step, cell_output, cell_state, sample_ids)
+        if tf.reduce_all(finished):
+            break
     ```
 
     Note that the input_tensors should not be fed to the Sampler as __init__()

--- a/tensorflow_addons/seq2seq/sampler.py
+++ b/tensorflow_addons/seq2seq/sampler.py
@@ -37,11 +37,11 @@ class Sampler(metaclass=abc.ABCMeta):
     (initial_finished, initial_inputs) = sampler.initialize(input_tensors)
     cell_input = initial_inputs
     cell_state = cell.get_initial_state(...)
-    for time_step in range(max_output_length):
+    for time_step in tf.range(max_output_length):
       cell_output, cell_state = cell(cell_input, cell_state)
       sample_ids = sampler.sample(time_step, cell_output, cell_state)
       (finished, cell_input, cell_state) = sampler.next_inputs(
-          time_step, cell_output, cell_state, sample_ids)
+        time_step, cell_output, cell_state, sample_ids)
       if tf.reduce_all(finished):
         break
     ```


### PR DESCRIPTION
Format code in python code block, add missing `sample_ids` in the call to `next_inputs(...)`, call `cell(...)` instead of `cell.call(...)` so the cell gets built if necessary (this makes it easier to take the code example and actually try it out), for example:

```python
import tensorflow_addons as tfa
import tensorflow as tf
from tensorflow import keras

input_tensors = tf.constant([[[1., 2.], [4., 3.], [6., 5.]],
                             [[7., 8.], [10., 9.], [11., 12.]]])
sampler = tfa.seq2seq.TrainingSampler()
(initial_finished, initial_inputs) = sampler.initialize(input_tensors)
cell = keras.layers.LSTMCell(4)
cell_input = initial_inputs
cell_state = cell.get_initial_state(batch_size=len(input_tensors),
                                    dtype=input_tensors.dtype)
max_output_length = input_tensors.shape[1]
for time_step in range(max_output_length):
  cell_output, cell_state = cell(cell_input, cell_state)
  sample_ids = sampler.sample(time_step, cell_output, cell_state)
  (finished, cell_input, cell_state) = sampler.next_inputs(
      time_step, cell_output, cell_state, sample_ids)
  if tf.reduce_all(finished):
    break
```