### PR TITLE
Make gaussian filter meet scipy's implementation

### DIFF
--- a/tensorflow_addons/image/filters.py
+++ b/tensorflow_addons/image/filters.py
@@ -206,10 +206,10 @@ def median_filter2d(
         return output
 
 
-def _get_gaussian_kernel(sigma, filter_shape_1d):
-    "This function creates a kernel of size [filter_shape]."
+def _get_gaussian_kernel(sigma, filter_shape):
+    """Compute 1D Gaussian kernel."""
     sigma = tf.convert_to_tensor(sigma)
-    x = tf.range(-filter_shape_1d // 2 + 1, filter_shape_1d // 2 + 1)
+    x = tf.range(-filter_shape // 2 + 1, filter_shape // 2 + 1)
     x = tf.cast(x ** 2, sigma.dtype)
     x = tf.exp(-x / (2.0 * (sigma ** 2)))
     x = x / tf.math.reduce_sum(x)
@@ -217,7 +217,7 @@ def _get_gaussian_kernel(sigma, filter_shape_1d):
 
 
 def _get_gaussian_kernel_2d(gaussian_filter_x, gaussian_filter_y):
-    "Compute 2D Gaussian kernel."
+    """Compute 2D Gaussian kernel given 1D kernels."""
     gaussian_kernel = tf.matmul(gaussian_filter_x, gaussian_filter_y)
     return gaussian_kernel
 

--- a/tensorflow_addons/image/filters.py
+++ b/tensorflow_addons/image/filters.py
@@ -209,7 +209,6 @@ def median_filter2d(
 def _get_gaussian_kernel(sigma, filter_shape_1d):
     "This function creates a kernel of size [filter_shape]."
     sigma = tf.convert_to_tensor(sigma)
-    sigma = tf.cast(sigma, tf.float32)
     x = tf.range(-filter_shape_1d // 2 + 1, filter_shape_1d // 2 + 1)
     x = tf.cast(x ** 2, sigma.dtype)
     x = tf.exp(-x / (2.0 * (sigma ** 2)))
@@ -276,6 +275,8 @@ def gaussian_filter2d(
             )
 
         image = tf.convert_to_tensor(image, name="image")
+        sigma = tf.convert_to_tensor(sigma, name="sigma")
+
         original_ndims = img_utils.get_ndims(image)
         image = img_utils.to_4D_image(image)
 
@@ -288,12 +289,11 @@ def gaussian_filter2d(
         channels = tf.shape(image)[3]
         filter_shape = keras_utils.normalize_tuple(filter_shape, 2, "filter_shape")
 
+        sigma = tf.cast(sigma, image.dtype)
         gaussian_kernel_x = _get_gaussian_kernel(sigma[1], filter_shape[1])
-        gaussian_kernel_x = tf.cast(gaussian_kernel_x, image.dtype)
         gaussian_kernel_x = tf.reshape(gaussian_kernel_x, [1, filter_shape[1]])
 
         gaussian_kernel_y = _get_gaussian_kernel(sigma[0], filter_shape[0])
-        gaussian_kernel_y = tf.cast(gaussian_kernel_y, image.dtype)
         gaussian_kernel_y = tf.reshape(gaussian_kernel_y, [filter_shape[0], 1])
 
         gaussian_kernel_2d = _get_gaussian_kernel_2d(

--- a/tensorflow_addons/image/filters.py
+++ b/tensorflow_addons/image/filters.py
@@ -93,7 +93,7 @@ def mean_filter2d(
 
         if padding not in ["REFLECT", "CONSTANT", "SYMMETRIC"]:
             raise ValueError(
-                'padding should be one of "REFLECT", "CONSTANT", or ' '"SYMMETRIC".'
+                'padding should be one of "REFLECT", "CONSTANT", or "SYMMETRIC".'
             )
 
         filter_shape = keras_utils.normalize_tuple(filter_shape, 2, "filter_shape")
@@ -161,7 +161,7 @@ def median_filter2d(
 
         if padding not in ["REFLECT", "CONSTANT", "SYMMETRIC"]:
             raise ValueError(
-                'padding should be one of "REFLECT", "CONSTANT", or ' '"SYMMETRIC".'
+                'padding should be one of "REFLECT", "CONSTANT", or "SYMMETRIC".'
             )
 
         filter_shape = keras_utils.normalize_tuple(filter_shape, 2, "filter_shape")
@@ -207,16 +207,18 @@ def median_filter2d(
 
 
 def _get_gaussian_kernel(sigma, filter_shape_1d):
-    "This function creates a kernel of size [filter_shape]"
+    "This function creates a kernel of size [filter_shape]."
+    sigma = tf.convert_to_tensor(sigma)
+    sigma = tf.cast(sigma, tf.float32)
     x = tf.range(-filter_shape_1d // 2 + 1, filter_shape_1d // 2 + 1)
-    x = tf.math.square(x)
-    a = tf.exp(-(x) / (2 * (sigma ** 2)))
-    a = a / tf.math.reduce_sum(a)
-    return a
+    x = tf.cast(x ** 2, sigma.dtype)
+    x = tf.exp(-x / (2.0 * (sigma ** 2)))
+    x = x / tf.math.reduce_sum(x)
+    return x
 
 
 def _get_gaussian_kernel_2d(gaussian_filter_x, gaussian_filter_y):
-    "Compute 2D Gaussian Kernel"
+    "Compute 2D Gaussian kernel."
     gaussian_kernel = tf.matmul(gaussian_filter_x, gaussian_filter_y)
     return gaussian_kernel
 
@@ -225,7 +227,7 @@ def _get_gaussian_kernel_2d(gaussian_filter_x, gaussian_filter_y):
 def gaussian_filter2d(
     image: FloatTensorLike,
     filter_shape: Union[List[int], Tuple[int]] = [3, 3],
-    sigma: FloatTensorLike = 1,
+    sigma: Union[List[float], Tuple[float]] = 1.0,
     padding: str = "REFLECT",
     constant_values: TensorLike = 0,
     name: Optional[str] = None,
@@ -239,7 +241,10 @@ def gaussian_filter2d(
       filter_shape: An `integer` or `tuple`/`list` of 2 integers, specifying
         the height and width of the 2-D gaussian filter. Can be a single
         integer to specify the same value for all spatial dimensions.
-      sigma: Standard deviation of Gaussian.
+      sigma: A `float` or `tuple`/`list` of 2 floats, specifying
+        the standard deviation in x and y direction the 2-D gaussian filter.
+        Can be a single float to specify the same value for all spatial
+        dimensions.
       padding: A `string`, one of "REFLECT", "CONSTANT", or "SYMMETRIC".
         The type of padding algorithm to use, which is compatible with
         `mode` argument in `tf.pad`. For more details, please refer to
@@ -253,34 +258,50 @@ def gaussian_filter2d(
       ValueError: If `image` is not 2, 3 or 4-dimensional,
         if `padding` is other than "REFLECT", "CONSTANT" or "SYMMETRIC",
         if `filter_shape` is invalid,
-        or if `sigma` is less than or equal to 0.
+        or if `sigma` is invalid.
     """
     with tf.name_scope(name or "gaussian_filter2d"):
-        if sigma <= 0:
-            raise ValueError("Sigma should not be zero")
-        if padding not in ["REFLECT", "CONSTANT", "SYMMETRIC"]:
-            raise ValueError("Padding should be REFLECT, CONSTANT, OR SYMMETRIC")
+        if isinstance(sigma, (list, tuple)):
+            if len(sigma) != 2:
+                raise ValueError("sigma should be a float or a tuple/list of 2 floats")
+        else:
+            sigma = (sigma,) * 2
 
-        image = tf.cast(image, tf.float32)
+        if any(s < 0 for s in sigma):
+            raise ValueError("sigma should be greater than or equal to 0.")
+
+        if padding not in ["REFLECT", "CONSTANT", "SYMMETRIC"]:
+            raise ValueError(
+                'padding should be one of "REFLECT", "CONSTANT", or "SYMMETRIC".'
+            )
+
+        image = tf.convert_to_tensor(image, name="image")
         original_ndims = img_utils.get_ndims(image)
         image = img_utils.to_4D_image(image)
+
+        # Keep the precision if it's float;
+        # otherwise, convert to float32 for computing.
+        orig_dtype = image.dtype
+        if not image.dtype.is_floating:
+            image = tf.cast(image, tf.float32)
+
         channels = tf.shape(image)[3]
         filter_shape = keras_utils.normalize_tuple(filter_shape, 2, "filter_shape")
 
-        gaussian_filter_x = _get_gaussian_kernel(sigma, filter_shape[1])
-        gaussian_filter_x = tf.cast(gaussian_filter_x, tf.float32)
-        gaussian_filter_x = tf.reshape(gaussian_filter_x, [1, filter_shape[1]])
+        gaussian_kernel_x = _get_gaussian_kernel(sigma[1], filter_shape[1])
+        gaussian_kernel_x = tf.cast(gaussian_kernel_x, image.dtype)
+        gaussian_kernel_x = tf.reshape(gaussian_kernel_x, [1, filter_shape[1]])
 
-        gaussian_filter_y = _get_gaussian_kernel(sigma, filter_shape[0])
-        gaussian_filter_y = tf.reshape(gaussian_filter_y, [filter_shape[0], 1])
-        gaussian_filter_y = tf.cast(gaussian_filter_y, tf.float32)
+        gaussian_kernel_y = _get_gaussian_kernel(sigma[0], filter_shape[0])
+        gaussian_kernel_y = tf.cast(gaussian_kernel_y, image.dtype)
+        gaussian_kernel_y = tf.reshape(gaussian_kernel_y, [filter_shape[0], 1])
 
-        gaussian_filter_2d = _get_gaussian_kernel_2d(
-            gaussian_filter_y, gaussian_filter_x
+        gaussian_kernel_2d = _get_gaussian_kernel_2d(
+            gaussian_kernel_y, gaussian_kernel_x
         )
-        gaussian_filter_2d = tf.repeat(gaussian_filter_2d, channels)
-        gaussian_filter_2d = tf.reshape(
-            gaussian_filter_2d, [filter_shape[0], filter_shape[1], channels, 1]
+        gaussian_kernel_2d = tf.repeat(gaussian_kernel_2d, channels)
+        gaussian_kernel_2d = tf.reshape(
+            gaussian_kernel_2d, [filter_shape[0], filter_shape[1], channels, 1]
         )
 
         image = _pad(
@@ -289,9 +310,9 @@ def gaussian_filter2d(
 
         output = tf.nn.depthwise_conv2d(
             input=image,
-            filter=gaussian_filter_2d,
+            filter=gaussian_kernel_2d,
             strides=(1, 1, 1, 1),
             padding="VALID",
         )
         output = img_utils.from_4D_image(output, original_ndims)
-        return output
+        return tf.cast(output, orig_dtype)

--- a/tensorflow_addons/image/tests/filters_test.py
+++ b/tensorflow_addons/image/tests/filters_test.py
@@ -19,7 +19,8 @@ import tensorflow as tf
 from tensorflow_addons.image import mean_filter2d
 from tensorflow_addons.image import median_filter2d
 from tensorflow_addons.image import gaussian_filter2d
-from skimage.filters import gaussian
+from tensorflow_addons.utils import test_utils
+from scipy.ndimage.filters import gaussian_filter
 
 _dtypes_to_test = {
     tf.dtypes.uint8,
@@ -364,110 +365,37 @@ def test_symmetric_padding_with_3x3_filter_median(image_shape):
 
 
 @pytest.mark.usefixtures("maybe_run_functions_eagerly")
-def test_gaussian_filter2d_constant():
-    test_image_tf = tf.random.uniform(
-        [1, 40, 40, 1], minval=0, maxval=255, dtype=tf.float64
+@pytest.mark.parametrize("shape", [[10, 10], [10, 10, 3], [2, 10, 10, 3]])
+@pytest.mark.parametrize("padding", ["SYMMETRIC", "CONSTANT", "REFLECT"])
+@pytest.mark.parametrize("dtype", [np.float32, np.float64])
+def test_gaussian_filter2d(shape, padding, dtype):
+    modes = {
+        "SYMMETRIC": "reflect",
+        "CONSTANT": "constant",
+        "REFLECT": "mirror",
+    }
+
+    image = np.arange(np.prod(shape)).reshape(*shape).astype(dtype)
+
+    ndims = len(shape)
+    sigma = [1.0, 1.0]
+    if ndims == 3:
+        sigma = [1.0, 1.0, 0.0]
+    elif ndims == 4:
+        sigma = [0.0, 1.0, 1.0, 0.0]
+
+    test_utils.assert_allclose_according_to_type(
+        gaussian_filter2d(image, 9, 1, padding=padding).numpy(),
+        gaussian_filter(image, sigma, mode=modes[padding]),
     )
-    gb = gaussian_filter2d(test_image_tf, 5, 1, padding="CONSTANT")
-    gb = gb.numpy()
-    gb1 = np.resize(gb, (40, 40))
-    test_image_np = test_image_tf.numpy()
-    test_image_np = np.resize(test_image_np, [40, 40])
-    gb2 = gaussian(test_image_np, 1, mode="constant")
-    np.testing.assert_allclose(gb2, gb1, 0.06)
 
 
 @pytest.mark.usefixtures("maybe_run_functions_eagerly")
-def test_gaussian_filter2d_reflect():
-    test_image_tf = tf.random.uniform(
-        [1, 40, 40, 1], minval=0, maxval=255, dtype=tf.float32
+def test_gaussian_filter2d_different_sigma():
+    image = np.arange(40 * 40).reshape(40, 40).astype(np.float32)
+    sigma = [1.0, 2.0]
+
+    test_utils.assert_allclose_according_to_type(
+        gaussian_filter2d(image, [9, 17], sigma).numpy(),
+        gaussian_filter(image, sigma, mode="mirror"),
     )
-    gb = gaussian_filter2d(test_image_tf, 5, 1, padding="REFLECT")
-    gb = gb.numpy()
-    gb1 = np.resize(gb, (40, 40))
-    test_image_np = test_image_tf.numpy()
-    test_image_np = np.resize(test_image_np, [40, 40])
-    gb2 = gaussian(test_image_np, 1, mode="mirror")
-    np.testing.assert_allclose(gb2, gb1, 0.06)
-
-
-@pytest.mark.usefixtures("maybe_run_functions_eagerly")
-def test_gaussian_filter2d_symmetric():
-    test_image_tf = tf.random.uniform(
-        [1, 40, 40, 1], minval=0, maxval=255, dtype=tf.float64
-    )
-    gb = gaussian_filter2d(test_image_tf, (5, 5), 1, padding="SYMMETRIC")
-    gb = gb.numpy()
-    gb1 = np.resize(gb, (40, 40))
-    test_image_np = test_image_tf.numpy()
-    test_image_np = np.resize(test_image_np, [40, 40])
-    gb2 = gaussian(test_image_np, 1, mode="reflect")
-    np.testing.assert_allclose(gb2, gb1, 0.06)
-
-
-@pytest.mark.usefixtures("maybe_run_functions_eagerly")
-@pytest.mark.parametrize("image_shape", [[2, 5, 5, 3]])
-def test_gaussian_filter2d_batch(image_shape):
-    test_image_tf = tf.random.uniform(
-        [1, 40, 40, 1], minval=0, maxval=255, dtype=tf.float32
-    )
-    gb = gaussian_filter2d(test_image_tf, 5, 1, padding="SYMMETRIC")
-    gb = gb.numpy()
-    gb1 = np.resize(gb, (40, 40))
-    test_image_np = test_image_tf.numpy()
-    test_image_np = np.resize(test_image_np, [40, 40])
-    gb2 = gaussian(test_image_np, 1, mode="reflect")
-    np.testing.assert_allclose(gb2, gb1, 0.06)
-
-
-@pytest.mark.usefixtures("maybe_run_functions_eagerly")
-def test_gaussian_filter2d_channels():
-    test_image_tf = tf.constant(
-        [
-            [
-                [
-                    [0.0, 0.0, 0.0],
-                    [2.0, 2.0, 0.0],
-                    [4.0, 4.0, 0.0],
-                    [6.0, 6.0, 0.0],
-                    [8.0, 8.0, 0.0],
-                ],
-                [
-                    [10.0, 10.0, 0.0],
-                    [12.0, 12.0, 0.0],
-                    [14.0, 14.0, 0.0],
-                    [16.0, 16.0, 0.0],
-                    [18.0, 18.0, 0.0],
-                ],
-                [
-                    [20.0, 20.0, 0.0],
-                    [22.0, 22.0, 0.0],
-                    [24.0, 24.0, 0.0],
-                    [26.0, 26.0, 0.0],
-                    [28.0, 28.0, 0.0],
-                ],
-                [
-                    [30.0, 30.0, 0.0],
-                    [32.0, 32.0, 0.0],
-                    [34.0, 34.0, 0.0],
-                    [36.0, 36.0, 0.0],
-                    [38.0, 38.0, 0.0],
-                ],
-                [
-                    [40.0, 40.0, 0.0],
-                    [42.0, 42.0, 0.0],
-                    [44.0, 44.0, 0.0],
-                    [46.0, 46.0, 0.0],
-                    [48.0, 48.0, 0.0],
-                ],
-            ]
-        ],
-        dtype=tf.float32,
-    )
-    gb = gaussian_filter2d(test_image_tf, 5, 1, padding="SYMMETRIC", name="gaussian")
-    gb = gb.numpy()
-    gb1 = np.resize(gb, (5, 5, 3))
-    test_image_np = test_image_tf.numpy()
-    test_image_np = np.resize(test_image_np, [5, 5, 3])
-    gb2 = gaussian(test_image_np, sigma=1, mode="reflect", multichannel=True)
-    np.testing.assert_allclose(gb2, gb1, 0.06)


### PR DESCRIPTION
- Support different sigma for x and y direction.
- Minor docs.
- Depthwise conv2d on floating type and retain the original dtype if it is not floating type.
- Simplify tests, including 2d, 3d and 4d image, three different padding modes and different dtype.
- The radius of gaussian kernel is computed as `ceil(sigma * truncate) * 2 + 1`. So for sigma=1.0, truncate=4.0, the kernel size should be 9 instead 3, which is the value we used before.
https://github.com/scipy/scipy/blob/v1.4.1/scipy/ndimage/filters.py#L216
- Use `scipy.ndimage.filters.gaussian_filter` instead of the one in `skimage` to test 4D image directly.