### PR TITLE
Added angular distance option to triplet loss

### DIFF
--- a/tensorflow_addons/losses/metric_learning.py
+++ b/tensorflow_addons/losses/metric_learning.py
@@ -65,6 +65,7 @@ def pairwise_distance(feature, squared=False):
     pairwise_distances = tf.math.multiply(pairwise_distances, mask_offdiagonals)
     return pairwise_distances
 
+
 @tf.function
 def angular_distance(feature):
     """Computes the angular distance matrix
@@ -78,12 +79,12 @@ def angular_distance(feature):
       angular_distances: 2-D Tensor of size [number of data, number of data].
     """
     # normalize input
-    feature = tf.math.l2_normalize(feature, axis = 1)
+    feature = tf.math.l2_normalize(feature, axis=1)
 
     # create adjaceny matrix of cosine similarity
     angular_distances = 1 - tf.matmul(feature, tf.transpose(feature))
 
     # ensure all distances > 1e-16
     angular_distances = tf.maximum(angular_distances, 1e-16)
-    
+
     return angular_distances

--- a/tensorflow_addons/losses/metric_learning.py
+++ b/tensorflow_addons/losses/metric_learning.py
@@ -68,7 +68,7 @@ def pairwise_distance(feature, squared=False):
 
 @tf.function
 def angular_distance(feature):
-    """Computes the angular distance matrix
+    """Computes the angular distance matrix.
 
     output[i, j] = 1 - cosine_similarity(feature[i, :], feature[j, :])
 
@@ -82,9 +82,9 @@ def angular_distance(feature):
     feature = tf.math.l2_normalize(feature, axis=1)
 
     # create adjaceny matrix of cosine similarity
-    angular_distances = 1 - tf.matmul(feature, tf.transpose(feature))
+    angular_distances = 1 - tf.matmul(feature, feature, transpose_b=True)
 
     # ensure all distances > 1e-16
-    angular_distances = tf.maximum(angular_distances, 1e-16)
+    angular_distances = tf.maximum(angular_distances, 0.0)
 
     return angular_distances

--- a/tensorflow_addons/losses/metric_learning.py
+++ b/tensorflow_addons/losses/metric_learning.py
@@ -70,7 +70,7 @@ def pairwise_distance(feature, squared=False):
 def angular_distance(feature):
     """Computes the angular distance matrix
 
-    output[i, j] = cosine_similarity(feature[i, :], feature[j, :])
+    output[i, j] = 1 - cosine_similarity(feature[i, :], feature[j, :])
 
     Args:
       feature: 2-D Tensor of size [number of data, feature dimension].

--- a/tensorflow_addons/losses/metric_learning.py
+++ b/tensorflow_addons/losses/metric_learning.py
@@ -64,3 +64,26 @@ def pairwise_distance(feature, squared=False):
     )
     pairwise_distances = tf.math.multiply(pairwise_distances, mask_offdiagonals)
     return pairwise_distances
+
+@tf.function
+def angular_distance(feature):
+    """Computes the angular distance matrix
+
+    output[i, j] = cosine_similarity(feature[i, :], feature[j, :])
+
+    Args:
+      feature: 2-D Tensor of size [number of data, feature dimension].
+
+    Returns:
+      angular_distances: 2-D Tensor of size [number of data, number of data].
+    """
+    # normalize input
+    feature = tf.math.l2_normalize(feature, axis = 1)
+
+    # create adjaceny matrix of cosine similarity
+    angular_distances = 1 - tf.matmul(feature, tf.transpose(feature))
+
+    # ensure all distances > 1e-16
+    angular_distances = tf.maximum(angular_distances, 1e-16)
+    
+    return angular_distances

--- a/tensorflow_addons/losses/metric_learning.py
+++ b/tensorflow_addons/losses/metric_learning.py
@@ -15,10 +15,11 @@
 """Functions of metric learning."""
 
 import tensorflow as tf
+from tensorflow_addons.utils.types import TensorLike
 
 
 @tf.function
-def pairwise_distance(feature, squared=False):
+def pairwise_distance(feature: TensorLike, squared: bool = False):
     """Computes the pairwise distance matrix with numerical stability.
 
     output[i, j] = || feature[i, :] - feature[j, :] ||_2
@@ -67,7 +68,7 @@ def pairwise_distance(feature, squared=False):
 
 
 @tf.function
-def angular_distance(feature):
+def angular_distance(feature: TensorLike):
     """Computes the angular distance matrix.
 
     output[i, j] = 1 - cosine_similarity(feature[i, :], feature[j, :])

--- a/tensorflow_addons/losses/tests/triplet_test.py
+++ b/tensorflow_addons/losses/tests/triplet_test.py
@@ -70,9 +70,7 @@ def angular_distance_np(feature):
 
     # l2-normalize all features
     normed = feature / np.linalg.norm(feature, ord=2, axis=1, keepdims=True)
-
     cosine_similarity = normed @ normed.T
-
     inverse_cos_sim = 1 - cosine_similarity
 
     return inverse_cos_sim
@@ -156,7 +154,7 @@ def triplet_hard_loss_np(labels, embedding, margin, dist_func, soft=False):
 @pytest.mark.parametrize("dtype", [tf.float32, tf.float16, tf.bfloat16])
 @pytest.mark.parametrize(
     "dist_func, dist_metric",
-    [(angular_distance_np, "angular"), (l_2_dists, "L_2"), (l_1_dists, "L_1")],
+    [(angular_distance_np, "angular"), (l_2_dists, "L2"), (l_1_dists, "L1")],
 )
 def test_semihard_tripled_loss_angular(dtype, dist_func, dist_metric):
     num_data = 10
@@ -195,7 +193,7 @@ def test_serialization_semihard():
 @pytest.mark.parametrize("soft", [False, True])
 @pytest.mark.parametrize(
     "dist_func, dist_metric",
-    [(angular_distance_np, "angular"), (l_2_dists, "L_2"), (l_1_dists, "L_1")],
+    [(angular_distance_np, "angular"), (l_2_dists, "L2"), (l_1_dists, "L1")],
 )
 def test_hard_tripled_loss_angular(dtype, soft, dist_func, dist_metric):
     num_data = 20

--- a/tensorflow_addons/losses/tests/triplet_test.py
+++ b/tensorflow_addons/losses/tests/triplet_test.py
@@ -51,6 +51,14 @@ def pairwise_distance_np(feature, squared=False):
     return pairwise_distances
 
 
+def L_2_dists(embs):
+    return pairwise_distance_np(embs, True)
+
+
+def L_1_dists(embs):
+    return pairwise_distance_np(embs, False)
+
+
 def angular_distance_np(feature):
     """Computes the angular distance matrix in numpy.
     Args:
