### PR TITLE
Support extended mode on projective transform

### DIFF
--- a/tensorflow_addons/custom_ops/image/cc/kernels/image_projective_transform_op.h
+++ b/tensorflow_addons/custom_ops/image/cc/kernels/image_projective_transform_op.h
@@ -20,7 +20,6 @@ limitations under the License.
 
 #define EIGEN_USE_THREADS
 
-#include "tensorflow/core/framework/bounds_check.h"
 #include "tensorflow/core/framework/tensor_types.h"
 #include "tensorflow/core/platform/types.h"
 #include "third_party/eigen3/unsupported/Eigen/CXX11/Tensor"

--- a/tensorflow_addons/custom_ops/image/cc/ops/image_ops.cc
+++ b/tensorflow_addons/custom_ops/image/cc/ops/image_ops.cc
@@ -135,6 +135,8 @@ REGISTER_OP("Addons>ImageProjectiveTransformV2")
     .Input("output_shape: int32")
     .Attr("dtype: {uint8, int32, int64, float16, float32, float64}")
     .Attr("interpolation: string")
+    .Attr("extend: string")
+    .Attr("constant_values: float = 0.0")
     .Output("transformed_images: dtype")
     .SetShapeFn(ResizeShapeFn)
     .Doc(kImageProjectiveTransformDoc);

--- a/tensorflow_addons/image/tests/transform_ops_test.py
+++ b/tensorflow_addons/image/tests/transform_ops_test.py
@@ -19,7 +19,6 @@ import numpy as np
 import tensorflow as tf
 
 from tensorflow_addons.image import transform_ops
-from tensorflow_addons.utils import test_utils
 from scipy import ndimage
 from skimage import transform
 

--- a/tensorflow_addons/image/tests/transform_ops_test.py
+++ b/tensorflow_addons/image/tests/transform_ops_test.py
@@ -20,6 +20,7 @@ import tensorflow as tf
 
 from tensorflow_addons.image import transform_ops
 from tensorflow_addons.utils import test_utils
+from scipy import ndimage
 from skimage import transform
 
 _DTYPES = {
@@ -212,6 +213,31 @@ def test_rotate_odd(dtype):
                 [24, 19, 14, 9, 4],
             ],
         ],
+    )
+
+
+@pytest.mark.usefixtures("maybe_run_functions_eagerly")
+@pytest.mark.parametrize("extend", ["MIRROR", "CONSTANT", "NEAREST", "WRAP"])
+def test_rotate_extend(extend):
+    image = tf.constant(
+        [
+            [0, 0, 0, 0, 0],
+            [0, 1, 1, 1, 0],
+            [0, 1, 0, 1, 0],
+            [0, 1, 1, 1, 0],
+            [0, 0, 0, 0, 0],
+        ],
+        tf.float32,
+    )
+
+    transformed = transform_ops.rotate(
+        image, np.pi / 4.0, interpolation="BILINEAR", extend=extend
+    )
+    np.testing.assert_allclose(
+        transformed.numpy(),
+        ndimage.rotate(image.numpy(), 45, order=1, mode=extend.lower(), reshape=False),
+        rtol=1e-6,
+        atol=5e-6,
     )
 
 

--- a/tensorflow_addons/image/tests/transform_ops_test.py
+++ b/tensorflow_addons/image/tests/transform_ops_test.py
@@ -217,7 +217,7 @@ def test_rotate_odd(dtype):
 
 
 @pytest.mark.usefixtures("maybe_run_functions_eagerly")
