### PR TITLE
Pin pip version for ubuntu build env

### DIFF
--- a/tools/docker/build_wheel.Dockerfile
+++ b/tools/docker/build_wheel.Dockerfile
@@ -23,7 +23,7 @@ RUN mv /usr/bin/lsb_release2 /usr/bin/lsb_release
 ARG PY_VERSION
 RUN ln -sf $(which python$PY_VERSION) /usr/bin/python
 
-RUN python -m pip install auditwheel==2.0.0
+RUN python -m pip install --upgrade pip==20.0.2 auditwheel==2.0.0
 
 ARG TF_VERSION
 RUN python -m pip install tensorflow==$TF_VERSION


### PR DESCRIPTION
Py3.7 in the Ubuntu container needs pip to be upgraded:
https://github.com/tensorflow/addons/runs/635031760?check_suite_focus=true

We got breaks for 20.1 and it's probably best to make our build env as static as possible