@@ -70,14 +78,14 @@ def angular_distance_np(feature):
     return inverse_cos_sim
 
 
-def triplet_semihard_loss_np(labels, embedding, margin):
+def triplet_semihard_loss_np(labels, embedding, margin, dist_func):
 
     num_data = embedding.shape[0]
     # Reshape labels to compute adjacency matrix.
     labels_reshaped = np.reshape(labels.astype(np.float32), (labels.shape[0], 1))
 
     adjacency = np.equal(labels_reshaped, labels_reshaped.T)
-    pdist_matrix = pairwise_distance_np(embedding, squared=True)
+    pdist_matrix = dist_func(embedding)
     loss_np = 0.0
     num_positives = 0.0
     for i in range(num_data):
@@ -107,14 +115,14 @@ def triplet_semihard_loss_np(labels, embedding, margin):
     return loss_np
 
 
-def triplet_hard_loss_np(labels, embedding, margin, soft=False):
+def triplet_hard_loss_np(labels, embedding, margin, dist_func, soft=False):
 
     num_data = embedding.shape[0]
     # Reshape labels to compute adjacency matrix.
     labels_reshaped = np.reshape(labels.astype(np.float32), (labels.shape[0], 1))
 
     adjacency = np.equal(labels_reshaped, labels_reshaped.T)
-    pdist_matrix = pairwise_distance_np(embedding, squared=True)
+    pdist_matrix = dist_func(embedding)
     loss_np = 0.0
     for i in range(num_data):
         pos_distances = []
@@ -144,81 +152,9 @@ def triplet_hard_loss_np(labels, embedding, margin, soft=False):
     return loss_np
 
 
-def triplet_semihard_loss_angular_np(labels, embedding, margin):
-
-    num_data = embedding.shape[0]
-    # Reshape labels to compute adjacency matrix.
-    labels_reshaped = np.reshape(labels.astype(np.float32), (labels.shape[0], 1))
-
-    adjacency = np.equal(labels_reshaped, labels_reshaped.T)
-    pdist_matrix = angular_distance_np(embedding)
-    loss_np = 0.0
-    num_positives = 0.0
-    for i in range(num_data):
-        for j in range(num_data):
-            if adjacency[i][j] > 0.0 and i != j:
-                num_positives += 1.0
-
-                pos_distance = pdist_matrix[i][j]
-                neg_distances = []
-
-                for k in range(num_data):
-                    if adjacency[i][k] == 0:
-                        neg_distances.append(pdist_matrix[i][k])
-
-                # Sort by distance.
-                neg_distances.sort()
-                chosen_neg_distance = neg_distances[0]
-
-                for l in range(len(neg_distances)):
-                    chosen_neg_distance = neg_distances[l]
-                    if chosen_neg_distance > pos_distance:
-                        break
-                loss_np += np.maximum(0.0, margin - chosen_neg_distance + pos_distance)
-
-    loss_np /= num_positives
-    return loss_np
-
-
-def triplet_hard_loss_angular_np(labels, embedding, margin, soft=False):
-
-    num_data = embedding.shape[0]
-    # Reshape labels to compute adjacency matrix.
-    labels_reshaped = np.reshape(labels.astype(np.float32), (labels.shape[0], 1))
-
-    adjacency = np.equal(labels_reshaped, labels_reshaped.T)
-    pdist_matrix = angular_distance_np(embedding)
-    loss_np = 0.0
-    for i in range(num_data):
-        pos_distances = []
-        neg_distances = []
-        for j in range(num_data):
-            if adjacency[i][j] == 0:
-                neg_distances.append(pdist_matrix[i][j])
-            if adjacency[i][j] > 0.0 and i != j:
-                pos_distances.append(pdist_matrix[i][j])
-
-        # if there are no positive pairs, distance is 0
-        if len(pos_distances) == 0:
-            pos_distances.append(0)
-
-        # Sort by distance.
-        neg_distances.sort()
-        min_neg_distance = neg_distances[0]
-        pos_distances.sort(reverse=True)
-        max_pos_distance = pos_distances[0]
-
-        if soft:
-            loss_np += np.log1p(np.exp(max_pos_distance - min_neg_distance))
-        else:
-            loss_np += np.maximum(0.0, max_pos_distance - min_neg_distance + margin)
-
-    loss_np /= num_data
-    return loss_np
-
-
+# test cosine similarity
 @pytest.mark.parametrize("dtype", [tf.float32, tf.float16, tf.bfloat16])
-def test_semihard_tripled_loss(dtype):
+def test_semihard_tripled_loss_angular(dtype):
     num_data = 10
     feat_dim = 6
     margin = 1.0
@@ -228,12 +164,56 @@ def test_semihard_tripled_loss(dtype):
     labels = np.random.randint(0, num_classes, size=(num_data))
 
     # Compute the loss in NP.
-    loss_np = triplet_semihard_loss_np(labels, embedding, margin)
+    loss_np = triplet_semihard_loss_np(labels, embedding, margin, angular_distance_np)
+
+    # Compute the loss in TF.
+    y_true = tf.constant(labels)
+    y_pred = tf.constant(embedding, dtype=dtype)
+    cce_obj = triplet.TripletSemiHardLoss(distance_metric="angular")
+    loss = cce_obj(y_true, y_pred)
+    test_utils.assert_allclose_according_to_type(loss.numpy(), loss_np)
+
+
+# test L-2 distance
+@pytest.mark.parametrize("dtype", [tf.float32, tf.float16, tf.bfloat16])
+def test_semihard_tripled_loss_l2(dtype):
+    num_data = 10
+    feat_dim = 6
+    margin = 1.0
+    num_classes = 4
+
+    embedding = np.random.rand(num_data, feat_dim).astype(np.float32)
+    labels = np.random.randint(0, num_classes, size=(num_data))
+
+    # Compute the loss in NP.
+    loss_np = triplet_semihard_loss_np(labels, embedding, margin, L_2_dists)
 
     # Compute the loss in TF.
     y_true = tf.constant(labels)
     y_pred = tf.constant(embedding, dtype=dtype)
     cce_obj = triplet.TripletSemiHardLoss()
