### PR TITLE
Extend Image Function

### DIFF
--- a/tensorflow_addons/image/tests/transform_ops_test.py
+++ b/tensorflow_addons/image/tests/transform_ops_test.py
@@ -132,6 +132,38 @@ def test_transform_eager():
 
 @pytest.mark.usefixtures("maybe_run_functions_eagerly")
 @pytest.mark.parametrize("dtype", _DTYPES)
+def test_extend_basic(dtype):
+    image = tf.reshape(tf.range(4, dtype=dtype), (2, 2))
+    image_extended = transform_ops.extend(image, 1)
+    np.testing.assert_equal(
+        image_extended.numpy(),
+        [
+            [0, 0, 1, 1],
+            [0, 0, 1, 1],
+            [2, 2, 3, 3],
+            [2, 2, 3, 3],
+        ]
+    )
+
+
+@pytest.mark.usefixtures("maybe_run_functions_eagerly")
+@pytest.mark.parametrize("dtype", _DTYPES)
+def test_extend_uneven(dtype):
+    image = tf.reshape(tf.range(4, dtype=dtype), (2, 2))
+    image_extended = transform_ops.extend(image, (1, 2))
+    np.testing.assert_equal(
+        image_extended.numpy(),
+        [
+            [0, 0, 0, 1, 1, 1],
+            [0, 0, 0, 1, 1, 1],
+            [2, 2, 2, 3, 3, 3],
+            [2, 2, 2, 3, 3, 3],
+        ]
+    )
+
+
+@pytest.mark.usefixtures("maybe_run_functions_eagerly")
+@pytest.mark.parametrize("dtype", _DTYPES)
 def test_zeros(dtype):
     for shape in [(5, 5), (24, 24), (2, 24, 24, 3)]:
         for angle in [0, 1, np.pi / 2.0]:

--- a/tensorflow_addons/image/transform_ops.py
+++ b/tensorflow_addons/image/transform_ops.py
@@ -434,6 +434,3 @@ def shear_y(image: TensorLike, level: float, replace: int) -> TensorLike:
     #  level  1].
     image = transform(wrap(image), [1.0, 0.0, 0.0, level, 1.0, 0.0, 0.0, 0.0])
     return unwrap(image, replace)
-
-
-


### PR DESCRIPTION
Related to #1318.

Pads an image by extending the borders of the image by some predefined size. I separated it out to a new function because it seemed useful for more situations than just rotation (for example, I used it before calling `tf.image.random_crop` to get a randomly shifted image). I currently named it `tfa.image.extend` but it might make more sense to use something like `tfa.image.pad____` to fit in line with the other pad functions (`tf.image.resize_and_pad`, `tf.image.pad_to_bounding_box`, etc.).