### PR TITLE
DOC: Correct example of new experimental argument

### DIFF
--- a/tensorflow_addons/optimizers/weight_decay_optimizers.py
+++ b/tensorflow_addons/optimizers/weight_decay_optimizers.py
@@ -140,7 +140,7 @@ class DecoupledWeightDecayExtension:
                 to all variables in var_list.
             **kwargs: Additional arguments to pass to the base optimizer's
                 apply_gradient method, e.g., TF2.2 added an argument
-                `all_reduce_sum_gradients`.
+                `experimental_aggregate_gradients`.
         Returns:
             An `Operation` that applies the specified gradients.
         Raises:


### PR DESCRIPTION
The new argument was actually `experimental_aggregate_gradients`

Reference: https://github.com/tensorflow/models/commit/9fc4fd082968c0c959c1d7bc938a9fcbf0f9e50d