+    loss = cce_obj(y_true, y_pred)
+    test_utils.assert_allclose_according_to_type(loss.numpy(), loss_np)
+
+
+# test L-1 distance
+@pytest.mark.parametrize("dtype", [tf.float32, tf.float16, tf.bfloat16])
+def test_semihard_tripled_loss_l1(dtype):
+    num_data = 10
+    feat_dim = 6
+    margin = 1.0
+    num_classes = 4
+
+    embedding = np.random.rand(num_data, feat_dim).astype(np.float32)
+    labels = np.random.randint(0, num_classes, size=(num_data))
+
+    # Compute the loss in NP.
+    loss_np = triplet_semihard_loss_np(labels, embedding, margin, L_1_dists)
+
+    # Compute the loss in TF.
+    y_true = tf.constant(labels)
+    y_pred = tf.constant(embedding, dtype=dtype)
+    cce_obj = triplet.TripletSemiHardLoss(distance_metric="L_1")
     loss = cce_obj(y_true, y_pred)
     test_utils.assert_allclose_according_to_type(loss.numpy(), loss_np)
 
@@ -250,9 +230,10 @@ def test_serialization_semihard():
     tf.keras.losses.deserialize(tf.keras.losses.serialize(loss))
 
 
+# test cosine similarity
 @pytest.mark.parametrize("dtype", [tf.float32, tf.float16, tf.bfloat16])
 @pytest.mark.parametrize("soft", [False, True])
-def test_hard_tripled_loss(dtype, soft):
+def test_hard_tripled_loss_angular(dtype, soft):
     num_data = 20
     feat_dim = 6
     margin = 1.0
@@ -262,12 +243,58 @@ def test_hard_tripled_loss(dtype, soft):
     labels = np.random.randint(0, num_classes, size=(num_data))
 
     # Compute the loss in NP.
-    loss_np = triplet_hard_loss_np(labels, embedding, margin, soft)
+    loss_np = triplet_hard_loss_np(labels, embedding, margin, angular_distance_np, soft)
 
     # Compute the loss in TF.
     y_true = tf.constant(labels)
     y_pred = tf.constant(embedding, dtype=dtype)
-    cce_obj = triplet.TripletHardLoss(soft=soft)
+    cce_obj = triplet.TripletHardLoss(soft=soft, distance_metric="angular")
+    loss = cce_obj(y_true, y_pred)
+    test_utils.assert_allclose_according_to_type(loss.numpy(), loss_np)
+
+
+# test L-2 distance
+@pytest.mark.parametrize("dtype", [tf.float32, tf.float16, tf.bfloat16])
+@pytest.mark.parametrize("soft", [False, True])
+def test_hard_tripled_loss_l2(dtype, soft):
+    num_data = 20
+    feat_dim = 6
+    margin = 1.0
+    num_classes = 4
+
+    embedding = np.random.rand(num_data, feat_dim).astype(np.float32)
+    labels = np.random.randint(0, num_classes, size=(num_data))
+
+    # Compute the loss in NP.
+    loss_np = triplet_hard_loss_np(labels, embedding, margin, L_2_dists, soft)
+
+    # Compute the loss in TF.
+    y_true = tf.constant(labels)
+    y_pred = tf.constant(embedding, dtype=dtype)
+    cce_obj = triplet.TripletHardLoss(soft=soft, distance_metric="L_2")
+    loss = cce_obj(y_true, y_pred)
+    test_utils.assert_allclose_according_to_type(loss.numpy(), loss_np)
+
+
+# test L-1 distance
+@pytest.mark.parametrize("dtype", [tf.float32, tf.float16, tf.bfloat16])
+@pytest.mark.parametrize("soft", [False, True])
+def test_hard_tripled_loss_l1(dtype, soft):
+    num_data = 20
+    feat_dim = 6
+    margin = 1.0
+    num_classes = 4
+
+    embedding = np.random.rand(num_data, feat_dim).astype(np.float32)
+    labels = np.random.randint(0, num_classes, size=(num_data))
+
+    # Compute the loss in NP.
+    loss_np = triplet_hard_loss_np(labels, embedding, margin, L_1_dists, soft)
+
+    # Compute the loss in TF.
+    y_true = tf.constant(labels)
+    y_pred = tf.constant(embedding, dtype=dtype)
+    cce_obj = triplet.TripletHardLoss(soft=soft, distance_metric="L_1")
     loss = cce_obj(y_true, y_pred)
     test_utils.assert_allclose_according_to_type(loss.numpy(), loss_np)
 

--- a/tensorflow_addons/losses/tests/triplet_test.py
+++ b/tensorflow_addons/losses/tests/triplet_test.py
@@ -183,6 +183,43 @@ def triplet_semihard_loss_angular_np(labels, embedding, margin):
     return loss_np
 
 
+def triplet_hard_loss_angular_np(labels, embedding, margin, soft=False):
+
+    num_data = embedding.shape[0]
+    # Reshape labels to compute adjacency matrix.
+    labels_reshaped = np.reshape(labels.astype(np.float32), (labels.shape[0], 1))
+
+    adjacency = np.equal(labels_reshaped, labels_reshaped.T)
+    pdist_matrix = angular_distance_np(embedding, squared=True)
+    loss_np = 0.0
+    for i in range(num_data):
+        pos_distances = []
+        neg_distances = []
+        for j in range(num_data):
+            if adjacency[i][j] == 0:
+                neg_distances.append(pdist_matrix[i][j])
+            if adjacency[i][j] > 0.0 and i != j:
+                pos_distances.append(pdist_matrix[i][j])
+
+        # if there are no positive pairs, distance is 0
+        if len(pos_distances) == 0:
+            pos_distances.append(0)
+
+        # Sort by distance.
+        neg_distances.sort()
+        min_neg_distance = neg_distances[0]
+        pos_distances.sort(reverse=True)
+        max_pos_distance = pos_distances[0]
+
+        if soft:
+            loss_np += np.log1p(np.exp(max_pos_distance - min_neg_distance))
+        else:
+            loss_np += np.maximum(0.0, max_pos_distance - min_neg_distance + margin)
+
+    loss_np /= num_data
+    return loss_np
+
+
 @pytest.mark.parametrize("dtype", [tf.float32, tf.float16, tf.bfloat16])
 def test_semihard_tripled_loss(dtype):
     num_data = 10

--- a/tensorflow_addons/losses/tests/triplet_test.py
+++ b/tensorflow_addons/losses/tests/triplet_test.py
@@ -190,7 +190,7 @@ def triplet_hard_loss_angular_np(labels, embedding, margin, soft=False):
     labels_reshaped = np.reshape(labels.astype(np.float32), (labels.shape[0], 1))
 
     adjacency = np.equal(labels_reshaped, labels_reshaped.T)
-    pdist_matrix = angular_distance_np(embedding, squared=True)
+    pdist_matrix = angular_distance_np(embedding)
     loss_np = 0.0
     for i in range(num_data):
         pos_distances = []

--- a/tensorflow_addons/losses/tests/triplet_test.py
+++ b/tensorflow_addons/losses/tests/triplet_test.py
@@ -152,9 +152,13 @@ def triplet_hard_loss_np(labels, embedding, margin, dist_func, soft=False):
     return loss_np
 
 