-@pytest.mark.parametrize("extend", ["MIRROR", "CONSTANT", "NEAREST", "WRAP"])
+@pytest.mark.parametrize("extend", ["CONSTANT", "MIRROR", "NEAREST", "WRAP"])
 def test_rotate_extend(extend):
     image = tf.constant(
         [

--- a/tensorflow_addons/image/transform_ops.py
+++ b/tensorflow_addons/image/transform_ops.py
@@ -65,7 +65,6 @@ def transform(
       extend: Extend mode. Supported values: "REFLECT",
         "CONSTANT", "NEAREST", "MIRROR", "WRAP".
       constant_values: The fill value to use in "CONSTANT" extend mode.
-
       name: The name of the op.
 
     Returns:

--- a/tensorflow_addons/image/transform_ops.py
+++ b/tensorflow_addons/image/transform_ops.py
@@ -40,6 +40,8 @@ def transform(
     transforms: TensorLike,
     interpolation: str = "NEAREST",
     output_shape: Optional[list] = None,
+    extend: str = "CONSTANT",
+    constant_values: TensorLike = 0.0,
     name: Optional[str] = None,
 ) -> tf.Tensor:
     """Applies the given transform(s) to the image(s).
@@ -60,6 +62,9 @@ def transform(
         Supported values: "NEAREST", "BILINEAR".
       output_shape: Output dimesion after the transform, [height, width].
         If None, output is the same size as input image.
+      extend: Extend mode. Supported values: "REFLECT",
+        "CONSTANT", "NEAREST", "MIRROR", "WRAP".
+      constant_values: The fill value to use in "CONSTANT" extend mode.
 
       name: The name of the op.
 
@@ -113,6 +118,8 @@ def transform(
             output_shape=output_shape,
             transforms=transforms,
             interpolation=interpolation.upper(),
+            extend=extend.upper(),
+            constant_values=constant_values,
         )
         return img_utils.from_4D_image(output, original_ndims)
 
@@ -277,6 +284,8 @@ def _image_projective_transform_grad(op, grad):
     images = op.inputs[0]
     transforms = op.inputs[1]
     interpolation = op.get_attr("interpolation")
+    extend = op.get_attr("extend")
+    constant_values = op.get_attr("constant_values")
 
     image_or_images = tf.convert_to_tensor(images, name="images")
     transform_or_transforms = tf.convert_to_tensor(
@@ -305,6 +314,8 @@ def _image_projective_transform_grad(op, grad):
         transforms=transforms,
         output_shape=tf.shape(image_or_images)[1:3],
         interpolation=interpolation,
+        extend=extend,
+        constant_values=constant_values,
     )
     return [output, None, None]
 
@@ -313,6 +324,8 @@ def rotate(
     images: TensorLike,
     angles: TensorLike,
     interpolation: str = "NEAREST",
+    extend: str = "CONSTANT",
+    constant_values: TensorLike = 0.0,
     name: Optional[str] = None,
 ) -> tf.Tensor:
     """Rotate image(s) counterclockwise by the passed angle(s) in radians.
@@ -327,6 +340,9 @@ def rotate(
         batch.
       interpolation: Interpolation mode. Supported values: "NEAREST",
         "BILINEAR".
+      extend: Extend mode. Supported values: "REFLECT",
+        "CONSTANT", "NEAREST", "MIRROR", "WRAP".
+      constant_values: The fill value to use in "CONSTANT" extend mode.
       name: The name of the op.
 
     Returns:
@@ -349,6 +365,8 @@ def rotate(
             images,
             angles_to_projective_transforms(angles, image_height, image_width),
             interpolation=interpolation,
+            extend=extend,
+            constant_values=constant_values,
         )
         return img_utils.from_4D_image(output, original_ndims)
 


### PR DESCRIPTION
Closed #1318. Support extend mode on projective transform. Mainly follow the [scipy's implementation](https://github.com/scipy/scipy/blob/master/scipy/ndimage/src/ni_interpolation.c).

From top to bottom: original, reflect, constant, mirror, nearest, wrap. Addons is on the left, scipy is on the right.

![test](https://user-images.githubusercontent.com/11615393/80158428-4e57bb00-857d-11ea-8830-dd67ce71fd6d.png)


Testing script:
```python3
import numpy as np

import tensorflow as tf
import tensorflow_addons as tfa

from scipy import ndimage, misc

image = misc.face()

tf.io.write_file("test.jpeg", tf.io.encode_jpeg(image))

for mode in ["CONSTANT", "REFLECT", "WRAP", "MIRROR", "NEAREST"]:
    t = tfa.image.rotate(image, np.pi / 4, extend=mode)
    tf.io.write_file(mode.lower() + ".jpeg", tf.io.encode_jpeg(t))
    st = ndimage.rotate(image, 45, mode=mode.lower(), reshape=False)
    tf.io.write_file("scipy-" + mode.lower() + ".jpeg", tf.io.encode_jpeg(st))
```
