### PR TITLE
Don't hide utils from the API docs generator

### DIFF
--- a/docs/build_docs.py
+++ b/docs/build_docs.py
@@ -73,7 +73,7 @@ def main(argv):
         root_title=PROJECT_FULL_NAME,
         py_modules=[(PROJECT_SHORT_NAME, tfa)],
         code_url_prefix=code_url_prefix,
-        private_map={"tfa": ["__version__", "utils", "version"]},
+        private_map={"tfa": ["__version__", "version"]},
         # This callback usually cleans up a lot of aliases caused by internal imports.
         callbacks=[public_api.local_definitions_filter],
         search_hints=FLAGS.search_hints,

--- a/docs/build_docs.py
+++ b/docs/build_docs.py
@@ -77,8 +77,8 @@ def main(argv):
         # This callback usually cleans up a lot of aliases caused by internal imports.
         callbacks=[
             public_api.local_definitions_filter,
-            public_api.explicit_package_contents_filter
-	],
+            public_api.explicit_package_contents_filter,
+        ],
         search_hints=FLAGS.search_hints,
         site_path=FLAGS.site_path,
     )

--- a/docs/build_docs.py
+++ b/docs/build_docs.py
@@ -75,7 +75,10 @@ def main(argv):
         code_url_prefix=code_url_prefix,
         private_map={"tfa": ["__version__", "version"]},
         # This callback usually cleans up a lot of aliases caused by internal imports.
-        callbacks=[public_api.local_definitions_filter],
+        callbacks=[
+            public_api.local_definitions_filter,
+            public_api.explicit_package_contents_filter
+	],
         search_hints=FLAGS.search_hints,
         site_path=FLAGS.site_path,
     )

--- a/tensorflow_addons/utils/__init__.py
+++ b/tensorflow_addons/utils/__init__.py
@@ -1,0 +1,1 @@
+from tensorflow_addons.utils import types


### PR DESCRIPTION
Utils contains types/ and since the API generator now supports type annotation with links, it will be good to link off to the type pages.