-# test cosine similarity
+# triplet semihard
 @pytest.mark.parametrize("dtype", [tf.float32, tf.float16, tf.bfloat16])
-def test_semihard_tripled_loss_angular(dtype):
+@pytest.mark.parametrize(
+    "dist_func, dist_metric",
+    [(angular_distance_np, "angular"), (l_2_dists, "L_2"), (l_1_dists, "L_1")],
+)
+def test_semihard_tripled_loss_angular(dtype, dist_func, dist_metric):
     num_data = 10
     feat_dim = 6
     margin = 1.0
@@ -164,56 +168,12 @@ def test_semihard_tripled_loss_angular(dtype):
     labels = np.random.randint(0, num_classes, size=(num_data))
 
     # Compute the loss in NP.
-    loss_np = triplet_semihard_loss_np(labels, embedding, margin, angular_distance_np)
+    loss_np = triplet_semihard_loss_np(labels, embedding, margin, dist_func)
 
     # Compute the loss in TF.
     y_true = tf.constant(labels)
     y_pred = tf.constant(embedding, dtype=dtype)
-    cce_obj = triplet.TripletSemiHardLoss(distance_metric="angular")
-    loss = cce_obj(y_true, y_pred)
-    test_utils.assert_allclose_according_to_type(loss.numpy(), loss_np)
-
-
-# test L-2 distance
-@pytest.mark.parametrize("dtype", [tf.float32, tf.float16, tf.bfloat16])
-def test_semihard_tripled_loss_l2(dtype):
-    num_data = 10
-    feat_dim = 6
-    margin = 1.0
-    num_classes = 4
-
-    embedding = np.random.rand(num_data, feat_dim).astype(np.float32)
-    labels = np.random.randint(0, num_classes, size=(num_data))
-
-    # Compute the loss in NP.
-    loss_np = triplet_semihard_loss_np(labels, embedding, margin, l_2_dists)
-
-    # Compute the loss in TF.
-    y_true = tf.constant(labels)
-    y_pred = tf.constant(embedding, dtype=dtype)
-    cce_obj = triplet.TripletSemiHardLoss()
-    loss = cce_obj(y_true, y_pred)
-    test_utils.assert_allclose_according_to_type(loss.numpy(), loss_np)
-
-
-# test L-1 distance
-@pytest.mark.parametrize("dtype", [tf.float32, tf.float16, tf.bfloat16])
-def test_semihard_tripled_loss_l1(dtype):
-    num_data = 10
-    feat_dim = 6
-    margin = 1.0
-    num_classes = 4
-
-    embedding = np.random.rand(num_data, feat_dim).astype(np.float32)
-    labels = np.random.randint(0, num_classes, size=(num_data))
-
-    # Compute the loss in NP.
-    loss_np = triplet_semihard_loss_np(labels, embedding, margin, l_1_dists)
-
-    # Compute the loss in TF.
-    y_true = tf.constant(labels)
-    y_pred = tf.constant(embedding, dtype=dtype)
-    cce_obj = triplet.TripletSemiHardLoss(distance_metric="L_1")
+    cce_obj = triplet.TripletSemiHardLoss(distance_metric=dist_metric)
     loss = cce_obj(y_true, y_pred)
     test_utils.assert_allclose_according_to_type(loss.numpy(), loss_np)
 
@@ -233,7 +193,11 @@ def test_serialization_semihard():
 # test cosine similarity
 @pytest.mark.parametrize("dtype", [tf.float32, tf.float16, tf.bfloat16])
 @pytest.mark.parametrize("soft", [False, True])
-def test_hard_tripled_loss_angular(dtype, soft):
+@pytest.mark.parametrize(
+    "dist_func, dist_metric",
+    [(angular_distance_np, "angular"), (l_2_dists, "L_2"), (l_1_dists, "L_1")],
+)
+def test_hard_tripled_loss_angular(dtype, soft, dist_func, dist_metric):
     num_data = 20
     feat_dim = 6
     margin = 1.0
@@ -243,58 +207,12 @@ def test_hard_tripled_loss_angular(dtype, soft):
     labels = np.random.randint(0, num_classes, size=(num_data))
 
     # Compute the loss in NP.
-    loss_np = triplet_hard_loss_np(labels, embedding, margin, angular_distance_np, soft)
+    loss_np = triplet_hard_loss_np(labels, embedding, margin, dist_func, soft)
 
     # Compute the loss in TF.
     y_true = tf.constant(labels)
     y_pred = tf.constant(embedding, dtype=dtype)
-    cce_obj = triplet.TripletHardLoss(soft=soft, distance_metric="angular")
-    loss = cce_obj(y_true, y_pred)
-    test_utils.assert_allclose_according_to_type(loss.numpy(), loss_np)
-
-
-# test L-2 distance
-@pytest.mark.parametrize("dtype", [tf.float32, tf.float16, tf.bfloat16])
-@pytest.mark.parametrize("soft", [False, True])
-def test_hard_tripled_loss_l2(dtype, soft):
-    num_data = 20
-    feat_dim = 6
-    margin = 1.0
-    num_classes = 4
-
-    embedding = np.random.rand(num_data, feat_dim).astype(np.float32)
-    labels = np.random.randint(0, num_classes, size=(num_data))
-
-    # Compute the loss in NP.
-    loss_np = triplet_hard_loss_np(labels, embedding, margin, l_2_dists, soft)
-
-    # Compute the loss in TF.
-    y_true = tf.constant(labels)
-    y_pred = tf.constant(embedding, dtype=dtype)
-    cce_obj = triplet.TripletHardLoss(soft=soft, distance_metric="L_2")
-    loss = cce_obj(y_true, y_pred)
-    test_utils.assert_allclose_according_to_type(loss.numpy(), loss_np)
-
-
-# test L-1 distance
-@pytest.mark.parametrize("dtype", [tf.float32, tf.float16, tf.bfloat16])
-@pytest.mark.parametrize("soft", [False, True])
-def test_hard_tripled_loss_l1(dtype, soft):
-    num_data = 20
-    feat_dim = 6
-    margin = 1.0
-    num_classes = 4
-
-    embedding = np.random.rand(num_data, feat_dim).astype(np.float32)
-    labels = np.random.randint(0, num_classes, size=(num_data))
-
-    # Compute the loss in NP.
-    loss_np = triplet_hard_loss_np(labels, embedding, margin, l_1_dists, soft)
-
-    # Compute the loss in TF.
-    y_true = tf.constant(labels)
-    y_pred = tf.constant(embedding, dtype=dtype)
-    cce_obj = triplet.TripletHardLoss(soft=soft, distance_metric="L_1")
+    cce_obj = triplet.TripletHardLoss(soft=soft, distance_metric=dist_metric)
     loss = cce_obj(y_true, y_pred)
     test_utils.assert_allclose_according_to_type(loss.numpy(), loss_np)
 

