### PR TITLE
In scheduled samplers, don't convert sampling_probability if it's a tf.Variable

### DIFF
--- a/tensorflow_addons/seq2seq/sampler.py
+++ b/tensorflow_addons/seq2seq/sampler.py
@@ -336,9 +336,12 @@ class ScheduledEmbeddingTrainingSampler(TrainingSampler):
             raise ValueError(
                 "embedding_fn is expected to be callable, got %s" % type(embedding_fn)
             )
-        self.sampling_probability = tf.convert_to_tensor(
-            sampling_probability, name="sampling_probability"
-        )
+        if isinstance(sampling_probability, tf.Variable):
+            self.sampling_probability = sampling_probability
+        else:
+            self.sampling_probability = tf.convert_to_tensor(
+                sampling_probability, name="sampling_probability"
+            )
         if self.sampling_probability.get_shape().ndims not in (0, 1):
             raise ValueError(
                 "sampling_probability must be either a scalar or a vector. "
@@ -430,13 +433,16 @@ class ScheduledOutputTrainingSampler(TrainingSampler):
         Raises:
           ValueError: if `sampling_probability` is not a scalar or vector.
         """
-        self.sampling_probability = tf.convert_to_tensor(
-            sampling_probability, name="sampling_probability"
-        )
+        if isinstance(sampling_probability, tf.Variable):
+            self.sampling_probability = sampling_probability
+        else:
+            self.sampling_probability = tf.convert_to_tensor(
+                sampling_probability, name="sampling_probability"
+            )
         if self.sampling_probability.get_shape().ndims not in (0, 1):
             raise ValueError(
                 "sampling_probability must be either a scalar or a vector. "
-                "saw shape: %s" % (self._sampling_probability.get_shape())
+                "saw shape: %s" % (self.sampling_probability.get_shape())
             )
 
         self.seed = seed


### PR DESCRIPTION
To change the `sampling_probability` during training, the simplest option is to make it a `tf.Variable` (alternatively, it could be a placeholder). However, the current constructors of the scheduled samplers call `tf.convert_to_tensor(sampling_probability)`, which converts variables into static tensors. This forces the user to write:

```python
sampler = tfa.seq2seq.sampler.ScheduledEmbeddingTrainingSampler(
    sampling_probability=0.,
    embedding_fn=decoder_embedding_layer)
sampler.sampling_probability = tf.Variable(0.)
```

This is not too hard, but it's not immediately obvious (and the documentation does not cover this), and it really feels like a hack. It would be more natural to just keep the `sampling_probability` as a variable in the constructor, so we could just write:

```
sampling_probability = tf.Variable(0.)
sampler = tfa.seq2seq.sampler.ScheduledEmbeddingTrainingSampler(
    sampling_probability=sampling_probability,
    embedding_fn=decoder_embedding_layer)
```

Note: I also fixed a typo `_sampling_probability` => `sampling_probability`