### PR TITLE
Use commit SHA for unverified actions

### DIFF
--- a/.github/workflows/backport.yml
+++ b/.github/workflows/backport.yml
@@ -12,7 +12,7 @@ jobs:
     steps:
       - name: Backport Bot
         if: github.event.pull_request.merged && ( ( github.event.action == 'closed' && contains( join( github.event.pull_request.labels.*.name ), 'backport') ) || contains( github.event.label.name, 'backport' ) )
-        uses: Gaurav0/backport@v1.0.24
+        uses: Gaurav0/backport@d69fd1d # Version 1.0.24
         with:
           bot_username: bot-of-gabrieldemarmiesse
           bot_token: 1353d990cdb8b8ceb1b73d301dce83cc0da3db29

--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -10,7 +10,7 @@ jobs:
   update_release_draft:
     runs-on: ubuntu-latest
     steps:
-      - uses: release-drafter/release-drafter@v5
+      - uses: release-drafter/release-drafter@74e7c42 # Version 5.7.0
         with:
           config-name: release-template.yml
         env:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -61,7 +61,7 @@ jobs:
         # Ubuntu bazel is run inside of the docker image
         if: matrix.os != 'ubuntu-18.04'
         # MacOS VMs share IP addr on GH actions. This bazel installation authenticates token to prevent api rate limiting.
-        uses: jwlawson/actions-setup-bazel@v1.0
+        uses: jwlawson/actions-setup-bazel@784af34 # Version 1.1
         with:
           bazel-version: ${{ env.BAZEL_VERSION}}
           github-api-token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
For unauthenticated github action creators, I would be more comfortable pinning our use to commit SHA.  Not a whole lot can go wrong here, GITHUB_TOKENS expire in an hour and don't have much access, but better safe than sorry.