--- a/tensorflow_addons/losses/tests/triplet_test.py
+++ b/tensorflow_addons/losses/tests/triplet_test.py
@@ -51,11 +51,11 @@ def pairwise_distance_np(feature, squared=False):
     return pairwise_distances
 
 
-def L_2_dists(embs):
+def l_2_dists(embs):
     return pairwise_distance_np(embs, True)
 
 
-def L_1_dists(embs):
+def l_1_dists(embs):
     return pairwise_distance_np(embs, False)
 
 
@@ -186,7 +186,7 @@ def test_semihard_tripled_loss_l2(dtype):
     labels = np.random.randint(0, num_classes, size=(num_data))
 
     # Compute the loss in NP.
-    loss_np = triplet_semihard_loss_np(labels, embedding, margin, L_2_dists)
+    loss_np = triplet_semihard_loss_np(labels, embedding, margin, l_2_dists)
 
     # Compute the loss in TF.
     y_true = tf.constant(labels)
@@ -208,7 +208,7 @@ def test_semihard_tripled_loss_l1(dtype):
     labels = np.random.randint(0, num_classes, size=(num_data))
 
     # Compute the loss in NP.
-    loss_np = triplet_semihard_loss_np(labels, embedding, margin, L_1_dists)
+    loss_np = triplet_semihard_loss_np(labels, embedding, margin, l_1_dists)
 
     # Compute the loss in TF.
     y_true = tf.constant(labels)
@@ -266,7 +266,7 @@ def test_hard_tripled_loss_l2(dtype, soft):
     labels = np.random.randint(0, num_classes, size=(num_data))
 
     # Compute the loss in NP.
-    loss_np = triplet_hard_loss_np(labels, embedding, margin, L_2_dists, soft)
+    loss_np = triplet_hard_loss_np(labels, embedding, margin, l_2_dists, soft)
 
     # Compute the loss in TF.
     y_true = tf.constant(labels)
@@ -289,7 +289,7 @@ def test_hard_tripled_loss_l1(dtype, soft):
     labels = np.random.randint(0, num_classes, size=(num_data))
 
     # Compute the loss in NP.
-    loss_np = triplet_hard_loss_np(labels, embedding, margin, L_1_dists, soft)
+    loss_np = triplet_hard_loss_np(labels, embedding, margin, l_1_dists, soft)
 
     # Compute the loss in TF.
     y_true = tf.constant(labels)

--- a/tensorflow_addons/losses/tests/triplet_test.py
+++ b/tensorflow_addons/losses/tests/triplet_test.py
@@ -150,8 +150,6 @@ def triplet_semihard_loss_angular_np(labels, embedding, margin):
     # Reshape labels to compute adjacency matrix.
     labels_reshaped = np.reshape(labels.astype(np.float32), (labels.shape[0], 1))
 
-    print(labels_reshaped.shape)
-
     adjacency = np.equal(labels_reshaped, labels_reshaped.T)
     pdist_matrix = angular_distance_np(embedding)
     loss_np = 0.0
@@ -176,7 +174,6 @@ def triplet_semihard_loss_angular_np(labels, embedding, margin):
                     chosen_neg_distance = neg_distances[l]
                     if chosen_neg_distance > pos_distance:
                         break
-                print(chosen_neg_distance, pos_distance)
                 loss_np += np.maximum(0.0, margin - chosen_neg_distance + pos_distance)
 
     loss_np /= num_positives

--- a/tensorflow_addons/losses/triplet.py
+++ b/tensorflow_addons/losses/triplet.py
@@ -69,7 +69,10 @@ def _masked_minimum(data, mask, dim=1):
 @tf.keras.utils.register_keras_serializable(package="Addons")
 @tf.function
 def triplet_semihard_loss(
-    y_true: TensorLike, y_pred: TensorLike, margin: FloatTensorLike = 1.0, angular: bool = False
+    y_true: TensorLike,
+    y_pred: TensorLike,
+    margin: FloatTensorLike = 1.0,
+    angular: bool = False,
 ) -> tf.Tensor:
     """Computes the triplet loss with semi-hard negative mining.
 
@@ -101,7 +104,9 @@ def triplet_semihard_loss(
     if angular:
         pdist_matrix = metric_learning.angular_distances(precise_embeddings)
     else:
-        pdist_matrix = metric_learning.pairwise_distance(precise_embeddings, squared=True)
+        pdist_matrix = metric_learning.pairwise_distance(
+            precise_embeddings, squared=True
+        )
 
     # Build pairwise binary adjacency matrix.
     adjacency = tf.math.equal(labels, tf.transpose(labels))

--- a/tensorflow_addons/losses/triplet.py
+++ b/tensorflow_addons/losses/triplet.py
@@ -72,7 +72,7 @@ def triplet_semihard_loss(
     y_true: TensorLike,
     y_pred: TensorLike,
     margin: FloatTensorLike = 1.0,
-    distance_metric: Union[str, Callable] = "L_2",
+    distance_metric: Union[str, Callable] = "L2",
 ) -> tf.Tensor:
     """Computes the triplet loss with semi-hard negative mining.
 
