### PR TITLE
Better names for parametrize.

### DIFF
--- a/tensorflow_addons/conftest.py
+++ b/tensorflow_addons/conftest.py
@@ -1,5 +1,6 @@
 from tensorflow_addons.utils.test_utils import (  # noqa: F401
     maybe_run_functions_eagerly,
+    pytest_make_parametrize_id,
     data_format,
     set_seeds,
     pytest_addoption,

--- a/tensorflow_addons/utils/test_utils.py
+++ b/tensorflow_addons/utils/test_utils.py
@@ -57,6 +57,31 @@ def finalizer():
     tf.config.experimental_run_functions_eagerly(False)
 
 
+def pytest_make_parametrize_id(config, val, argname):
+    numpy_dtypes = [
+        np.float16,
+        np.float32,
+        np.float64,
+        np.int8,
+        np.int16,
+        np.int32,
+        np.int64,
+        np.uint8,
+        np.uint16,
+        np.uint32,
+        np.uint64,
+    ]
+
+    if isinstance(val, tf.DType):
+        return val.name
+    if val in numpy_dtypes:
+        return val.__name__
+    if val is False:
+        return "no_" + argname
+    if val is True:
+        return argname
+
+
 @pytest.fixture(scope="function", params=["eager_mode", "tf_function"])
 def maybe_run_functions_eagerly(request):
     if request.param == "eager_mode":

--- a/tensorflow_addons/utils/test_utils.py
+++ b/tensorflow_addons/utils/test_utils.py
@@ -74,7 +74,8 @@ def pytest_make_parametrize_id(config, val, argname):
 
     if isinstance(val, tf.DType):
         return val.name
-    if val in numpy_dtypes:
+    # need isinstance here because tf tensors don't like to be compared to np dtypes.
+    if isinstance(val, type) and val in numpy_dtypes:
         return val.__name__
     if val is False:
         return "no_" + argname

--- a/tensorflow_addons/utils/test_utils.py
+++ b/tensorflow_addons/utils/test_utils.py
@@ -58,25 +58,8 @@ def finalizer():
 
 
 def pytest_make_parametrize_id(config, val, argname):
-    numpy_dtypes = [
-        np.float16,
-        np.float32,
-        np.float64,
-        np.int8,
-        np.int16,
-        np.int32,
-        np.int64,
-        np.uint8,
-        np.uint16,
-        np.uint32,
-        np.uint64,
-    ]
-
     if isinstance(val, tf.DType):
         return val.name
-    # need isinstance here because tf tensors don't like to be compared to np dtypes.
-    if isinstance(val, type) and val in numpy_dtypes:
-        return val.__name__
     if val is False:
         return "no_" + argname
     if val is True:


### PR DESCRIPTION
In the pytest reports, having `dtype0`, `True`, `False` as test parameters isn't helpful for debugging. There is a pytest hook to make custom names.

### Before:

```
tensorflow_addons/activations/tests/gelu_test.py::test_same_as_py_func[cpu-True-float32] PASSED                                                                                                                                        [ 19%]
tensorflow_addons/activations/tests/gelu_test.py::test_same_as_py_func[cpu-True-float64] PASSED                                                                                                                                        [ 20%]
tensorflow_addons/activations/tests/gelu_test.py::test_same_as_py_func[cpu-False-float32] PASSED                                                                                                                                       [ 21%]
tensorflow_addons/activations/tests/gelu_test.py::test_same_as_py_func[cpu-False-float64] PASSED
#24 464.5 tensorflow_addons/image/tests/transform_ops_test.py::test_compose[eager_mode-gpu-dtype1] 
--------
tensorflow_addons/image/tests/transform_ops_test.py::test_compose[eager_mode-gpu-dtype1] 
tensorflow_addons/image/tests/transform_ops_test.py::test_compose[eager_mode-gpu-dtype2] 
tensorflow_addons/image/tests/transform_ops_test.py::test_compose[eager_mode-gpu-dtype3] 
tensorflow_addons/image/tests/transform_ops_test.py::test_compose[eager_mode-gpu-dtype4] 
tensorflow_addons/image/tests/transform_ops_test.py::test_compose[eager_mode-gpu-dtype5] 
```

### After:
```
tensorflow_addons/activations/tests/gelu_test.py::test_same_as_py_func[cpu-approximate-float32] PASSED                                                                                                                                 [ 19%]
tensorflow_addons/activations/tests/gelu_test.py::test_same_as_py_func[cpu-approximate-float64] PASSED                                                                                                                                 [ 20%]
tensorflow_addons/activations/tests/gelu_test.py::test_same_as_py_func[cpu-no_approximate-float32] PASSED                                                                                                                              [ 21%]
tensorflow_addons/activations/tests/gelu_test.py::test_same_as_py_func[cpu-no_approximate-float64] PASSED
-----------
tensorflow_addons/image/tests/transform_ops_test.py::test_compose[eager_mode-cpu-float32] 
tensorflow_addons/image/tests/transform_ops_test.py::test_compose[eager_mode-cpu-float64] 
tensorflow_addons/image/tests/transform_ops_test.py::test_compose[eager_mode-cpu-int32] 
tensorflow_addons/image/tests/transform_ops_test.py::test_compose[eager_mode-cpu-uint8] 
tensorflow_addons/image/tests/transform_ops_test.py::test_compose[eager_mode-cpu-int64] 
tensorflow_addons/image/tests/transform_ops_test.py::test_compose[eager_mode-cpu-float16] 
```



For tensorflow dtypes, I think pytest didn't detect the right name because dtypes don't have a `__name__` attribute (though maybe they should?). Anyway, the name is correctly displayed in the report now.

Documentation of the hook: https://docs.pytest.org/en/latest/reference.html#_pytest.hookspec.pytest_make_parametrize_id