### PR TITLE
Apply Multi-GPU/TPU Normalization

### DIFF
--- a/tensorflow_addons/layers/wrappers.py
+++ b/tensorflow_addons/layers/wrappers.py
@@ -55,7 +55,7 @@ class WeightNormalization(tf.keras.layers.Wrapper):
     """
 
     @typechecked
-    def __init__(self, layer: tf.keras.layers.Layer, data_init: bool=True, **kwargs):
+    def __init__(self, layer: tf.keras.layers.Layer, data_init: bool　=　True, **kwargs):
         super().__init__(layer, **kwargs)
         self.data_init = data_init
         self._track_trackable(layer, name="layer")

--- a/tensorflow_addons/layers/wrappers.py
+++ b/tensorflow_addons/layers/wrappers.py
@@ -108,7 +108,7 @@ class WeightNormalization(tf.keras.layers.Wrapper):
             # Used for data initialization in self._data_dep_init.
             with tf.name_scope("data_dep_init"):
                 layer_config = tf.keras.layers.serialize(self.layer)
-                layer_config['config']['trainable'] = False
+                layer_config["config"]["trainable"] = False
                 self._naked_clone_layer = tf.keras.layers.deserialize(layer_config)
                 self._naked_clone_layer.build(input_shape)
                 self._naked_clone_layer.set_weights(self.layer.get_weights())

--- a/tensorflow_addons/layers/wrappers.py
+++ b/tensorflow_addons/layers/wrappers.py
@@ -23,7 +23,6 @@ from typeguard import typechecked
 class WeightNormalization(tf.keras.layers.Wrapper):
     """This wrapper reparameterizes a layer by decoupling the weight's
     magnitude and direction.
-
     This speeds up convergence by improving the
     conditioning of the optimization problem.
     Weight Normalization: A Simple Reparameterization to Accelerate
@@ -64,7 +63,8 @@ class WeightNormalization(tf.keras.layers.Wrapper):
         if self.data_init and self.is_rnn:
             logging.warning(
                 "WeightNormalization: Using `data_init=True` with RNNs "
-                "is advised against by the paper. Use `data_init=False`.")
+                "is advised against by the paper. Use `data_init=False`."
+            )
 
     def build(self, input_shape):
         """Build `Layer`"""
@@ -77,8 +77,10 @@ class WeightNormalization(tf.keras.layers.Wrapper):
         kernel_layer = self.layer.cell if self.is_rnn else self.layer
 
         if not hasattr(kernel_layer, "kernel"):
-            raise ValueError("`WeightNormalization` must wrap a layer that"
-                             " contains a `kernel` for weights")
+            raise ValueError(
+                "`WeightNormalization` must wrap a layer that"
+                " contains a `kernel` for weights"
+            )
 
         if self.is_rnn:
             kernel = kernel_layer.recurrent_kernel
@@ -94,7 +96,8 @@ class WeightNormalization(tf.keras.layers.Wrapper):
             shape=(self.layer_depth,),
             initializer="ones",
             dtype=kernel.dtype,
-            trainable=True)
+            trainable=True,
+        )
         self.v = kernel
 
         self._initialized = self.add_weight(
@@ -102,7 +105,8 @@ class WeightNormalization(tf.keras.layers.Wrapper):
             shape=None,
             initializer="zeros",
             dtype=tf.dtypes.bool,
-            trainable=False)
+            trainable=False,
+        )
 
         if self.data_init:
             # Used for data initialization in self._data_dep_init.