@@ -83,14 +83,26 @@ def triplet_semihard_loss(
         be l2 normalized.
       margin: Float, margin term in the loss definition.
       distance_metric: str or function, determines distance metric:
-                       "L_1" for l1-norm distance
-                       "L_2" for l2-norm distance
+                       "L1" for l1-norm distance
+                       "L2" for l2-norm distance
                        "angular" for cosine similarity
-                        function for custom metric
+                        A custom function returning a 2d adjacency
+                          matrix of a chosen distance metric can
+                          also be passed here. e.g.
+
+                          def custom_distance(batch):
+                              batch = 1 - batch @ batch.T
+                              return batch
+
+                          triplet_semihard_loss(batch, labels,
+                                        distance_metric=custom_distance
+                                    )
+
 
     Returns:
       triplet_loss: float scalar with dtype of y_pred.
     """
+
     labels, embeddings = y_true, y_pred
 
     convert_to_float32 = (
@@ -106,12 +118,12 @@ def triplet_semihard_loss(
 
     # Build pairwise squared distance matrix
 
-    if distance_metric == "L_1":
+    if distance_metric == "L1":
         pdist_matrix = metric_learning.pairwise_distance(
             precise_embeddings, squared=False
         )
 
-    elif distance_metric == "L_2":
+    elif distance_metric == "L2":
         pdist_matrix = metric_learning.pairwise_distance(
             precise_embeddings, squared=True
         )
@@ -193,7 +205,7 @@ def triplet_hard_loss(
     y_pred: TensorLike,
     margin: FloatTensorLike = 1.0,
     soft: bool = False,
-    distance_metric: Union[str, Callable] = "L_2",
+    distance_metric: Union[str, Callable] = "L2",
 ) -> tf.Tensor:
     """Computes the triplet loss with hard negative and hard positive mining.
 
@@ -205,10 +217,20 @@ def triplet_hard_loss(
       margin: Float, margin term in the loss definition.
       soft: Boolean, if set, use the soft margin version.
       distance_metric: str or function, determines distance metric:
-                       "L_1" for l1-norm distance
-                       "L_2" for l2-norm distance
+                       "L1" for l1-norm distance
+                       "L2" for l2-norm distance
                        "angular" for cosine similarity
-                        function for custom metric
+                        A custom function returning a 2d adjacency
+                          matrix of a chosen distance metric can
+                          also be passed here. e.g.
+
+                          def custom_distance(batch):
+                              batch = 1 - batch @ batch.T
+                              return batch
+
+                          triplet_semihard_loss(batch, labels,
+                                        distance_metric=custom_distance
+                                    )
 
     Returns:
       triplet_loss: float scalar with dtype of y_pred.
@@ -227,12 +249,12 @@ def triplet_hard_loss(
     labels = tf.reshape(labels, [lshape[0], 1])
 
     # Build pairwise squared distance matrix.
-    if distance_metric == "L_1":
+    if distance_metric == "L1":
         pdist_matrix = metric_learning.pairwise_distance(
             precise_embeddings, squared=False
         )
 
-    elif distance_metric == "L_2":
+    elif distance_metric == "L2":
         pdist_matrix = metric_learning.pairwise_distance(
             precise_embeddings, squared=True
         )
@@ -301,7 +323,7 @@ class TripletSemiHardLoss(LossFunctionWrapper):
     def __init__(
         self,
         margin: FloatTensorLike = 1.0,
-        distance_metric: Union[str, Callable] = "L_2",
+        distance_metric: Union[str, Callable] = "L2",
         name: Optional[str] = None,
         **kwargs
     ):
@@ -340,7 +362,7 @@ class TripletHardLoss(LossFunctionWrapper):
         self,
         margin: FloatTensorLike = 1.0,
         soft: bool = False,
-        distance_metric: Union[str, Callable] = "L_2",
+        distance_metric: Union[str, Callable] = "L2",
         name: Optional[str] = None,
         **kwargs
     ):

--- a/tensorflow_addons/losses/triplet.py
+++ b/tensorflow_addons/losses/triplet.py
@@ -72,7 +72,6 @@ def triplet_semihard_loss(
     y_true: TensorLike,
     y_pred: TensorLike,
     margin: FloatTensorLike = 1.0,
-    squared: bool = True,
     distance_metric: Union[str, Callable] = "L_2",
 ) -> tf.Tensor:
     """Computes the triplet loss with semi-hard negative mining.
@@ -105,13 +104,13 @@ def triplet_semihard_loss(
     lshape = tf.shape(labels)
     labels = tf.reshape(labels, [lshape[0], 1])
 
-    # Build pairwise squared distance matrix.
-    
+    # Build pairwise squared distance matrix
+
     if distance_metric == "L_1":
         pdist_matrix = metric_learning.pairwise_distance(
             precise_embeddings, squared=False
         )
-    
+
     elif distance_metric == "L_2":
         pdist_matrix = metric_learning.pairwise_distance(
             precise_embeddings, squared=True
@@ -232,7 +231,7 @@ def triplet_hard_loss(
         pdist_matrix = metric_learning.pairwise_distance(
             precise_embeddings, squared=False
         )
-    
+
     elif distance_metric == "L_2":
         pdist_matrix = metric_learning.pairwise_distance(
             precise_embeddings, squared=True

--- a/tensorflow_addons/losses/triplet.py
+++ b/tensorflow_addons/losses/triplet.py
@@ -178,8 +178,8 @@ def triplet_hard_loss(
     y_true: TensorLike,
     y_pred: TensorLike,
     margin: FloatTensorLike = 1.0,
-    angular: bool = False,
     soft: bool = False,
+    angular: bool = False,
 ) -> tf.Tensor:
     """Computes the triplet loss with hard negative and hard positive mining.
 

--- a/tensorflow_addons/losses/triplet.py
+++ b/tensorflow_addons/losses/triplet.py
@@ -86,7 +86,7 @@ def triplet_semihard_loss(
       squared: bool, determines whether L-1 or L-2 norm is used
       dist_metric: str or function, determines distance metric:
                    "L_2" for euclidean distance
-                   "angular" for cosine similarity 
+                   "angular" for cosine similarity
                     function for custom metric
 
     Returns:
@@ -204,7 +204,7 @@ def triplet_hard_loss(
       squared: bool, determines whether L-1 or L-2 norm is used
       dist_metric: str or function, determines distance metric:
                    "L_2" for euclidean distance
-                   "angular" for cosine similarity 
+                   "angular" for cosine similarity
                     function for custom metric
 
     Returns:

--- a/tensorflow_addons/losses/triplet.py
+++ b/tensorflow_addons/losses/triplet.py
@@ -72,7 +72,6 @@ def triplet_semihard_loss(
     y_true: TensorLike,
     y_pred: TensorLike,
     margin: FloatTensorLike = 1.0,
-    squared: bool = True,
     angular: bool = False,
 ) -> tf.Tensor:
     """Computes the triplet loss with semi-hard negative mining.
@@ -106,7 +105,7 @@ def triplet_semihard_loss(
         pdist_matrix = metric_learning.angular_distance(precise_embeddings)
     else:
         pdist_matrix = metric_learning.pairwise_distance(
-            precise_embeddings, squared=squared
+            precise_embeddings, squared=True
         )
 
     # Build pairwise binary adjacency matrix.
@@ -180,7 +179,6 @@ def triplet_hard_loss(
     y_pred: TensorLike,
     margin: FloatTensorLike = 1.0,
     soft: bool = False,
-    squared: bool = True,
     angular: bool = False,
 ) -> tf.Tensor:
     """Computes the triplet loss with hard negative and hard positive mining.
@@ -214,7 +212,7 @@ def triplet_hard_loss(
         pdist_matrix = metric_learning.angular_distance(precise_embeddings)
     else:
         pdist_matrix = metric_learning.pairwise_distance(
-            precise_embeddings, squared=squared
+            precise_embeddings, squared=True
         )
 
     # Build pairwise binary adjacency matrix.
@@ -275,7 +273,6 @@ class TripletSemiHardLoss(LossFunctionWrapper):
     def __init__(
         self,
         margin: FloatTensorLike = 1.0,
-        squared: bool = True,
         angular: bool = False,
         name: Optional[str] = None,
         **kwargs
@@ -285,7 +282,6 @@ class TripletSemiHardLoss(LossFunctionWrapper):
             name=name,
             reduction=tf.keras.losses.Reduction.NONE,
             margin=margin,
-            squared=squared,
             angular=angular,
         )
 
@@ -316,7 +312,6 @@ class TripletHardLoss(LossFunctionWrapper):
         self,
         margin: FloatTensorLike = 1.0,
         soft: bool = False,
-        squared: bool = True,
         angular: bool = False,
         name: Optional[str] = None,
         **kwargs
@@ -327,6 +322,5 @@ class TripletHardLoss(LossFunctionWrapper):
             reduction=tf.keras.losses.Reduction.NONE,
             margin=margin,
             soft=soft,
-            squared=squared,
             angular=angular,
         )

--- a/tensorflow_addons/losses/triplet.py
+++ b/tensorflow_addons/losses/triplet.py
@@ -178,6 +178,7 @@ def triplet_hard_loss(
     y_true: TensorLike,
     y_pred: TensorLike,
     margin: FloatTensorLike = 1.0,
+    angular: bool = False,
     soft: bool = False,
 ) -> tf.Tensor:
     """Computes the triplet loss with hard negative and hard positive mining.
@@ -207,7 +208,13 @@ def triplet_hard_loss(
     labels = tf.reshape(labels, [lshape[0], 1])
 
     # Build pairwise squared distance matrix.
-    pdist_matrix = metric_learning.pairwise_distance(precise_embeddings, squared=True)
+    if angular:
+        pdist_matrix = metric_learning.angular_distances(precise_embeddings)
+    else:
+        pdist_matrix = metric_learning.pairwise_distance(
+            precise_embeddings, squared=True
+        )
+
     # Build pairwise binary adjacency matrix.
     adjacency = tf.math.equal(labels, tf.transpose(labels))
     # Invert so we can select negatives only.

--- a/tensorflow_addons/losses/triplet.py
+++ b/tensorflow_addons/losses/triplet.py
@@ -69,7 +69,7 @@ def _masked_minimum(data, mask, dim=1):
 @tf.keras.utils.register_keras_serializable(package="Addons")
 @tf.function
 def triplet_semihard_loss(
-    y_true: TensorLike, y_pred: TensorLike, margin: FloatTensorLike = 1.0
+    y_true: TensorLike, y_pred: TensorLike, margin: FloatTensorLike = 1.0, angular: bool = False
 ) -> tf.Tensor:
     """Computes the triplet loss with semi-hard negative mining.
 
@@ -97,7 +97,12 @@ def triplet_semihard_loss(
     labels = tf.reshape(labels, [lshape[0], 1])
 
     # Build pairwise squared distance matrix.
-    pdist_matrix = metric_learning.pairwise_distance(precise_embeddings, squared=True)
+
+    if angular:
+        pdist_matrix = metric_learning.angular_distances(precise_embeddings)
+    else:
+        pdist_matrix = metric_learning.pairwise_distance(precise_embeddings, squared=True)
+
     # Build pairwise binary adjacency matrix.
     adjacency = tf.math.equal(labels, tf.transpose(labels))
     # Invert so we can select negatives only.

--- a/tensorflow_addons/losses/triplet.py
+++ b/tensorflow_addons/losses/triplet.py
@@ -271,13 +271,18 @@ class TripletSemiHardLoss(LossFunctionWrapper):
 
     @typechecked
     def __init__(
-        self, margin: FloatTensorLike = 1.0, name: Optional[str] = None, **kwargs
+        self,
+        margin: FloatTensorLike = 1.0,
+        angular: bool = False,
+        name: Optional[str] = None,
+        **kwargs
     ):
         super().__init__(
             triplet_semihard_loss,
             name=name,
             reduction=tf.keras.losses.Reduction.NONE,
             margin=margin,
+            angular=angular,
         )
 
 
@@ -307,6 +312,7 @@ class TripletHardLoss(LossFunctionWrapper):
         self,
         margin: FloatTensorLike = 1.0,
         soft: bool = False,
+        angular: bool = False,
         name: Optional[str] = None,
         **kwargs
     ):
@@ -316,4 +322,5 @@ class TripletHardLoss(LossFunctionWrapper):
             reduction=tf.keras.losses.Reduction.NONE,
             margin=margin,
             soft=soft,
+            angular=angular,
         )

--- a/tensorflow_addons/losses/triplet.py
+++ b/tensorflow_addons/losses/triplet.py
@@ -73,7 +73,7 @@ def triplet_semihard_loss(
     y_pred: TensorLike,
     margin: FloatTensorLike = 1.0,
     squared: bool = True,
-    dist_metric: Union[str, Callable] = "L_2"
+    dist_metric: Union[str, Callable] = "L_2",
 ) -> tf.Tensor:
     """Computes the triplet loss with semi-hard negative mining.
 
@@ -111,13 +111,12 @@ def triplet_semihard_loss(
         pdist_matrix = metric_learning.pairwise_distance(
             precise_embeddings, squared=squared
         )
-        
+
     elif dist_metric == "angular":
         pdist_matrix = metric_learning.angular_distance(precise_embeddings)
-    
+
     else:
         pdist_matrix = dist_metric(precise_embeddings)
-
 
     # Build pairwise binary adjacency matrix.
     adjacency = tf.math.equal(labels, tf.transpose(labels))
@@ -191,7 +190,7 @@ def triplet_hard_loss(
     margin: FloatTensorLike = 1.0,
     soft: bool = False,
     squared: bool = True,
-    dist_metric: Union[str, Callable] = "L_2"
+    dist_metric: Union[str, Callable] = "L_2",
 ) -> tf.Tensor:
     """Computes the triplet loss with hard negative and hard positive mining.
 
@@ -229,10 +228,10 @@ def triplet_hard_loss(
         pdist_matrix = metric_learning.pairwise_distance(
             precise_embeddings, squared=squared
         )
-        
+
     elif dist_metric == "angular":
         pdist_matrix = metric_learning.angular_distance(precise_embeddings)
-    
+
     else:
         pdist_matrix = dist_metric(precise_embeddings)
 
@@ -305,7 +304,7 @@ class TripletSemiHardLoss(LossFunctionWrapper):
             reduction=tf.keras.losses.Reduction.NONE,
             margin=margin,
             squared=squared,
-            dist_metric=dist_metric
+            dist_metric=dist_metric,
         )
 
 
@@ -347,5 +346,5 @@ class TripletHardLoss(LossFunctionWrapper):
             margin=margin,
             soft=soft,
             squared=squared,
-            dist_metric=dist_metric
+            dist_metric=dist_metric,
         )

--- a/tensorflow_addons/losses/triplet.py
+++ b/tensorflow_addons/losses/triplet.py
@@ -72,6 +72,7 @@ def triplet_semihard_loss(
     y_true: TensorLike,
     y_pred: TensorLike,
     margin: FloatTensorLike = 1.0,
+    squared: bool = True,
     angular: bool = False,
 ) -> tf.Tensor:
     """Computes the triplet loss with semi-hard negative mining.
@@ -105,7 +106,7 @@ def triplet_semihard_loss(
         pdist_matrix = metric_learning.angular_distance(precise_embeddings)
     else:
         pdist_matrix = metric_learning.pairwise_distance(
-            precise_embeddings, squared=True
+            precise_embeddings, squared=squared
         )
 
     # Build pairwise binary adjacency matrix.
@@ -179,6 +180,7 @@ def triplet_hard_loss(
     y_pred: TensorLike,
     margin: FloatTensorLike = 1.0,
     soft: bool = False,
+    squared: bool = True,
     angular: bool = False,
 ) -> tf.Tensor:
     """Computes the triplet loss with hard negative and hard positive mining.
@@ -212,7 +214,7 @@ def triplet_hard_loss(
         pdist_matrix = metric_learning.angular_distance(precise_embeddings)
     else:
         pdist_matrix = metric_learning.pairwise_distance(
-            precise_embeddings, squared=True
+            precise_embeddings, squared=squared
         )
 
     # Build pairwise binary adjacency matrix.
@@ -273,6 +275,7 @@ class TripletSemiHardLoss(LossFunctionWrapper):
     def __init__(
         self,
         margin: FloatTensorLike = 1.0,
+        squared: bool = True,
         angular: bool = False,
         name: Optional[str] = None,
         **kwargs
@@ -282,7 +285,8 @@ class TripletSemiHardLoss(LossFunctionWrapper):
             name=name,
             reduction=tf.keras.losses.Reduction.NONE,
             margin=margin,
-            angular=angular,
+            squared=squared,
+            angular=angular
         )
 
 
@@ -312,6 +316,7 @@ class TripletHardLoss(LossFunctionWrapper):
         self,
         margin: FloatTensorLike = 1.0,
         soft: bool = False,
+        squared: bool = True,
         angular: bool = False,
         name: Optional[str] = None,
         **kwargs
@@ -322,5 +327,6 @@ class TripletHardLoss(LossFunctionWrapper):
             reduction=tf.keras.losses.Reduction.NONE,
             margin=margin,
             soft=soft,
-            angular=angular,
+            squared=squared,
+            angular=angular
         )

--- a/tensorflow_addons/losses/triplet.py
+++ b/tensorflow_addons/losses/triplet.py
@@ -103,7 +103,7 @@ def triplet_semihard_loss(
     # Build pairwise squared distance matrix.
 
     if angular:
-        pdist_matrix = metric_learning.angular_distances(precise_embeddings)
+        pdist_matrix = metric_learning.angular_distance(precise_embeddings)
     else:
         pdist_matrix = metric_learning.pairwise_distance(
             precise_embeddings, squared=squared
@@ -211,7 +211,7 @@ def triplet_hard_loss(
 
     # Build pairwise squared distance matrix.
     if angular:
-        pdist_matrix = metric_learning.angular_distances(precise_embeddings)
+        pdist_matrix = metric_learning.angular_distance(precise_embeddings)
     else:
         pdist_matrix = metric_learning.pairwise_distance(
             precise_embeddings, squared=squared

--- a/tensorflow_addons/losses/triplet.py
+++ b/tensorflow_addons/losses/triplet.py
@@ -72,6 +72,7 @@ def triplet_semihard_loss(
     y_true: TensorLike,
     y_pred: TensorLike,
     margin: FloatTensorLike = 1.0,
+    squared: bool = True,
     angular: bool = False,
 ) -> tf.Tensor:
     """Computes the triplet loss with semi-hard negative mining.
@@ -105,7 +106,7 @@ def triplet_semihard_loss(
         pdist_matrix = metric_learning.angular_distances(precise_embeddings)
     else:
         pdist_matrix = metric_learning.pairwise_distance(
-            precise_embeddings, squared=True
+            precise_embeddings, squared=squared
         )
 
     # Build pairwise binary adjacency matrix.
@@ -179,6 +180,7 @@ def triplet_hard_loss(
     y_pred: TensorLike,
     margin: FloatTensorLike = 1.0,
     soft: bool = False,
+    squared: bool = True,
     angular: bool = False,
 ) -> tf.Tensor:
     """Computes the triplet loss with hard negative and hard positive mining.
@@ -212,7 +214,7 @@ def triplet_hard_loss(
         pdist_matrix = metric_learning.angular_distances(precise_embeddings)
     else:
         pdist_matrix = metric_learning.pairwise_distance(
-            precise_embeddings, squared=True
+            precise_embeddings, squared=squared
         )
 
     # Build pairwise binary adjacency matrix.
@@ -273,6 +275,7 @@ class TripletSemiHardLoss(LossFunctionWrapper):
     def __init__(
         self,
         margin: FloatTensorLike = 1.0,
+        squared: bool = True,
         angular: bool = False,
         name: Optional[str] = None,
         **kwargs
@@ -282,6 +285,7 @@ class TripletSemiHardLoss(LossFunctionWrapper):
             name=name,
             reduction=tf.keras.losses.Reduction.NONE,
             margin=margin,
+            squared=squared,
             angular=angular,
         )
 
@@ -312,6 +316,7 @@ class TripletHardLoss(LossFunctionWrapper):
         self,
         margin: FloatTensorLike = 1.0,
         soft: bool = False,
+        squared: bool = True,
         angular: bool = False,
         name: Optional[str] = None,
         **kwargs
@@ -322,5 +327,6 @@ class TripletHardLoss(LossFunctionWrapper):
             reduction=tf.keras.losses.Reduction.NONE,
             margin=margin,
             soft=soft,
+            squared=squared,
             angular=angular,
         )


### PR DESCRIPTION
Added an option to base pairwise distances on cosine similarity in addition to euclidean distance as suggested by several papers.

Formula for distance taken from  [Metric Learning for Adversarial Robustness](https://arxiv.org/pdf/1909.00900.pdf)