### PR TITLE
Use the mark for the gpu tests in conditional_gradient_test.py

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -434,6 +434,17 @@ def test_something():
     # the code here will run twice, once on gpu, once on cpu.
     ...
 
+
+@pytest.mark.with_device(["cpu", "gpu"])
+def test_something2(device):
+    # the code here will run twice, once on gpu, once on cpu.
+    # device will be "cpu:0" or "gpu:0" or "gpu:1" or "gpu:2" ...   
+    if "cpu" in device:
+        print("do something.")
+    if "gpu" in device:
+        print("do something else.")
+
+
 @pytest.mark.with_device(["gpu"])
 def test_something_else():
     # This test will be only run on gpu.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -455,6 +455,13 @@ def test_something_else():
 def test_something_more():
     # Don't do that, this is the default behavior. 
     ...
+
+
+@pytest.mark.with_device(["no_device"])
+def test_something_more2():
+    # When running the function, there will be no `with tf.device` wrapper.
+    # You are free to do whatever you wish with the devices in there.
+    ...
 ```
 
 Note that if a gpu is not detected on the system, the test will be 

--- a/tensorflow_addons/conftest.py
+++ b/tensorflow_addons/conftest.py
@@ -5,7 +5,7 @@ from tensorflow_addons.utils.test_utils import (  # noqa: F401
     pytest_addoption,
     set_global_variables,
     pytest_configure,
-    _device_placement,
+    device,
     pytest_generate_tests,
 )
 

--- a/tensorflow_addons/optimizers/tests/conditional_gradient_test.py
+++ b/tensorflow_addons/optimizers/tests/conditional_gradient_test.py
@@ -23,33 +23,6 @@ from tensorflow_addons.utils import test_utils
 from tensorflow_addons.optimizers import conditional_gradient as cg_lib
 
 
-def _dtypes_to_test(use_gpu):
-    # Based on issue #347 in the following link,
-    #        "https://github.com/tensorflow/addons/issues/347"
-    # tf.half is not registered for 'ResourceScatterUpdate' OpKernel
-    # for 'GPU' devices.
-    # So we have to remove tf.half when testing with gpu.
-    # The function "_DtypesToTest" is from
-    #       "https://github.com/tensorflow/tensorflow/blob/5d4a6cee737a1dc6c20172a1dc1
-    #        5df10def2df72/tensorflow/python/kernel_tests/conv_ops_3d_test.py#L53-L62"
-    if use_gpu:
-        return [tf.float32, tf.float64]
-    else:
-        return [tf.half, tf.float32, tf.float64]
-
-
-def _dtypes_with_checking_system(use_gpu, system):
-    # Based on issue #36764 in the following link,
-    #        "https://github.com/tensorflow/tensorflow/issues/36764"
-    # tf.half is not registered for tf.linalg.svd function on Windows
-    # CPU version.
-    # So we have to remove tf.half when testing with Windows CPU version.
-    if system == "Windows":
-        return [tf.float32, tf.float64]
-    else:
-        return _dtypes_to_test(use_gpu)
-
-
 @pytest.mark.usefixtures("maybe_run_functions_eagerly")
 def test_like_dist_belief_nuclear_cg01():
     db_grad, db_out = _db_params_nuclear_cg01()
@@ -67,48 +40,38 @@ def test_like_dist_belief_nuclear_cg01():
         )
 
 
-def test_minimize_sparse_resource_variable_frobenius():
-    # This test invokes the ResourceSparseApplyConditionalGradient
-    # operation. And it will call the 'ResourceScatterUpdate' OpKernel
-    # for 'GPU' devices. However, tf.half is not registered in this case,
-    # based on issue #347.
-    # Thus, we will call the "_dtypes_to_test" function.
-    #
-    # TODO:
-    #       Wait for the solving of issue #347. After that, we will test
-    #       for the dtype to be tf.half, with 'GPU' devices.
-    for dtype in _dtypes_to_test(use_gpu=tf.test.is_gpu_available()):
-        var0 = tf.Variable([[1.0, 2.0]], dtype=dtype)
+@pytest.mark.with_device(["cpu", "gpu"])
+@pytest.mark.parametrize("dtype", [tf.float16, tf.float32, tf.float64])
+def test_minimize_sparse_resource_variable_frobenius(dtype):
+    var0 = tf.Variable([[1.0, 2.0]], dtype=dtype)
 
-        def loss():
-            x = tf.constant([[4.0], [5.0]], dtype=dtype)
-            pred = tf.matmul(tf.nn.embedding_lookup([var0], [0]), x)
-            return pred * pred
+    def loss():
+        x = tf.constant([[4.0], [5.0]], dtype=dtype)
+        pred = tf.matmul(tf.nn.embedding_lookup([var0], [0]), x)
+        return pred * pred
 
-        # the gradient based on the current loss function
-        grads0_0 = 32 * 1.0 + 40 * 2.0
-        grads0_1 = 40 * 1.0 + 50 * 2.0
-        grads0 = tf.constant([[grads0_0, grads0_1]], dtype=dtype)
-        norm0 = tf.math.reduce_sum(grads0 ** 2) ** 0.5
+    # the gradient based on the current loss function
+    grads0_0 = 32 * 1.0 + 40 * 2.0
+    grads0_1 = 40 * 1.0 + 50 * 2.0
+    grads0 = tf.constant([[grads0_0, grads0_1]], dtype=dtype)
+    norm0 = tf.math.reduce_sum(grads0 ** 2) ** 0.5
 
-        learning_rate = 0.1
-        lambda_ = 0.1
-        ord = "fro"
-        opt = cg_lib.ConditionalGradient(
-            learning_rate=learning_rate, lambda_=lambda_, ord=ord
-        )
-        _ = opt.minimize(loss, var_list=[var0])
-        test_utils.assert_allclose_according_to_type(
+    learning_rate = 0.1
+    lambda_ = 0.1
+    ord = "fro"
+    opt = cg_lib.ConditionalGradient(
+        learning_rate=learning_rate, lambda_=lambda_, ord=ord
+    )
+    _ = opt.minimize(loss, var_list=[var0])
+    test_utils.assert_allclose_according_to_type(
+        [
             [
-                [
-                    1.0 * learning_rate
-                    - (1 - learning_rate) * lambda_ * grads0_0 / norm0,
-                    2.0 * learning_rate
-                    - (1 - learning_rate) * lambda_ * grads0_1 / norm0,
-                ]
-            ],
-            var0.numpy(),
-        )
+                1.0 * learning_rate - (1 - learning_rate) * lambda_ * grads0_0 / norm0,
+                2.0 * learning_rate - (1 - learning_rate) * lambda_ * grads0_1 / norm0,
+            ]
+        ],
+        var0.numpy(),
+    )
 
 
 @pytest.mark.parametrize("dtype", [(tf.half, 0), (tf.float32, 1), (tf.float64, 2)])
@@ -193,210 +156,195 @@ def test_basic_frobenius(dtype, use_resource):
 
 @pytest.mark.usefixtures("maybe_run_functions_eagerly")
 @pytest.mark.parametrize("use_resource", [True, False])
-def test_basic_nuclear(use_resource):
-    # TODO:
-    #       to address issue #36764
-    for i, dtype in enumerate(
-        _dtypes_with_checking_system(
-            use_gpu=tf.test.is_gpu_available(), system=platform.system()
-        )
-    ):
-
-        if use_resource:
-            var0 = tf.Variable([1.0, 2.0], dtype=dtype, name="var0_%d" % i)
-            var1 = tf.Variable([3.0, 4.0], dtype=dtype, name="var1_%d" % i)
-        else:
-            var0 = tf.Variable([1.0, 2.0], dtype=dtype)
-            var1 = tf.Variable([3.0, 4.0], dtype=dtype)
-
-        grads0 = tf.constant([0.1, 0.1], dtype=dtype)
-        grads1 = tf.constant([0.01, 0.01], dtype=dtype)
-        top_singular_vector0 = cg_lib.ConditionalGradient._top_singular_vector(grads0)
-        top_singular_vector1 = cg_lib.ConditionalGradient._top_singular_vector(grads1)
-
-        def learning_rate():
-            return 0.5
-
-        def lambda_():
-            return 0.01
-
-        ord = "nuclear"
-
-        cg_opt = cg_lib.ConditionalGradient(
-            learning_rate=learning_rate, lambda_=lambda_, ord=ord
-        )
-        _ = cg_opt.apply_gradients(zip([grads0, grads1], [var0, var1]))
-
-        # Check we have slots
-        assert ["conditional_gradient"] == cg_opt.get_slot_names()
-        slot0 = cg_opt.get_slot(var0, "conditional_gradient")
-        assert slot0.get_shape() == var0.get_shape()
-        slot1 = cg_opt.get_slot(var1, "conditional_gradient")
-        assert slot1.get_shape() == var1.get_shape()
-
-        test_utils.assert_allclose_according_to_type(
-            np.array(
-                [
-                    1.0 * 0.5 - (1 - 0.5) * 0.01 * top_singular_vector0[0],
-                    2.0 * 0.5 - (1 - 0.5) * 0.01 * top_singular_vector0[1],
-                ]
-            ),
-            var0.numpy(),
-        )
-        test_utils.assert_allclose_according_to_type(
-            np.array(
-                [
-                    3.0 * 0.5 - (1 - 0.5) * 0.01 * top_singular_vector1[0],
-                    4.0 * 0.5 - (1 - 0.5) * 0.01 * top_singular_vector1[1],
-                ]
-            ),
-            var1.numpy(),
-        )
-
-        # Step 2: the conditional_gradient contain the previous update.
-        cg_opt.apply_gradients(zip([grads0, grads1], [var0, var1]))
-        test_utils.assert_allclose_according_to_type(
-            np.array(
-                [
-                    (1.0 * 0.5 - (1 - 0.5) * 0.01 * top_singular_vector0[0]) * 0.5
-                    - (1 - 0.5) * 0.01 * top_singular_vector0[0],
-                    (2.0 * 0.5 - (1 - 0.5) * 0.01 * top_singular_vector0[1]) * 0.5
-                    - (1 - 0.5) * 0.01 * top_singular_vector0[1],
-                ]
-            ),
-            var0.numpy(),
-        )
-        test_utils.assert_allclose_according_to_type(
-            np.array(
-                [
-                    (3.0 * 0.5 - (1 - 0.5) * 0.01 * top_singular_vector1[0]) * 0.5
-                    - (1 - 0.5) * 0.01 * top_singular_vector1[1],
-                    (4.0 * 0.5 - (1 - 0.5) * 0.01 * top_singular_vector1[0]) * 0.5
-                    - (1 - 0.5) * 0.01 * top_singular_vector1[1],
-                ]
-            ),
-            var1.numpy(),
-        )
-
-
-@pytest.mark.usefixtures("maybe_run_functions_eagerly")
-def test_minimize_sparse_resource_variable_nuclear():
-    # TODO:
-    #       to address issue #347 and #36764.
-    for dtype in _dtypes_with_checking_system(
-        use_gpu=tf.test.is_gpu_available(), system=platform.system()
-    ):
-        var0 = tf.Variable([[1.0, 2.0]], dtype=dtype)
-
-        def loss():
-            x = tf.constant([[4.0], [5.0]], dtype=dtype)
-            pred = tf.matmul(tf.nn.embedding_lookup([var0], [0]), x)
-            return pred * pred
-
-        # the gradient based on the current loss function
-        grads0_0 = 32 * 1.0 + 40 * 2.0
-        grads0_1 = 40 * 1.0 + 50 * 2.0
-        grads0 = tf.constant([[grads0_0, grads0_1]], dtype=dtype)
-        top_singular_vector0 = cg_lib.ConditionalGradient._top_singular_vector(grads0)
-
-        learning_rate = 0.1
-        lambda_ = 0.1
-        ord = "nuclear"
-        opt = cg_lib.ConditionalGradient(
-            learning_rate=learning_rate, lambda_=lambda_, ord=ord
-        )
-        _ = opt.minimize(loss, var_list=[var0])
-
-        # Validate updated params
-        test_utils.assert_allclose_according_to_type(
-            [
-                [
-                    1.0 * learning_rate
-                    - (1 - learning_rate) * lambda_ * top_singular_vector0[0][0],
-                    2.0 * learning_rate
-                    - (1 - learning_rate) * lambda_ * top_singular_vector0[0][1],
-                ]
-            ],
-            var0.numpy(),
-        )
-
-
-@pytest.mark.usefixtures("maybe_run_functions_eagerly")
-def test_tensor_learning_rate_and_conditional_gradient_nuclear():
-    for dtype in _dtypes_with_checking_system(
-        use_gpu=tf.test.is_gpu_available(), system=platform.system()
-    ):
-        # TODO:
-        # Based on issue #36764 in the following link,
-        #        "https://github.com/tensorflow/tensorflow/issues/36764"
-        # tf.half is not registered for tf.linalg.svd function on Windows
-        # CPU version.
-        # So we have to remove tf.half when testing with Windows CPU version.
+@pytest.mark.with_device(["cpu", "gpu"])
+@pytest.mark.parametrize("dtype", [tf.float16, tf.float32, tf.float64])
+def test_basic_nuclear(use_resource, dtype):
+    if use_resource:
         var0 = tf.Variable([1.0, 2.0], dtype=dtype)
         var1 = tf.Variable([3.0, 4.0], dtype=dtype)
-        grads0 = tf.constant([0.1, 0.1], dtype=dtype)
-        grads1 = tf.constant([0.01, 0.01], dtype=dtype)
-        top_singular_vector0 = cg_lib.ConditionalGradient._top_singular_vector(grads0)
-        top_singular_vector1 = cg_lib.ConditionalGradient._top_singular_vector(grads1)
-        ord = "nuclear"
-        cg_opt = cg_lib.ConditionalGradient(
-            learning_rate=tf.constant(0.5), lambda_=tf.constant(0.01), ord=ord
-        )
-        _ = cg_opt.apply_gradients(zip([grads0, grads1], [var0, var1]))
+    else:
+        var0 = tf.Variable([1.0, 2.0], dtype=dtype)
+        var1 = tf.Variable([3.0, 4.0], dtype=dtype)
 
-        # Check we have slots
-        assert ["conditional_gradient"] == cg_opt.get_slot_names()
-        slot0 = cg_opt.get_slot(var0, "conditional_gradient")
-        assert slot0.get_shape() == var0.get_shape()
-        slot1 = cg_opt.get_slot(var1, "conditional_gradient")
-        assert slot1.get_shape() == var1.get_shape()
+    grads0 = tf.constant([0.1, 0.1], dtype=dtype)
+    grads1 = tf.constant([0.01, 0.01], dtype=dtype)
+    top_singular_vector0 = cg_lib.ConditionalGradient._top_singular_vector(grads0)
+    top_singular_vector1 = cg_lib.ConditionalGradient._top_singular_vector(grads1)
 
-        # Check that the parameters have been updated.
-        test_utils.assert_allclose_according_to_type(
-            np.array(
-                [
-                    1.0 * 0.5 - (1 - 0.5) * 0.01 * top_singular_vector0[0],
-                    2.0 * 0.5 - (1 - 0.5) * 0.01 * top_singular_vector0[1],
-                ]
-            ),
-            var0.numpy(),
-        )
-        test_utils.assert_allclose_according_to_type(
-            np.array(
-                [
-                    3.0 * 0.5 - (1 - 0.5) * 0.01 * top_singular_vector1[0],
-                    4.0 * 0.5 - (1 - 0.5) * 0.01 * top_singular_vector1[1],
-                ]
-            ),
-            var1.numpy(),
-        )
-        # Step 2: the conditional_gradient contain the
-        # previous update.
-        cg_opt.apply_gradients(zip([grads0, grads1], [var0, var1]))
+    def learning_rate():
+        return 0.5
 
-        # Check that the parameters have been updated.
-        test_utils.assert_allclose_according_to_type(
-            np.array(
-                [
-                    (1.0 * 0.5 - (1 - 0.5) * 0.01 * top_singular_vector0[0]) * 0.5
-                    - (1 - 0.5) * 0.01 * top_singular_vector0[0],
-                    (2.0 * 0.5 - (1 - 0.5) * 0.01 * top_singular_vector0[1]) * 0.5
-                    - (1 - 0.5) * 0.01 * top_singular_vector0[1],
-                ]
-            ),
-            var0.numpy(),
-        )
-        test_utils.assert_allclose_according_to_type(
-            np.array(
-                [
-                    (3.0 * 0.5 - (1 - 0.5) * 0.01 * top_singular_vector1[0]) * 0.5
-                    - (1 - 0.5) * 0.01 * top_singular_vector1[0],
-                    (4.0 * 0.5 - (1 - 0.5) * 0.01 * top_singular_vector1[1]) * 0.5
-                    - (1 - 0.5) * 0.01 * top_singular_vector1[1],
-                ]
-            ),
-            var1.numpy(),
-        )
+    def lambda_():
+        return 0.01
+
+    ord = "nuclear"
+
+    cg_opt = cg_lib.ConditionalGradient(
+        learning_rate=learning_rate, lambda_=lambda_, ord=ord
+    )
+    _ = cg_opt.apply_gradients(zip([grads0, grads1], [var0, var1]))
+
+    # Check we have slots
+    assert ["conditional_gradient"] == cg_opt.get_slot_names()
+    slot0 = cg_opt.get_slot(var0, "conditional_gradient")
+    assert slot0.get_shape() == var0.get_shape()
+    slot1 = cg_opt.get_slot(var1, "conditional_gradient")
+    assert slot1.get_shape() == var1.get_shape()
+
+    test_utils.assert_allclose_according_to_type(
+        np.array(
+            [
+                1.0 * 0.5 - (1 - 0.5) * 0.01 * top_singular_vector0[0],
+                2.0 * 0.5 - (1 - 0.5) * 0.01 * top_singular_vector0[1],
+            ]
+        ),
+        var0.numpy(),
+    )
+    test_utils.assert_allclose_according_to_type(
+        np.array(
+            [
+                3.0 * 0.5 - (1 - 0.5) * 0.01 * top_singular_vector1[0],
+                4.0 * 0.5 - (1 - 0.5) * 0.01 * top_singular_vector1[1],
+            ]
+        ),
+        var1.numpy(),
+    )
+
+    # Step 2: the conditional_gradient contain the previous update.
+    cg_opt.apply_gradients(zip([grads0, grads1], [var0, var1]))
+    test_utils.assert_allclose_according_to_type(
+        np.array(
+            [
+                (1.0 * 0.5 - (1 - 0.5) * 0.01 * top_singular_vector0[0]) * 0.5
+                - (1 - 0.5) * 0.01 * top_singular_vector0[0],
+                (2.0 * 0.5 - (1 - 0.5) * 0.01 * top_singular_vector0[1]) * 0.5
+                - (1 - 0.5) * 0.01 * top_singular_vector0[1],
+            ]
+        ),
+        var0.numpy(),
+    )
+    test_utils.assert_allclose_according_to_type(
+        np.array(
+            [
+                (3.0 * 0.5 - (1 - 0.5) * 0.01 * top_singular_vector1[0]) * 0.5
+                - (1 - 0.5) * 0.01 * top_singular_vector1[1],
+                (4.0 * 0.5 - (1 - 0.5) * 0.01 * top_singular_vector1[0]) * 0.5
+                - (1 - 0.5) * 0.01 * top_singular_vector1[1],
+            ]
+        ),
+        var1.numpy(),
+    )
+
+
+@pytest.mark.usefixtures("maybe_run_functions_eagerly")
+@pytest.mark.with_device(["cpu", "gpu"])
+@pytest.mark.parametrize("dtype", [tf.float16, tf.float32, tf.float64])
+def test_minimize_sparse_resource_variable_nuclear(dtype):
+
+    var0 = tf.Variable([[1.0, 2.0]], dtype=dtype)
+
+    def loss():
+        x = tf.constant([[4.0], [5.0]], dtype=dtype)
+        pred = tf.matmul(tf.nn.embedding_lookup([var0], [0]), x)
+        return pred * pred
+
+    # the gradient based on the current loss function
+    grads0_0 = 32 * 1.0 + 40 * 2.0
+    grads0_1 = 40 * 1.0 + 50 * 2.0
+    grads0 = tf.constant([[grads0_0, grads0_1]], dtype=dtype)
+    top_singular_vector0 = cg_lib.ConditionalGradient._top_singular_vector(grads0)
+
+    learning_rate = 0.1
+    lambda_ = 0.1
+    ord = "nuclear"
+    opt = cg_lib.ConditionalGradient(
+        learning_rate=learning_rate, lambda_=lambda_, ord=ord
+    )
+    _ = opt.minimize(loss, var_list=[var0])
+
+    # Validate updated params
+    test_utils.assert_allclose_according_to_type(
+        [
+            [
+                1.0 * learning_rate
+                - (1 - learning_rate) * lambda_ * top_singular_vector0[0][0],
+                2.0 * learning_rate
+                - (1 - learning_rate) * lambda_ * top_singular_vector0[0][1],
+            ]
+        ],
+        var0.numpy(),
+    )
+
+
+@pytest.mark.usefixtures("maybe_run_functions_eagerly")
+@pytest.mark.with_device(["cpu", "gpu"])
+@pytest.mark.parametrize("dtype", [tf.float16, tf.float32, tf.float64])
+def test_tensor_learning_rate_and_conditional_gradient_nuclear(dtype):
+    var0 = tf.Variable([1.0, 2.0], dtype=dtype)
+    var1 = tf.Variable([3.0, 4.0], dtype=dtype)
+    grads0 = tf.constant([0.1, 0.1], dtype=dtype)
+    grads1 = tf.constant([0.01, 0.01], dtype=dtype)
+    top_singular_vector0 = cg_lib.ConditionalGradient._top_singular_vector(grads0)
+    top_singular_vector1 = cg_lib.ConditionalGradient._top_singular_vector(grads1)
+    ord = "nuclear"
+    cg_opt = cg_lib.ConditionalGradient(
+        learning_rate=tf.constant(0.5), lambda_=tf.constant(0.01), ord=ord
+    )
+    _ = cg_opt.apply_gradients(zip([grads0, grads1], [var0, var1]))
+
+    # Check we have slots
+    assert ["conditional_gradient"] == cg_opt.get_slot_names()
+    slot0 = cg_opt.get_slot(var0, "conditional_gradient")
+    assert slot0.get_shape() == var0.get_shape()
+    slot1 = cg_opt.get_slot(var1, "conditional_gradient")
+    assert slot1.get_shape() == var1.get_shape()
+
+    # Check that the parameters have been updated.
+    test_utils.assert_allclose_according_to_type(
+        np.array(
+            [
+                1.0 * 0.5 - (1 - 0.5) * 0.01 * top_singular_vector0[0],
+                2.0 * 0.5 - (1 - 0.5) * 0.01 * top_singular_vector0[1],
+            ]
+        ),
+        var0.numpy(),
+    )
+    test_utils.assert_allclose_according_to_type(
+        np.array(
+            [
+                3.0 * 0.5 - (1 - 0.5) * 0.01 * top_singular_vector1[0],
+                4.0 * 0.5 - (1 - 0.5) * 0.01 * top_singular_vector1[1],
+            ]
+        ),
+        var1.numpy(),
+    )
+    # Step 2: the conditional_gradient contain the
+    # previous update.
+    cg_opt.apply_gradients(zip([grads0, grads1], [var0, var1]))
+
+    # Check that the parameters have been updated.
+    test_utils.assert_allclose_according_to_type(
+        np.array(
+            [
+                (1.0 * 0.5 - (1 - 0.5) * 0.01 * top_singular_vector0[0]) * 0.5
+                - (1 - 0.5) * 0.01 * top_singular_vector0[0],
+                (2.0 * 0.5 - (1 - 0.5) * 0.01 * top_singular_vector0[1]) * 0.5
+                - (1 - 0.5) * 0.01 * top_singular_vector0[1],
+            ]
+        ),
+        var0.numpy(),
+    )
+    test_utils.assert_allclose_according_to_type(
+        np.array(
+            [
+                (3.0 * 0.5 - (1 - 0.5) * 0.01 * top_singular_vector1[0]) * 0.5
+                - (1 - 0.5) * 0.01 * top_singular_vector1[0],
+                (4.0 * 0.5 - (1 - 0.5) * 0.01 * top_singular_vector1[1]) * 0.5
+                - (1 - 0.5) * 0.01 * top_singular_vector1[1],
+            ]
+        ),
+        var1.numpy(),
+    )
 
 
 @pytest.mark.usefixtures("maybe_run_functions_eagerly")
@@ -850,96 +798,93 @@ def test_like_dist_belief_frobenius_cg01():
 
 
 @pytest.mark.usefixtures("maybe_run_functions_eagerly")
-def test_sparse_frobenius():
-    # TODO:
-    #       To address the issue #347.
-    for dtype in _dtypes_to_test(use_gpu=tf.test.is_gpu_available()):
-        var0 = tf.Variable(tf.zeros([4, 2], dtype=dtype))
-        var1 = tf.Variable(tf.constant(1.0, dtype, [4, 2]))
-        grads0 = tf.IndexedSlices(
-            tf.constant([[0.1, 0.1]], dtype=dtype),
-            tf.constant([1]),
-            tf.constant([4, 2]),
-        )
-        grads1 = tf.IndexedSlices(
-            tf.constant([[0.01, 0.01], [0.01, 0.01]], dtype=dtype),
-            tf.constant([2, 3]),
-            tf.constant([4, 2]),
-        )
-        norm0 = tf.math.reduce_sum(tf.math.multiply(grads0, grads0)) ** 0.5
-        norm1 = tf.math.reduce_sum(tf.math.multiply(grads1, grads1)) ** 0.5
-        learning_rate = 0.1
-        lambda_ = 0.1
-        ord = "fro"
-        cg_opt = cg_lib.ConditionalGradient(
-            learning_rate=learning_rate, lambda_=lambda_, ord=ord
-        )
-        _ = cg_opt.apply_gradients(zip([grads0, grads1], [var0, var1]))
+@pytest.mark.with_device(["cpu", "gpu"])
+@pytest.mark.parametrize("dtype", [tf.float16, tf.float32, tf.float64])
+def test_sparse_frobenius(dtype):
+    var0 = tf.Variable(tf.zeros([4, 2], dtype=dtype))
+    var1 = tf.Variable(tf.constant(1.0, dtype, [4, 2]))
+    grads0 = tf.IndexedSlices(
+        tf.constant([[0.1, 0.1]], dtype=dtype), tf.constant([1]), tf.constant([4, 2]),
+    )
+    grads1 = tf.IndexedSlices(
+        tf.constant([[0.01, 0.01], [0.01, 0.01]], dtype=dtype),
+        tf.constant([2, 3]),
+        tf.constant([4, 2]),
+    )
+    norm0 = tf.math.reduce_sum(tf.math.multiply(grads0, grads0)) ** 0.5
+    norm1 = tf.math.reduce_sum(tf.math.multiply(grads1, grads1)) ** 0.5
+    learning_rate = 0.1
+    lambda_ = 0.1
+    ord = "fro"
+    cg_opt = cg_lib.ConditionalGradient(
+        learning_rate=learning_rate, lambda_=lambda_, ord=ord
+    )
+    _ = cg_opt.apply_gradients(zip([grads0, grads1], [var0, var1]))
 
-        # Check we have slots
-        assert ["conditional_gradient"] == cg_opt.get_slot_names()
-        slot0 = cg_opt.get_slot(var0, "conditional_gradient")
-        assert slot0.get_shape() == var0.get_shape()
-        slot1 = cg_opt.get_slot(var1, "conditional_gradient")
-        assert slot1.get_shape() == var1.get_shape()
+    # Check we have slots
+    assert ["conditional_gradient"] == cg_opt.get_slot_names()
+    slot0 = cg_opt.get_slot(var0, "conditional_gradient")
+    assert slot0.get_shape() == var0.get_shape()
+    slot1 = cg_opt.get_slot(var1, "conditional_gradient")
+    assert slot1.get_shape() == var1.get_shape()
 
-        # Check that the parameters have been updated.
-        test_utils.assert_allclose_according_to_type(
-            np.array(
-                [
-                    0 - (1 - learning_rate) * lambda_ * 0 / norm0,
-                    0 - (1 - learning_rate) * lambda_ * 0 / norm0,
-                ]
-            ),
-            var0[0].numpy(),
-        )
-        test_utils.assert_allclose_according_to_type(
-            np.array(
-                [
-                    0 - (1 - learning_rate) * lambda_ * 0.1 / norm0,
-                    0 - (1 - learning_rate) * lambda_ * 0.1 / norm0,
-                ]
-            ),
-            var0[1].numpy(),
-        )
-        test_utils.assert_allclose_according_to_type(
-            np.array(
-                [
-                    1.0 * learning_rate - (1 - learning_rate) * lambda_ * 0.01 / norm1,
-                    1.0 * learning_rate - (1 - learning_rate) * lambda_ * 0.01 / norm1,
-                ]
-            ),
-            var1[2].numpy(),
-        )
-        # Step 2: the conditional_gradient contain the
-        # previous update.
-        cg_opt.apply_gradients(zip([grads0, grads1], [var0, var1]))
-        # Check that the parameters have been updated.
-        np.testing.assert_allclose(np.array([0, 0]), var0[0].numpy())
-        test_utils.assert_allclose_according_to_type(
-            np.array(
-                [
-                    (0 - (1 - learning_rate) * lambda_ * 0.1 / norm0) * learning_rate
-                    - (1 - learning_rate) * lambda_ * 0.1 / norm0,
-                    (0 - (1 - learning_rate) * lambda_ * 0.1 / norm0) * learning_rate
-                    - (1 - learning_rate) * lambda_ * 0.1 / norm0,
-                ]
-            ),
-            var0[1].numpy(),
-        )
-        test_utils.assert_allclose_according_to_type(
-            np.array(
-                [
-                    (1.0 * learning_rate - (1 - learning_rate) * lambda_ * 0.01 / norm1)
-                    * learning_rate
-                    - (1 - learning_rate) * lambda_ * 0.01 / norm1,
-                    (1.0 * learning_rate - (1 - learning_rate) * lambda_ * 0.01 / norm1)
-                    * learning_rate
-                    - (1 - learning_rate) * lambda_ * 0.01 / norm1,
-                ]
-            ),
-            var1[2].numpy(),
-        )
+    # Check that the parameters have been updated.
+    test_utils.assert_allclose_according_to_type(
+        np.array(
+            [
+                0 - (1 - learning_rate) * lambda_ * 0 / norm0,
+                0 - (1 - learning_rate) * lambda_ * 0 / norm0,
+            ]
+        ),
+        var0[0].numpy(),
+    )
+    test_utils.assert_allclose_according_to_type(
+        np.array(
+            [
+                0 - (1 - learning_rate) * lambda_ * 0.1 / norm0,
+                0 - (1 - learning_rate) * lambda_ * 0.1 / norm0,
+            ]
+        ),
+        var0[1].numpy(),
+    )
+    test_utils.assert_allclose_according_to_type(
+        np.array(
+            [
+                1.0 * learning_rate - (1 - learning_rate) * lambda_ * 0.01 / norm1,
+                1.0 * learning_rate - (1 - learning_rate) * lambda_ * 0.01 / norm1,
+            ]
+        ),
+        var1[2].numpy(),
+    )
+    # Step 2: the conditional_gradient contain the
+    # previous update.
+    cg_opt.apply_gradients(zip([grads0, grads1], [var0, var1]))
+    # Check that the parameters have been updated.
+    np.testing.assert_allclose(np.array([0, 0]), var0[0].numpy())
+    test_utils.assert_allclose_according_to_type(
+        np.array(
+            [
+                (0 - (1 - learning_rate) * lambda_ * 0.1 / norm0) * learning_rate
+                - (1 - learning_rate) * lambda_ * 0.1 / norm0,
+                (0 - (1 - learning_rate) * lambda_ * 0.1 / norm0) * learning_rate
+                - (1 - learning_rate) * lambda_ * 0.1 / norm0,
+            ]
+        ),
+        var0[1].numpy(),
+    )
+    test_utils.assert_allclose_according_to_type(
+        np.array(
+            [
+                (1.0 * learning_rate - (1 - learning_rate) * lambda_ * 0.01 / norm1)
+                * learning_rate
+                - (1 - learning_rate) * lambda_ * 0.01 / norm1,
+                (1.0 * learning_rate - (1 - learning_rate) * lambda_ * 0.01 / norm1)
+                * learning_rate
+                - (1 - learning_rate) * lambda_ * 0.01 / norm1,
+            ]
+        ),
+        var1[2].numpy(),
+    )
 
 
 @pytest.mark.usefixtures("maybe_run_functions_eagerly")
@@ -1005,81 +950,78 @@ def test_sharing_frobenius(dtype):
 
 
 @pytest.mark.usefixtures("maybe_run_functions_eagerly")
-def test_sharing_nuclear():
-    # TODO:
-    #       To address the issue #36764.
-    for dtype in _dtypes_with_checking_system(
-        use_gpu=tf.test.is_gpu_available(), system=platform.system()
-    ):
-        var0 = tf.Variable([1.0, 2.0], dtype=dtype)
-        var1 = tf.Variable([3.0, 4.0], dtype=dtype)
-        grads0 = tf.constant([0.1, 0.1], dtype=dtype)
-        grads1 = tf.constant([0.01, 0.01], dtype=dtype)
-        top_singular_vector0 = cg_lib.ConditionalGradient._top_singular_vector(grads0)
-        top_singular_vector1 = cg_lib.ConditionalGradient._top_singular_vector(grads1)
-        learning_rate = 0.1
-        lambda_ = 0.1
-        ord = "nuclear"
-        cg_opt = cg_lib.ConditionalGradient(
-            learning_rate=learning_rate, lambda_=lambda_, ord=ord
-        )
-        _ = cg_opt.apply_gradients(zip([grads0, grads1], [var0, var1]))
+@pytest.mark.with_device(["cpu", "gpu"])
+@pytest.mark.parametrize("dtype", [tf.float16, tf.float32, tf.float64])
+def test_sharing_nuclear(dtype):
+    var0 = tf.Variable([1.0, 2.0], dtype=dtype)
+    var1 = tf.Variable([3.0, 4.0], dtype=dtype)
+    grads0 = tf.constant([0.1, 0.1], dtype=dtype)
+    grads1 = tf.constant([0.01, 0.01], dtype=dtype)
+    top_singular_vector0 = cg_lib.ConditionalGradient._top_singular_vector(grads0)
+    top_singular_vector1 = cg_lib.ConditionalGradient._top_singular_vector(grads1)
+    learning_rate = 0.1
+    lambda_ = 0.1
+    ord = "nuclear"
+    cg_opt = cg_lib.ConditionalGradient(
+        learning_rate=learning_rate, lambda_=lambda_, ord=ord
+    )
+    _ = cg_opt.apply_gradients(zip([grads0, grads1], [var0, var1]))
 
-        # Check we have slots
-        assert ["conditional_gradient"] == cg_opt.get_slot_names()
-        slot0 = cg_opt.get_slot(var0, "conditional_gradient")
-        assert slot0.get_shape() == var0.get_shape()
-        slot1 = cg_opt.get_slot(var1, "conditional_gradient")
-        assert slot1.get_shape() == var1.get_shape()
+    # Check we have slots
+    assert ["conditional_gradient"] == cg_opt.get_slot_names()
+    slot0 = cg_opt.get_slot(var0, "conditional_gradient")
+    assert slot0.get_shape() == var0.get_shape()
+    slot1 = cg_opt.get_slot(var1, "conditional_gradient")
+    assert slot1.get_shape() == var1.get_shape()
 
-        # Because in the eager mode, as we declare two cg_update
-        # variables, it already altomatically finish executing them.
-        # Thus, we cannot test the param value at this time for
-        # eager mode. We can only test the final value of param
-        # after the second execution.
+    # Because in the eager mode, as we declare two cg_update
+    # variables, it already altomatically finish executing them.
+    # Thus, we cannot test the param value at this time for
+    # eager mode. We can only test the final value of param
+    # after the second execution.
 
-        # Step 2: the second conditional_gradient contain
-        # the previous update.
-        # Check that the parameters have been updated.
-        cg_opt.apply_gradients(zip([grads0, grads1], [var0, var1]))
-        test_utils.assert_allclose_according_to_type(
-            np.array(
-                [
-                    (
-                        1.0 * learning_rate
-                        - (1 - learning_rate) * lambda_ * top_singular_vector0[0]
-                    )
-                    * learning_rate
-                    - (1 - learning_rate) * lambda_ * top_singular_vector0[0],
-                    (
-                        2.0 * learning_rate
-                        - (1 - learning_rate) * lambda_ * top_singular_vector0[1]
-                    )
-                    * learning_rate
-                    - (1 - learning_rate) * lambda_ * top_singular_vector0[1],
-                ]
-            ),
-            var0.numpy(),
-        )
-        test_utils.assert_allclose_according_to_type(
-            np.array(
-                [
-                    (
-                        3.0 * learning_rate
-                        - (1 - learning_rate) * lambda_ * top_singular_vector1[0]
-                    )
-                    * learning_rate
-                    - (1 - learning_rate) * lambda_ * top_singular_vector1[0],
-                    (
-                        4.0 * learning_rate
-                        - (1 - learning_rate) * lambda_ * top_singular_vector1[1]
-                    )
-                    * learning_rate
-                    - (1 - learning_rate) * lambda_ * top_singular_vector1[1],
-                ]
-            ),
-            var1.numpy(),
-        )
+    # Step 2: the second conditional_gradient contain
+    # the previous update.
+    # Check that the parameters have been updated.
+    cg_opt.apply_gradients(zip([grads0, grads1], [var0, var1]))
+    test_utils.assert_allclose_according_to_type(
+        np.array(
+            [
+                (
+                    1.0 * learning_rate
+                    - (1 - learning_rate) * lambda_ * top_singular_vector0[0]
+                )
+                * learning_rate
+                - (1 - learning_rate) * lambda_ * top_singular_vector0[0],
+                (
+                    2.0 * learning_rate
+                    - (1 - learning_rate) * lambda_ * top_singular_vector0[1]
+                )
+                * learning_rate
+                - (1 - learning_rate) * lambda_ * top_singular_vector0[1],
+            ]
+        ),
+        var0.numpy(),
+    )
+    test_utils.assert_allclose_according_to_type(
+        np.array(
+            [
+                (
+                    3.0 * learning_rate
+                    - (1 - learning_rate) * lambda_ * top_singular_vector1[0]
+                )
+                * learning_rate
+                - (1 - learning_rate) * lambda_ * top_singular_vector1[0],
+                (
+                    4.0 * learning_rate
+                    - (1 - learning_rate) * lambda_ * top_singular_vector1[1]
+                )
+                * learning_rate
+                - (1 - learning_rate) * lambda_ * top_singular_vector1[1],
+            ]
+        ),
+        var1.numpy(),
+    )
 
 
 def _db_params_nuclear_cg01():
@@ -1344,119 +1286,115 @@ def _db_params_nuclear_cg01():
 
 
 @pytest.mark.usefixtures("maybe_run_functions_eagerly")
-def test_sparse_nuclear():
-    # TODO:
-    #       To address the issue #347 and issue #36764.
-    for dtype in _dtypes_with_checking_system(
-        use_gpu=tf.test.is_gpu_available(), system=platform.system()
-    ):
-        var0 = tf.Variable(tf.zeros([4, 2], dtype=dtype))
-        var1 = tf.Variable(tf.constant(1.0, dtype, [4, 2]))
-        grads0 = tf.IndexedSlices(
-            tf.constant([[0.1, 0.1]], dtype=dtype),
-            tf.constant([1]),
-            tf.constant([4, 2]),
-        )
-        grads1 = tf.IndexedSlices(
-            tf.constant([[0.01, 0.01], [0.01, 0.01]], dtype=dtype),
-            tf.constant([2, 3]),
-            tf.constant([4, 2]),
-        )
-        top_singular_vector0 = tf.constant(
-            [[0.0, 0.0], [0.7071067, 0.7071067], [0.0, 0.0], [0.0, 0.0]], dtype=dtype,
-        )
-        top_singular_vector1 = tf.constant(
+@pytest.mark.with_device(["cpu", "gpu"])
+@pytest.mark.parametrize("dtype", [tf.float16, tf.float32, tf.float64])
+def test_sparse_nuclear(dtype):
+
+    var0 = tf.Variable(tf.zeros([4, 2], dtype=dtype))
+    var1 = tf.Variable(tf.constant(1.0, dtype, [4, 2]))
+    grads0 = tf.IndexedSlices(
+        tf.constant([[0.1, 0.1]], dtype=dtype), tf.constant([1]), tf.constant([4, 2]),
+    )
+    grads1 = tf.IndexedSlices(
+        tf.constant([[0.01, 0.01], [0.01, 0.01]], dtype=dtype),
+        tf.constant([2, 3]),
+        tf.constant([4, 2]),
+    )
+    top_singular_vector0 = tf.constant(
+        [[0.0, 0.0], [0.7071067, 0.7071067], [0.0, 0.0], [0.0, 0.0]], dtype=dtype,
+    )
+    top_singular_vector1 = tf.constant(
+        [
+            [-4.2146844e-08, -4.2146844e-08],
+            [0.0000000e00, 0.0000000e00],
+            [4.9999994e-01, 4.9999994e-01],
+            [4.9999994e-01, 4.9999994e-01],
+        ],
+        dtype=dtype,
+    )
+    learning_rate = 0.1
+    lambda_ = 0.1
+    ord = "nuclear"
+    cg_opt = cg_lib.ConditionalGradient(
+        learning_rate=learning_rate, lambda_=lambda_, ord=ord
+    )
+    _ = cg_opt.apply_gradients(zip([grads0, grads1], [var0, var1]))
+
+    # Check we have slots
+    assert ["conditional_gradient"] == cg_opt.get_slot_names()
+    slot0 = cg_opt.get_slot(var0, "conditional_gradient")
+    assert slot0.get_shape() == var0.get_shape()
+    slot1 = cg_opt.get_slot(var1, "conditional_gradient")
+    assert slot1.get_shape() == var1.get_shape()
+
+    # Check that the parameters have been updated.
+    test_utils.assert_allclose_according_to_type(
+        np.array(
             [
-                [-4.2146844e-08, -4.2146844e-08],
-                [0.0000000e00, 0.0000000e00],
-                [4.9999994e-01, 4.9999994e-01],
-                [4.9999994e-01, 4.9999994e-01],
-            ],
-            dtype=dtype,
-        )
-        learning_rate = 0.1
-        lambda_ = 0.1
-        ord = "nuclear"
-        cg_opt = cg_lib.ConditionalGradient(
-            learning_rate=learning_rate, lambda_=lambda_, ord=ord
-        )
-        _ = cg_opt.apply_gradients(zip([grads0, grads1], [var0, var1]))
+                0 - (1 - learning_rate) * lambda_ * top_singular_vector0[0][0],
+                0 - (1 - learning_rate) * lambda_ * top_singular_vector0[0][1],
+            ]
+        ),
+        var0[0].numpy(),
+    )
+    test_utils.assert_allclose_according_to_type(
+        np.array(
+            [
+                0 - (1 - learning_rate) * lambda_ * top_singular_vector0[1][0],
+                0 - (1 - learning_rate) * lambda_ * top_singular_vector0[1][1],
+            ]
+        ),
+        var0[1].numpy(),
+    )
+    test_utils.assert_allclose_according_to_type(
+        np.array(
+            [
+                1.0 * learning_rate
+                - (1 - learning_rate) * lambda_ * top_singular_vector1[2][0],
+                1.0 * learning_rate
+                - (1 - learning_rate) * lambda_ * top_singular_vector1[2][1],
+            ]
+        ),
+        var1[2].numpy(),
+    )
+    # Step 2: the conditional_gradient contain the
+    # previous update.
+    cg_opt.apply_gradients(zip([grads0, grads1], [var0, var1]))
 
-        # Check we have slots
-        assert ["conditional_gradient"] == cg_opt.get_slot_names()
-        slot0 = cg_opt.get_slot(var0, "conditional_gradient")
-        assert slot0.get_shape() == var0.get_shape()
-        slot1 = cg_opt.get_slot(var1, "conditional_gradient")
-        assert slot1.get_shape() == var1.get_shape()
-
-        # Check that the parameters have been updated.
-        test_utils.assert_allclose_according_to_type(
-            np.array(
-                [
-                    0 - (1 - learning_rate) * lambda_ * top_singular_vector0[0][0],
-                    0 - (1 - learning_rate) * lambda_ * top_singular_vector0[0][1],
-                ]
-            ),
-            var0[0].numpy(),
-        )
-        test_utils.assert_allclose_according_to_type(
-            np.array(
-                [
-                    0 - (1 - learning_rate) * lambda_ * top_singular_vector0[1][0],
-                    0 - (1 - learning_rate) * lambda_ * top_singular_vector0[1][1],
-                ]
-            ),
-            var0[1].numpy(),
-        )
-        test_utils.assert_allclose_according_to_type(
-            np.array(
-                [
+    # Check that the parameters have been updated.
+    np.testing.assert_allclose(np.array([0, 0]), var0[0].numpy())
+    test_utils.assert_allclose_according_to_type(
+        np.array(
+            [
+                (0 - (1 - learning_rate) * lambda_ * top_singular_vector0[1][0])
+                * learning_rate
+                - (1 - learning_rate) * lambda_ * top_singular_vector0[1][0],
+                (0 - (1 - learning_rate) * lambda_ * top_singular_vector0[1][1])
+                * learning_rate
+                - (1 - learning_rate) * lambda_ * top_singular_vector0[1][1],
+            ]
+        ),
+        var0[1].numpy(),
+    )
+    test_utils.assert_allclose_according_to_type(
+        np.array(
+            [
+                (
                     1.0 * learning_rate
-                    - (1 - learning_rate) * lambda_ * top_singular_vector1[2][0],
+                    - (1 - learning_rate) * lambda_ * top_singular_vector1[2][0]
+                )
+                * learning_rate
+                - (1 - learning_rate) * lambda_ * top_singular_vector1[2][0],
+                (
                     1.0 * learning_rate
-                    - (1 - learning_rate) * lambda_ * top_singular_vector1[2][1],
-                ]
-            ),
-            var1[2].numpy(),
-        )
-        # Step 2: the conditional_gradient contain the
-        # previous update.
-        cg_opt.apply_gradients(zip([grads0, grads1], [var0, var1]))
-
-        # Check that the parameters have been updated.
-        np.testing.assert_allclose(np.array([0, 0]), var0[0].numpy())
-        test_utils.assert_allclose_according_to_type(
-            np.array(
-                [
-                    (0 - (1 - learning_rate) * lambda_ * top_singular_vector0[1][0])
-                    * learning_rate
-                    - (1 - learning_rate) * lambda_ * top_singular_vector0[1][0],
-                    (0 - (1 - learning_rate) * lambda_ * top_singular_vector0[1][1])
-                    * learning_rate
-                    - (1 - learning_rate) * lambda_ * top_singular_vector0[1][1],
-                ]
-            ),
-            var0[1].numpy(),
-        )
-        test_utils.assert_allclose_according_to_type(
-            np.array(
-                [
-                    (
-                        1.0 * learning_rate
-                        - (1 - learning_rate) * lambda_ * top_singular_vector1[2][0]
-                    )
-                    * learning_rate
-                    - (1 - learning_rate) * lambda_ * top_singular_vector1[2][0],
-                    (
-                        1.0 * learning_rate
-                        - (1 - learning_rate) * lambda_ * top_singular_vector1[2][1]
-                    )
-                    * learning_rate
-                    - (1 - learning_rate) * lambda_ * top_singular_vector1[2][1],
-                ]
-            ),
-            var1[2].numpy(),
-        )
+                    - (1 - learning_rate) * lambda_ * top_singular_vector1[2][1]
+                )
+                * learning_rate
+                - (1 - learning_rate) * lambda_ * top_singular_vector1[2][1],
+            ]
+        ),
+        var1[2].numpy(),
+    )
 
 
 def test_serialization():

--- a/tensorflow_addons/optimizers/tests/conditional_gradient_test.py
+++ b/tensorflow_addons/optimizers/tests/conditional_gradient_test.py
@@ -16,7 +16,6 @@
 
 import numpy as np
 import pytest
-import platform
 
 import tensorflow as tf
 from tensorflow_addons.utils import test_utils

--- a/tensorflow_addons/optimizers/tests/conditional_gradient_test.py
+++ b/tensorflow_addons/optimizers/tests/conditional_gradient_test.py
@@ -41,7 +41,9 @@ def test_like_dist_belief_nuclear_cg01():
 
 @pytest.mark.with_device(["cpu", "gpu"])
 @pytest.mark.parametrize("dtype", [tf.float16, tf.float32, tf.float64])
-def test_minimize_sparse_resource_variable_frobenius(dtype):
+def test_minimize_sparse_resource_variable_frobenius(dtype, device):
+    if "gpu" in device and dtype == tf.float16:
+        pytest.xfail("See https://github.com/tensorflow/addons/issues/347")
     var0 = tf.Variable([[1.0, 2.0]], dtype=dtype)
 
     def loss():
@@ -157,7 +159,9 @@ def test_basic_frobenius(dtype, use_resource):
 @pytest.mark.parametrize("use_resource", [True, False])
 @pytest.mark.with_device(["cpu", "gpu"])
 @pytest.mark.parametrize("dtype", [tf.float16, tf.float32, tf.float64])
-def test_basic_nuclear(use_resource, dtype):
+def test_basic_nuclear(use_resource, dtype, device):
+    if "gpu" in device and dtype == tf.float16:
+        pytest.xfail("See https://github.com/tensorflow/addons/issues/347")
     if use_resource:
         var0 = tf.Variable([1.0, 2.0], dtype=dtype)
         var1 = tf.Variable([3.0, 4.0], dtype=dtype)
@@ -238,7 +242,9 @@ def test_basic_nuclear(use_resource, dtype):
 @pytest.mark.usefixtures("maybe_run_functions_eagerly")
 @pytest.mark.with_device(["cpu", "gpu"])
 @pytest.mark.parametrize("dtype", [tf.float16, tf.float32, tf.float64])
-def test_minimize_sparse_resource_variable_nuclear(dtype):
+def test_minimize_sparse_resource_variable_nuclear(dtype, device):
+    if "gpu" in device and dtype == tf.float16:
+        pytest.xfail("See https://github.com/tensorflow/addons/issues/347")
 
     var0 = tf.Variable([[1.0, 2.0]], dtype=dtype)
 
@@ -278,7 +284,9 @@ def test_minimize_sparse_resource_variable_nuclear(dtype):
 @pytest.mark.usefixtures("maybe_run_functions_eagerly")
 @pytest.mark.with_device(["cpu", "gpu"])
 @pytest.mark.parametrize("dtype", [tf.float16, tf.float32, tf.float64])
-def test_tensor_learning_rate_and_conditional_gradient_nuclear(dtype):
+def test_tensor_learning_rate_and_conditional_gradient_nuclear(dtype, device):
+    if "gpu" in device and dtype == tf.float16:
+        pytest.xfail("See https://github.com/tensorflow/addons/issues/347")
     var0 = tf.Variable([1.0, 2.0], dtype=dtype)
     var1 = tf.Variable([3.0, 4.0], dtype=dtype)
     grads0 = tf.constant([0.1, 0.1], dtype=dtype)
@@ -799,7 +807,9 @@ def test_like_dist_belief_frobenius_cg01():
 @pytest.mark.usefixtures("maybe_run_functions_eagerly")
 @pytest.mark.with_device(["cpu", "gpu"])
 @pytest.mark.parametrize("dtype", [tf.float16, tf.float32, tf.float64])
-def test_sparse_frobenius(dtype):
+def test_sparse_frobenius(dtype, device):
+    if "gpu" in device and dtype == tf.float16:
+        pytest.xfail("See https://github.com/tensorflow/addons/issues/347")
     var0 = tf.Variable(tf.zeros([4, 2], dtype=dtype))
     var1 = tf.Variable(tf.constant(1.0, dtype, [4, 2]))
     grads0 = tf.IndexedSlices(
@@ -951,7 +961,9 @@ def test_sharing_frobenius(dtype):
 @pytest.mark.usefixtures("maybe_run_functions_eagerly")
 @pytest.mark.with_device(["cpu", "gpu"])
 @pytest.mark.parametrize("dtype", [tf.float16, tf.float32, tf.float64])
-def test_sharing_nuclear(dtype):
+def test_sharing_nuclear(dtype, device):
+    if "gpu" in device and dtype == tf.float16:
+        pytest.xfail("See https://github.com/tensorflow/addons/issues/347")
     var0 = tf.Variable([1.0, 2.0], dtype=dtype)
     var1 = tf.Variable([3.0, 4.0], dtype=dtype)
     grads0 = tf.constant([0.1, 0.1], dtype=dtype)
@@ -1287,8 +1299,9 @@ def _db_params_nuclear_cg01():
 @pytest.mark.usefixtures("maybe_run_functions_eagerly")
 @pytest.mark.with_device(["cpu", "gpu"])
 @pytest.mark.parametrize("dtype", [tf.float16, tf.float32, tf.float64])
-def test_sparse_nuclear(dtype):
-
+def test_sparse_nuclear(dtype, device):
+    if "gpu" in device and dtype == tf.float16:
+        pytest.xfail("See https://github.com/tensorflow/addons/issues/347")
     var0 = tf.Variable(tf.zeros([4, 2], dtype=dtype))
     var1 = tf.Variable(tf.constant(1.0, dtype, [4, 2]))
     grads0 = tf.IndexedSlices(

--- a/tensorflow_addons/optimizers/tests/conditional_gradient_test.py
+++ b/tensorflow_addons/optimizers/tests/conditional_gradient_test.py
@@ -39,7 +39,6 @@ def test_like_dist_belief_nuclear_cg01():
         )
 
 
-@pytest.mark.with_device(["cpu", "gpu"])
 @pytest.mark.parametrize("dtype", [tf.float16, tf.float32, tf.float64])
 def test_minimize_sparse_resource_variable_frobenius(dtype):
     var0 = tf.Variable([[1.0, 2.0]], dtype=dtype)
@@ -155,7 +154,6 @@ def test_basic_frobenius(dtype, use_resource):
 
 @pytest.mark.usefixtures("maybe_run_functions_eagerly")
 @pytest.mark.parametrize("use_resource", [True, False])
-@pytest.mark.with_device(["cpu", "gpu"])
 @pytest.mark.parametrize("dtype", [tf.float16, tf.float32, tf.float64])
 def test_basic_nuclear(use_resource, dtype):
     if use_resource:
@@ -236,7 +234,6 @@ def test_basic_nuclear(use_resource, dtype):
 
 
 @pytest.mark.usefixtures("maybe_run_functions_eagerly")
-@pytest.mark.with_device(["cpu", "gpu"])
 @pytest.mark.parametrize("dtype", [tf.float16, tf.float32, tf.float64])
 def test_minimize_sparse_resource_variable_nuclear(dtype):
 
@@ -276,7 +273,6 @@ def test_minimize_sparse_resource_variable_nuclear(dtype):
 
 
 @pytest.mark.usefixtures("maybe_run_functions_eagerly")
-@pytest.mark.with_device(["cpu", "gpu"])
 @pytest.mark.parametrize("dtype", [tf.float16, tf.float32, tf.float64])
 def test_tensor_learning_rate_and_conditional_gradient_nuclear(dtype):
     var0 = tf.Variable([1.0, 2.0], dtype=dtype)
@@ -797,7 +793,6 @@ def test_like_dist_belief_frobenius_cg01():
 
 
 @pytest.mark.usefixtures("maybe_run_functions_eagerly")
-@pytest.mark.with_device(["cpu", "gpu"])
 @pytest.mark.parametrize("dtype", [tf.float16, tf.float32, tf.float64])
 def test_sparse_frobenius(dtype):
     var0 = tf.Variable(tf.zeros([4, 2], dtype=dtype))
@@ -949,7 +944,6 @@ def test_sharing_frobenius(dtype):
 
 
 @pytest.mark.usefixtures("maybe_run_functions_eagerly")
-@pytest.mark.with_device(["cpu", "gpu"])
 @pytest.mark.parametrize("dtype", [tf.float16, tf.float32, tf.float64])
 def test_sharing_nuclear(dtype):
     var0 = tf.Variable([1.0, 2.0], dtype=dtype)
@@ -1285,7 +1279,6 @@ def _db_params_nuclear_cg01():
 
 
 @pytest.mark.usefixtures("maybe_run_functions_eagerly")
-@pytest.mark.with_device(["cpu", "gpu"])
 @pytest.mark.parametrize("dtype", [tf.float16, tf.float32, tf.float64])
 def test_sparse_nuclear(dtype):
 

--- a/tensorflow_addons/optimizers/tests/conditional_gradient_test.py
+++ b/tensorflow_addons/optimizers/tests/conditional_gradient_test.py
@@ -39,6 +39,7 @@ def test_like_dist_belief_nuclear_cg01():
         )
 
 
+@pytest.mark.with_device(["cpu", "gpu"])
 @pytest.mark.parametrize("dtype", [tf.float16, tf.float32, tf.float64])
 def test_minimize_sparse_resource_variable_frobenius(dtype):
     var0 = tf.Variable([[1.0, 2.0]], dtype=dtype)
@@ -154,6 +155,7 @@ def test_basic_frobenius(dtype, use_resource):
 
 @pytest.mark.usefixtures("maybe_run_functions_eagerly")
 @pytest.mark.parametrize("use_resource", [True, False])
+@pytest.mark.with_device(["cpu", "gpu"])
 @pytest.mark.parametrize("dtype", [tf.float16, tf.float32, tf.float64])
 def test_basic_nuclear(use_resource, dtype):
     if use_resource:
@@ -234,6 +236,7 @@ def test_basic_nuclear(use_resource, dtype):
 
 
 @pytest.mark.usefixtures("maybe_run_functions_eagerly")
+@pytest.mark.with_device(["cpu", "gpu"])
 @pytest.mark.parametrize("dtype", [tf.float16, tf.float32, tf.float64])
 def test_minimize_sparse_resource_variable_nuclear(dtype):
 
@@ -273,6 +276,7 @@ def test_minimize_sparse_resource_variable_nuclear(dtype):
 
 
 @pytest.mark.usefixtures("maybe_run_functions_eagerly")
+@pytest.mark.with_device(["cpu", "gpu"])
 @pytest.mark.parametrize("dtype", [tf.float16, tf.float32, tf.float64])
 def test_tensor_learning_rate_and_conditional_gradient_nuclear(dtype):
     var0 = tf.Variable([1.0, 2.0], dtype=dtype)
@@ -793,6 +797,7 @@ def test_like_dist_belief_frobenius_cg01():
 
 
 @pytest.mark.usefixtures("maybe_run_functions_eagerly")
+@pytest.mark.with_device(["cpu", "gpu"])
 @pytest.mark.parametrize("dtype", [tf.float16, tf.float32, tf.float64])
 def test_sparse_frobenius(dtype):
     var0 = tf.Variable(tf.zeros([4, 2], dtype=dtype))
@@ -944,6 +949,7 @@ def test_sharing_frobenius(dtype):
 
 
 @pytest.mark.usefixtures("maybe_run_functions_eagerly")
+@pytest.mark.with_device(["cpu", "gpu"])
 @pytest.mark.parametrize("dtype", [tf.float16, tf.float32, tf.float64])
 def test_sharing_nuclear(dtype):
     var0 = tf.Variable([1.0, 2.0], dtype=dtype)
@@ -1279,6 +1285,7 @@ def _db_params_nuclear_cg01():
 
 
 @pytest.mark.usefixtures("maybe_run_functions_eagerly")
+@pytest.mark.with_device(["cpu", "gpu"])
 @pytest.mark.parametrize("dtype", [tf.float16, tf.float32, tf.float64])
 def test_sparse_nuclear(dtype):
 

--- a/tensorflow_addons/utils/test_utils.py
+++ b/tensorflow_addons/utils/test_utils.py
@@ -101,10 +101,10 @@ def pytest_configure(config):
 
 
 @pytest.fixture(autouse=True, scope="function")
-def _device_placement(request):
+def device(request):
     device = request.param
     if device == "no_device":
-        yield
+        yield device
     else:
         if device in ["cpu", "gpu"]:
             # we use GPU:0 because the virtual device we created is the
@@ -113,7 +113,7 @@ def _device_placement(request):
         else:
             raise KeyError("Invalid device: " + device)
         with tf.device(device):
-            yield
+            yield device
 
 
 def get_marks(device_name):
@@ -137,7 +137,7 @@ def pytest_generate_tests(metafunc):
         devices = marker.args[0]
 
     parameters = [pytest.param(x, marks=get_marks(x)) for x in devices]
-    metafunc.parametrize("_device_placement", parameters, indirect=True)
+    metafunc.parametrize("device", parameters, indirect=True)
 
 
 def assert_allclose_according_to_type(

--- a/tensorflow_addons/utils/test_utils.py
+++ b/tensorflow_addons/utils/test_utils.py
@@ -102,18 +102,18 @@ def pytest_configure(config):
 
 @pytest.fixture(autouse=True, scope="function")
 def device(request):
-    device = request.param
-    if device == "no_device":
-        yield device
+    requested_device = request.param
+    if requested_device == "no_device":
+        yield requested_device
     else:
-        if device in ["cpu", "gpu"]:
+        if requested_device in ["cpu", "gpu"]:
             # we use GPU:0 because the virtual device we created is the
             # only one in the first GPU (so first in the list of virtual devices).
-            device += ":0"
+            requested_device += ":0"
         else:
-            raise KeyError("Invalid device: " + device)
-        with tf.device(device):
-            yield device
+            raise KeyError("Invalid device: " + requested_device)
+        with tf.device(requested_device):
+            yield requested_device
 
 
 def get_marks(device_name):


### PR DESCRIPTION
Made conditional_gradient_test.py use the pytest mark as it's more clean.

I also had to expose a way to grab the device used to run the test function. This can now be done by adding a parameter `device` to the test function. I adapted the CONTRIBUTING to reflect that. 