@@ -154,9 +158,13 @@ class WeightNormalization(tf.keras.layers.Wrapper):
         The initial value of g could either from the initial value in v,
         or by the input value if self.data_init is True.
         """
-        with tf.control_dependencies([
+        with tf.control_dependencies(
+            [
                 tf.debugging.assert_equal(  # pylint: disable=bad-continuation
-                    self._initialized, False, message='The layer has been initialized.')]):
+                    self._initialized, False, message="The layer has been initialized."
+                )
+            ]
+        ):
             if self.data_init:
                 assign_tensors = self._data_dep_init(inputs)
             else:
@@ -184,19 +192,16 @@ class WeightNormalization(tf.keras.layers.Wrapper):
         if replica_ctx:
             # define each GPU's variables
             local_sum = tf.reduce_sum(y, axis=axes, keepdims=True)
-            local_squared_sum = tf.reduce_sum(tf.math.square(y), axes,
-                                              keepdims=True)
+            local_squared_sum = tf.reduce_sum(tf.math.square(y), axes, keepdims=True)
             batch_size = tf.cast(tf.shape(y)[0], tf.float32)
 
             # reduce all GPUs' variables
-            y_sum, y_squared_sum, global_batch_size = (
-                replica_ctx.all_reduce(
-                    tf.distribute.ReduceOp.SUM,
-                    [local_sum, local_squared_sum, batch_size]))
+            y_sum, y_squared_sum, global_batch_size = replica_ctx.all_reduce(
+                tf.distribute.ReduceOp.SUM, [local_sum, local_squared_sum, batch_size]
+            )
 
             axes_vals = [(tf.shape(y))[i] for i in range(1, len(axes))]
-            multiplier = tf.cast(tf.reduce_prod(axes_vals),
-                                 tf.float32)
+            multiplier = tf.cast(tf.reduce_prod(axes_vals), tf.float32)
             multiplier = multiplier * global_batch_size
             mean = y_sum / multiplier
             y_squared_mean = y_squared_sum / multiplier
@@ -205,10 +210,8 @@ class WeightNormalization(tf.keras.layers.Wrapper):
         else:
             mean = tf.reduce_meam(y, axes, keepdims=True)
             variance = tf.reduce_mean(
-                tf.squared_difference(
-                    y, tf.stop_gradient(mean)),
-                axes,
-                keepdims=True)
+                tf.squared_difference(y, tf.stop_gradient(mean)), axes, keepdims=True
+            )
         if x.dtype == tf.float16:
             return (tf.cast(mean, tf.float16), tf.cast(variance, tf.float16))
         else:
@@ -222,7 +225,7 @@ class WeightNormalization(tf.keras.layers.Wrapper):
             data_norm_axes = list(range(x_init.shape.rank - 1))
 
             m_init, v_init = self._calculate_moments(x_init, data_norm_axes)
-            scale_init = 1. / tf.math.sqrt(v_init + 1e-10)
+            scale_init = 1.0 / tf.math.sqrt(v_init + 1e-10)
 
             # RNNs have fused kernels that are tiled
             # Repeat scale_init to match the shape of fused kernel
@@ -248,11 +251,12 @@ class WeightNormalization(tf.keras.layers.Wrapper):
     def remove(self):
         kernel = tf.Variable(
             tf.nn.l2_normalize(self.v, axis=self.kernel_norm_axes) * self.g,
-            name="recurrent_kernel" if self.is_rnn else "kernel")
+            name="recurrent_kernel" if self.is_rnn else "kernel",
+        )
 
         if self.is_rnn:
             self.layer.cell.recurrent_kernel = kernel
         else:
             self.layer.kernel = kernel
 
-        return self.layer
+        return self.layer  # Copyright 2019 The TensorFlow Authors. All Rights Reserved.

--- a/tensorflow_addons/layers/wrappers.py
+++ b/tensorflow_addons/layers/wrappers.py
@@ -227,7 +227,9 @@ class WeightNormalization(tf.keras.layers.Wrapper):
             x_init = self._naked_clone_layer(inputs)
             data_norm_axes = list(range(x_init.shape.rank - 1))
 
-            m_init, v_init = self._calculate_moments(x_init, data_norm_axes, keep_dims=False)
+            m_init, v_init = self._calculate_moments(
+                x_init, data_norm_axes, keep_dims=False
+            )
             scale_init = 1.0 / tf.math.sqrt(v_init + 1e-10)
 
             # RNNs have fused kernels that are tiled

--- a/tensorflow_addons/layers/wrappers.py
+++ b/tensorflow_addons/layers/wrappers.py
@@ -23,7 +23,6 @@ from typeguard import typechecked
 class WeightNormalization(tf.keras.layers.Wrapper):
     """This wrapper reparameterizes a layer by decoupling the weight's
     magnitude and direction.
-
     This speeds up convergence by improving the
     conditioning of the optimization problem.
     Weight Normalization: A Simple Reparameterization to Accelerate
