### PR TITLE
Added pytest-extra-durations to monitor the speed of the tests.

### DIFF
--- a/tools/install_deps/pytest.txt
+++ b/tools/install_deps/pytest.txt
@@ -1,5 +1,6 @@
 pytest~=5.3
 pytest-xdist~=1.31
+pytest-extra-durations~=0.1.2
 scikit-learn~=0.22
 scikit-image~=0.15.0
 Pillow~=7.0.0

--- a/tools/install_deps/pytest.txt
+++ b/tools/install_deps/pytest.txt
@@ -1,6 +1,6 @@
 pytest~=5.3
 pytest-xdist~=1.31
-pytest-extra-durations~=0.1.2
+pytest-extra-durations~=0.1.3
 scikit-learn~=0.22
 scikit-image~=0.15.0
 Pillow~=7.0.0

--- a/tools/testing/build_and_run_tests.sh
+++ b/tools/testing/build_and_run_tests.sh
@@ -32,4 +32,4 @@ if ! [ -x "$(command -v nvidia-smi)" ]; then
 fi
 
 
-python -m pytest -v --durations=25 $EXTRA_ARGS ./tensorflow_addons
+python -m pytest -v --functions-durations=20 --modules-durations=5 $EXTRA_ARGS ./tensorflow_addons


### PR DESCRIPTION
Should be enough to ensure the duration of the tests doesn't blow up out of nowhere.

Closes #1316

Current output:

```
========================== slowest modules durations ===========================
49.85s tensorflow_addons/seq2seq/tests/attention_wrapper_test.py
24.94s tensorflow_addons/layers/tests/normalizations_test.py
17.38s tensorflow_addons/image/tests/filters_test.py
14.21s tensorflow_addons/optimizers/tests/lookahead_test.py
14.14s tensorflow_addons/optimizers/tests/rectified_adam_test.py
======================= slowest test functions durations =======================
11.66s tensorflow_addons/layers/tests/optical_flow_test.py::test_gradients
10.53s tensorflow_addons/optimizers/tests/cyclical_learning_rate_test.py::test_exponential_cyclical_learning_rate
7.97s tensorflow_addons/optimizers/tests/lookahead_test.py::test_fit_simple_linear_model
7.69s tensorflow_addons/optimizers/tests/novograd_test.py::test_fit_simple_linear_model
6.88s tensorflow_addons/optimizers/tests/stochastic_weight_averaging_test.py::test_fit_simple_linear_model
6.00s tensorflow_addons/layers/tests/normalizations_test.py::test_groupnorm_2d_different_groups
5.97s tensorflow_addons/optimizers/tests/moving_average_test.py::test_fit_simple_linear_model
5.58s tensorflow_addons/seq2seq/tests/attention_wrapper_test.py::AttentionMechanismTest::test_save_load_layer_bahdanau_monotonic
5.28s tensorflow_addons/seq2seq/tests/attention_wrapper_test.py::AttentionMechanismTest::test_save_load_layer_bahdanau
5.18s tensorflow_addons/seq2seq/tests/attention_wrapper_test.py::AttentionMechanismTest::test_save_load_layer_luong
5.04s tensorflow_addons/seq2seq/tests/attention_wrapper_test.py::AttentionMechanismTest::test_save_load_layer_luong_monotonic
3.81s tensorflow_addons/optimizers/tests/lookahead_test.py::test_sparse_exact_ratio
3.64s tensorflow_addons/layers/tests/normalizations_test.py::test_picture_input
3.43s tensorflow_addons/layers/tests/wrappers_test.py::test_model_build
3.31s tensorflow_addons/layers/tests/netvlad_test.py::test_simple
2.97s tensorflow_addons/seq2seq/tests/attention_wrapper_test.py::AttentionWrapperTest::testLuongScaled
2.94s tensorflow_addons/image/tests/dense_image_warp_test.py::test_interpolation
2.76s tensorflow_addons/callbacks/tests/time_stopping_test.py::test_time_stopping_verbose
2.69s tensorflow_addons/losses/tests/npairs_test.py::test_unweighted
2.67s tensorflow_addons/seq2seq/tests/attention_wrapper_test.py::AttentionMechanismTest::test_memory_re_setup_bahdanau_monotonic
========================== sum of all tests durations ==========================
271.92s
```