### PR TITLE
Fixed CyclicLearningRate and its tests' errors

### DIFF
--- a/tensorflow_addons/optimizers/cyclical_learning_rate.py
+++ b/tensorflow_addons/optimizers/cyclical_learning_rate.py
@@ -104,6 +104,7 @@ class CyclicalLearningRate(tf.keras.optimizers.schedules.LearningRateSchedule):
         return {
             "initial_learning_rate": self.initial_learning_rate,
             "maximal_learning_rate": self.maximal_learning_rate,
+            "scale_fn": self.scale_fn,
             "step_size": self.step_size,
             "scale_mode": self.scale_mode,
         }
@@ -169,6 +170,11 @@ class TriangularCyclicalLearningRate(CyclicalLearningRate):
             name=name,
         )
 
+    def get_config(self):
+        super_config = super().get_config()
+        super_config = {k: v for k, v in super_config.items() if k != "scale_fn"}
+        return {**super_config}
+
 
 @tf.keras.utils.register_keras_serializable(package="Addons")
 class Triangular2CyclicalLearningRate(CyclicalLearningRate):
@@ -229,6 +235,11 @@ class Triangular2CyclicalLearningRate(CyclicalLearningRate):
             scale_mode=scale_mode,
             name=name,
         )
+
+    def get_config(self):
+        super_config = super().get_config()
+        super_config = {k: v for k, v in super_config.items() if k != "scale_fn"}
+        return {**super_config}
 
 
 @tf.keras.utils.register_keras_serializable(package="Addons")
@@ -297,4 +308,6 @@ class ExponentialCyclicalLearningRate(CyclicalLearningRate):
         )
 
     def get_config(self):
-        return {"gamma": self.gamma, **super().get_config()}
+        super_config = super().get_config()
+        super_config = {k: v for k, v in super_config.items() if k != "scale_fn"}
+        return {"gamma": self.gamma, **super_config}

--- a/tensorflow_addons/optimizers/cyclical_learning_rate.py
+++ b/tensorflow_addons/optimizers/cyclical_learning_rate.py
@@ -171,9 +171,12 @@ class TriangularCyclicalLearningRate(CyclicalLearningRate):
         )
 
     def get_config(self):
-        super_config = super().get_config()
-        super_config = {k: v for k, v in super_config.items() if k != "scale_fn"}
-        return {**super_config}
+        return {
+            "initial_learning_rate": self.initial_learning_rate,
+            "maximal_learning_rate": self.maximal_learning_rate,
+            "step_size": self.step_size,
+            "scale_mode": self.scale_mode,
+        }
 
 
 @tf.keras.utils.register_keras_serializable(package="Addons")
@@ -237,9 +240,12 @@ class Triangular2CyclicalLearningRate(CyclicalLearningRate):
         )
 
     def get_config(self):
-        super_config = super().get_config()
-        super_config = {k: v for k, v in super_config.items() if k != "scale_fn"}
-        return {**super_config}
+        return {
+            "initial_learning_rate": self.initial_learning_rate,
+            "maximal_learning_rate": self.maximal_learning_rate,
+            "step_size": self.step_size,
+            "scale_mode": self.scale_mode,
+        }
 
 
 @tf.keras.utils.register_keras_serializable(package="Addons")
@@ -308,6 +314,10 @@ class ExponentialCyclicalLearningRate(CyclicalLearningRate):
         )
 
     def get_config(self):
-        super_config = super().get_config()
-        super_config = {k: v for k, v in super_config.items() if k != "scale_fn"}
-        return {"gamma": self.gamma, **super_config}
+        return {
+            "initial_learning_rate": self.initial_learning_rate,
+            "maximal_learning_rate": self.maximal_learning_rate,
+            "step_size": self.step_size,
+            "scale_mode": self.scale_mode,
+            "gamma": self.gamma,
+        }


### PR DESCRIPTION
Fixes #1203 .  

**What was causing the errors?**  
- The derived classes of `CyclicLearningRate` doesn't have attribute `scale_fn` which was returned by mistake in `get_config()` through `**super().get_config()`.  
- The tests were poorly written and that's why y_true and y_pred were calculated from two different functions. That's why it was failing.

I have resolved all the errors related to it. Also added one more test which was overlooked in previous implementation.  

@gabrieldemarmiesse and @seanpmorgan - Please review it.