@@ -54,34 +53,32 @@ class WeightNormalization(tf.keras.layers.Wrapper):
       NotImplementedError: If `data_init` is True and running graph execution
     """
 
-    @typechecked
-    def __init__(self, layer: tf.keras.layers, data_init: bool = True, **kwargs):
-        super().__init__(layer, **kwargs)
+    def __init__(self, layer, data_init=True, **kwargs):
+        super(WeightNormalization, self).__init__(layer, **kwargs)
         self.data_init = data_init
-        self._track_trackable(layer, name="layer")
+        self._track_trackable(layer, name='layer')
+        self._init_critical_section = tf.CriticalSection(name='init_mutex')
         self.is_rnn = isinstance(self.layer, tf.keras.layers.RNN)
 
         if self.data_init and self.is_rnn:
             logging.warning(
                 "WeightNormalization: Using `data_init=True` with RNNs "
-                "is advised against by the paper. Use `data_init=False`."
-            )
+                "is advised against by the paper. Use `data_init=False`.")
 
     def build(self, input_shape):
         """Build `Layer`"""
         input_shape = tf.TensorShape(input_shape)
-        self.input_spec = tf.keras.layers.InputSpec(shape=[None] + input_shape[1:])
+        self.input_spec = tf.keras.layers.InputSpec(
+            shape=[None] + input_shape[1:])
 
         if not self.layer.built:
             self.layer.build(input_shape)
 
         kernel_layer = self.layer.cell if self.is_rnn else self.layer
 
-        if not hasattr(kernel_layer, "kernel"):
-            raise ValueError(
-                "`WeightNormalization` must wrap a layer that"
-                " contains a `kernel` for weights"
-            )
+        if not hasattr(kernel_layer, 'kernel'):
+            raise ValueError('`WeightNormalization` must wrap a layer that'
+                             ' contains a `kernel` for weights')
 
         if self.is_rnn:
             kernel = kernel_layer.recurrent_kernel
@@ -93,28 +90,27 @@ class WeightNormalization(tf.keras.layers.Wrapper):
         self.kernel_norm_axes = list(range(kernel.shape.rank - 1))
 
         self.g = self.add_weight(
-            name="g",
+            name='g',
             shape=(self.layer_depth,),
-            initializer="ones",
+            initializer='ones',
             dtype=kernel.dtype,
-            trainable=True,
-        )
+            trainable=True)
         self.v = kernel
 
         self._initialized = self.add_weight(
-            name="initialized",
+            name='initialized',
             shape=None,
-            initializer="zeros",
+            initializer='zeros',
             dtype=tf.dtypes.bool,
-            trainable=False,
-        )
+            trainable=False)
 
         if self.data_init:
             # Used for data initialization in self._data_dep_init.
-            with tf.name_scope("data_dep_init"):
+            with tf.name_scope('data_dep_init'):
                 layer_config = tf.keras.layers.serialize(self.layer)
-                layer_config["config"]["trainable"] = False
-                self._naked_clone_layer = tf.keras.layers.deserialize(layer_config)
+                layer_config['config']['trainable'] = False
+                self._naked_clone_layer = tf.keras.layers.deserialize(
+                    layer_config)
                 self._naked_clone_layer.build(input_shape)
                 self._naked_clone_layer.set_weights(self.layer.get_weights())
                 if not self.is_rnn:
@@ -133,9 +129,10 @@ class WeightNormalization(tf.keras.layers.Wrapper):
             with tf.control_dependencies(self._initialize_weights(inputs)):
                 return tf.identity(self.g)
 
-        g = tf.cond(self._initialized, _do_nothing, _update_weights)
+        g = self._init_critical_section.execute(lambda: tf.cond(
+            self._initialized, _do_nothing, _update_weights))
 
-        with tf.name_scope("compute_weights"):
+        with tf.name_scope('compute_weights'):
             # Replace kernel by normalized weight variable.
             kernel = tf.nn.l2_normalize(self.v, axis=self.kernel_norm_axes) * g
 
@@ -152,21 +149,20 @@ class WeightNormalization(tf.keras.layers.Wrapper):
                 return outputs
 
     def compute_output_shape(self, input_shape):
-        return tf.TensorShape(self.layer.compute_output_shape(input_shape).as_list())
+        return tf.TensorShape(
+            self.layer.compute_output_shape(input_shape).as_list())
 
     def _initialize_weights(self, inputs):
         """Initialize weight g.
-
         The initial value of g could either from the initial value in v,
         or by the input value if self.data_init is True.
         """
-        with tf.control_dependencies(
-            [
+        with tf.control_dependencies([
                 tf.debugging.assert_equal(  # pylint: disable=bad-continuation
-                    self._initialized, False, message="The layer has been initialized."
-                )
-            ]
-        ):
+                    self._initialized,
+                    False,
+                    message='The layer has been initialized.')
+        ]):
             if self.data_init:
                 assign_tensors = self._data_dep_init(inputs)
             else:
@@ -176,20 +172,64 @@ class WeightNormalization(tf.keras.layers.Wrapper):
 
     def _init_norm(self):
         """Set the weight g with the norm of the weight vector."""
-        with tf.name_scope("init_norm"):
+        with tf.name_scope('init_norm'):
             v_flat = tf.reshape(self.v, [-1, self.layer_depth])
             v_norm = tf.linalg.norm(v_flat, axis=0)
             g_tensor = self.g.assign(tf.reshape(v_norm, (self.layer_depth,)))
             return [g_tensor]
 
+    def _calculate_moments(self, x, axes, keep_dims=True):
+        """calculate moments between multi GPU
+        this function is as same as tf.nn.moments(x, axes)
+        if the code is running in Single-GPU environment.
+        Sources:
+            https://github.com/tensorflow/tensorflow/blob/v2.2.0/tensorflow/python/keras/layers/normalization_v2.py#L165-L204
+        """
+        y = tf.cast(x, tf.float32) if x.dtype == tf.float16 else x
+        replica_ctx = tf.distribute.get_replica_context()
+        if replica_ctx:
+            # define each GPU's variables
+            local_sum = tf.reduce_sum(y, axis=axes, keepdims=True)
+            local_squared_sum = tf.reduce_sum(tf.math.square(y), axes,
+                                              keepdims=True)
+            batch_size = tf.cast(tf.shape(y)[0], tf.float32)
+
+            # reduce all GPUs' variables
+            y_sum, y_squared_sum, global_batch_size = (
+                replica_ctx.all_reduce(
+                    tf.distribute.ReduceOp.SUM,
+                    [local_sum, local_squared_sum, batch_size]))
+
+            axes_vals = [(tf.shape(y))[i] for i in range(1, len(axes))]
+            multiplier = tf.cast(tf.reduce_prod(axes_vals),
+                                 tf.float32)
+            multiplier = multiplier * global_batch_size
+            mean = y_sum / multiplier
+            y_squared_mean = y_squared_sum / multiplier
+            # var = E(x^2) - E(x)^2
+            variance = y_squared_mean - tf.square(mean)
+        else:
+            mean = tf.reduce_meam(y, axes, keepdims=True)
+            variance = tf.reduce_mean(
+                tf.squared_difference(
+                    y, tf.stop_gradient(mean)),
+                axes,
+                keepdims=True)
+        if x.dtype == tf.float16:
+            return (tf.cast(mean, tf.float16), tf.cast(variance, tf.float16))
+        else:
+            return (mean, variance)
+
     def _data_dep_init(self, inputs):
         """Data dependent initialization."""
-        with tf.name_scope("data_dep_init"):
+        with tf.name_scope('data_dep_init'):
             # Generate data dependent init values
             x_init = self._naked_clone_layer(inputs)
             data_norm_axes = list(range(x_init.shape.rank - 1))
-            m_init, v_init = tf.nn.moments(x_init, data_norm_axes)
-            scale_init = 1.0 / tf.math.sqrt(v_init + 1e-10)
+
+            m_init, v_init = self._calculate_moments(x_init, data_norm_axes)
+
+            scale_init = 1. / tf.math.sqrt(v_init + 1e-10)
 
             # RNNs have fused kernels that are tiled
             # Repeat scale_init to match the shape of fused kernel
@@ -201,22 +241,21 @@ class WeightNormalization(tf.keras.layers.Wrapper):
 
             # Assign data dependent init values
             g_tensor = self.g.assign(self.g * scale_init)
-            if hasattr(self.layer, "bias") and self.layer.bias is not None:
+            if hasattr(self.layer, 'bias') and self.layer.bias is not None:
                 bias_tensor = self.layer.bias.assign(-m_init * scale_init)
                 return [g_tensor, bias_tensor]
             else:
                 return [g_tensor]
 
     def get_config(self):
-        config = {"data_init": self.data_init}
-        base_config = super().get_config()
-        return {**base_config, **config}
+        config = {'data_init': self.data_init}
+        base_config = super(WeightNormalization, self).get_config()
+        return dict(list(base_config.items()) + list(config.items()))
 
     def remove(self):
         kernel = tf.Variable(
             tf.nn.l2_normalize(self.v, axis=self.kernel_norm_axes) * self.g,
-            name="recurrent_kernel" if self.is_rnn else "kernel",
-        )
+            name='recurrent_kernel' if self.is_rnn else 'kernel')
 
         if self.is_rnn:
             self.layer.cell.recurrent_kernel = kernel

--- a/tensorflow_addons/layers/wrappers.py
+++ b/tensorflow_addons/layers/wrappers.py
@@ -55,7 +55,7 @@ class WeightNormalization(tf.keras.layers.Wrapper):
     """
 
     @typechecked
-    def __init__(self, layer: tf.keras.layers.Layer, data_init: bool　=　True, **kwargs):
+    def __init__(self, layer: tf.keras.layers.Layer, data_init: bool = True, **kwargs):
         super().__init__(layer, **kwargs)
         self.data_init = data_init
         self._track_trackable(layer, name="layer")

--- a/tensorflow_addons/layers/wrappers.py
+++ b/tensorflow_addons/layers/wrappers.py
@@ -23,7 +23,7 @@ from typeguard import typechecked
 class WeightNormalization(tf.keras.layers.Wrapper):
     """This wrapper reparameterizes a layer by decoupling the weight's
     magnitude and direction.
-    
+
     This speeds up convergence by improving the
     conditioning of the optimization problem.
     Weight Normalization: A Simple Reparameterization to Accelerate
@@ -53,9 +53,9 @@ class WeightNormalization(tf.keras.layers.Wrapper):
       ValueError: If `Layer` does not contain a `kernel` of weights
       NotImplementedError: If `data_init` is True and running graph execution
     """
-    
+
     @typechecked
-    def __init__(self, layer, data_init=True, **kwargs):
+    def __init__(self, layer: tf.keras.layers.Layer, data_init: bool=True, **kwargs):
         super().__init__(layer, **kwargs)
         self.data_init = data_init
         self._track_trackable(layer, name="layer")
@@ -77,8 +77,8 @@ class WeightNormalization(tf.keras.layers.Wrapper):
         kernel_layer = self.layer.cell if self.is_rnn else self.layer
 
         if not hasattr(kernel_layer, "kernel"):
-            raise ValueError('`WeightNormalization` must wrap a layer that'
-                             ' contains a `kernel` for weights')
+            raise ValueError("`WeightNormalization` must wrap a layer that"
+                             " contains a `kernel` for weights")
 
         if self.is_rnn:
             kernel = kernel_layer.recurrent_kernel
@@ -222,7 +222,6 @@ class WeightNormalization(tf.keras.layers.Wrapper):
             data_norm_axes = list(range(x_init.shape.rank - 1))
 
             m_init, v_init = self._calculate_moments(x_init, data_norm_axes)
-
             scale_init = 1. / tf.math.sqrt(v_init + 1e-10)
 
             # RNNs have fused kernels that are tiled
@@ -245,7 +244,7 @@ class WeightNormalization(tf.keras.layers.Wrapper):
         config = {"data_init": self.data_init}
         base_config = super().get_config()
         return {**base_config, **config}
-    
+
     def remove(self):
         kernel = tf.Variable(
             tf.nn.l2_normalize(self.v, axis=self.kernel_norm_axes) * self.g,


### PR DESCRIPTION
In Tensorflow 2.2.0, they implement multi-gpu/tpu's batch normalization layer, So I implement Weight Normalization Layer by reference to it.
Sources:
https://github.com/tensorflow/tensorflow/blob/v2.2.0/tensorflow/python/keras/layers/normalization_v2.py#L165-L204