### PR TITLE
Replace private TF API in MovingAverage

### DIFF
--- a/tensorflow_addons/optimizers/moving_average.py
+++ b/tensorflow_addons/optimizers/moving_average.py
@@ -50,10 +50,8 @@ def assign_moving_average(
         decay = tf.cast(decay, variable.dtype)
 
         def update_fn(v, value):
-            # TODO(squadrick): Replace with `v.assign_sub(...)`.
-            # This requires a change in `average_wrapper.py`,
-            # since it expects a TensorFlow op, not NoneType
-            return tf.compat.v1.assign_sub(v, (v - value) * decay, name=scope)
+            v.assign_sub((v - value) * decay, name=scope)
+            return tf.convert_to_tensor(v)
 
         def update(strategy, v, value):
             return strategy.extended.update(v, update_fn, args=(value,))

--- a/tensorflow_addons/optimizers/moving_average.py
+++ b/tensorflow_addons/optimizers/moving_average.py
@@ -46,12 +46,12 @@ def assign_moving_average(
         A tensor which if evaluated will compute and return the new moving average.
     """
 
-    with tf.name_scope(name) as scope:
+    with tf.name_scope(name):
         decay = tf.convert_to_tensor(1.0 - decay, name="decay")
         decay = tf.cast(decay, variable.dtype)
 
         def update_fn(v, value):
-            return v.assign_sub((v - value) * decay, name=scope)
+            return v.assign_sub((v - value) * decay)
 
         def update(strategy, v, value):
             return strategy.extended.update(v, update_fn, args=(value,))

--- a/tensorflow_addons/optimizers/moving_average.py
+++ b/tensorflow_addons/optimizers/moving_average.py
@@ -50,8 +50,7 @@ def assign_moving_average(
         decay = tf.cast(decay, variable.dtype)
 
         def update_fn(v, value):
-            v.assign_sub((v - value) * decay, name=scope)
-            return tf.convert_to_tensor(v)
+            return v.assign_sub((v - value) * decay, name=scope)
 
         def update(strategy, v, value):
             return strategy.extended.update(v, update_fn, args=(value,))

--- a/tensorflow_addons/optimizers/moving_average.py
+++ b/tensorflow_addons/optimizers/moving_average.py
@@ -15,6 +15,7 @@
 
 import tensorflow as tf
 from tensorflow_addons.optimizers import AveragedOptimizerWrapper
+from tensorflow_addons.utils import types
 from tensorflow_addons.utils.types import FloatTensorLike, TensorLike
 
 from typing import Optional
@@ -95,7 +96,7 @@ class MovingAverage(AveragedOptimizerWrapper):
         self,
         optimizer: types.Optimizer,
         sequential_update: bool = True,
-        average_decay: types.FloatTensorLike = 0.99,
+        average_decay: FloatTensorLike = 0.99,
         num_updates: Optional[str] = None,
         name: str = "MovingAverage",
         **kwargs

--- a/tensorflow_addons/optimizers/tests/moving_average_test.py
+++ b/tensorflow_addons/optimizers/tests/moving_average_test.py
@@ -131,8 +131,7 @@ def test_config():
         assert old_sgd_config[k1] == new_sgd_config[k2]
 
 
-@pytest.mark.usefixtures("maybe_run_functions_eagerly")
-def test_fit_simple_linear_model():
+def fit_model(name):
     seed = 0x2019
     np.random.seed(seed)
     tf.random.set_seed(seed)
@@ -141,10 +140,10 @@ def test_fit_simple_linear_model():
     w = np.random.standard_normal((3, 1))
     y = np.dot(x, w) + np.random.standard_normal((num_examples, 1)) * 1e-4
 
-    model = tf.keras.models.Sequential()
+    model = tf.keras.models.Sequential(name=name)
     model.add(tf.keras.layers.Dense(input_shape=(3,), units=1))
 
-    opt = MovingAverage("sgd")
+    opt = MovingAverage("sgd", name=name)
     model.compile(opt, loss="mse")
 
     model.fit(x, y, epochs=5)
@@ -159,10 +158,15 @@ def test_fit_simple_linear_model():
     assert max_abs_diff < 5e-3
 
 
+@pytest.mark.usefixtures("maybe_run_functions_eagerly")
+def test_fit_simple_linear_model():
+    fit_model("simple_model")
+
+
 @pytest.mark.with_device([tf.distribute.MirroredStrategy])
 def test_fit_distributed_model(device):
     with device.scope():
-        test_fit_simple_linear_model()
+        fit_model("dist_model")
 
 
 def test_serialization():

--- a/tensorflow_addons/optimizers/tests/moving_average_test.py
+++ b/tensorflow_addons/optimizers/tests/moving_average_test.py
@@ -159,6 +159,15 @@ def test_fit_simple_linear_model():
     assert max_abs_diff < 5e-3
 
 
+@pytest.mark.with_device(["cpu", "gpu", tf.distribute.MirroredStrategy])
+def test_fit_distributed_model(device):
+  if isinstance(device, str):
+    test_fit_simple_linear_model()
+  else:
+    with device.scope():
+      test_fit_simple_linear_model()
+
+
 def test_serialization():
     sgd_opt = tf.keras.optimizers.SGD(lr=2.0, nesterov=True, momentum=0.3, decay=0.1)
     optimizer = MovingAverage(sgd_opt, average_decay=0.5, num_updates=None)

--- a/tensorflow_addons/optimizers/tests/moving_average_test.py
+++ b/tensorflow_addons/optimizers/tests/moving_average_test.py
@@ -159,13 +159,10 @@ def test_fit_simple_linear_model():
     assert max_abs_diff < 5e-3
 
 
-@pytest.mark.with_device(["cpu", "gpu", tf.distribute.MirroredStrategy])
+@pytest.mark.with_device([tf.distribute.MirroredStrategy])
 def test_fit_distributed_model(device):
-    if isinstance(device, str):
+    with device.scope():
         test_fit_simple_linear_model()
-    else:
-        with device.scope():
-            test_fit_simple_linear_model()
 
 
 def test_serialization():

--- a/tensorflow_addons/optimizers/tests/moving_average_test.py
+++ b/tensorflow_addons/optimizers/tests/moving_average_test.py
@@ -161,11 +161,11 @@ def test_fit_simple_linear_model():
 
 @pytest.mark.with_device(["cpu", "gpu", tf.distribute.MirroredStrategy])
 def test_fit_distributed_model(device):
-  if isinstance(device, str):
-    test_fit_simple_linear_model()
-  else:
-    with device.scope():
-      test_fit_simple_linear_model()
+    if isinstance(device, str):
+        test_fit_simple_linear_model()
+    else:
+        with device.scope():
+            test_fit_simple_linear_model()
 
 
 def test_serialization():

--- a/tensorflow_addons/utils/types.py
+++ b/tensorflow_addons/utils/types.py
@@ -50,6 +50,7 @@ TensorLike = Union[
     tf.Tensor,
     tf.SparseTensor,
     tf.Variable,
+    tf.distribute.DistributedValues,
 ]
 FloatTensorLike = Union[tf.Tensor, float, np.float16, np.float32, np.float64]
 AcceptableDTypes = Union[tf.DType, np.dtype, type, int, str, None]

--- a/tools/testing/source_code_test.py
+++ b/tools/testing/source_code_test.py
@@ -89,7 +89,6 @@ def test_no_private_tf_api():
     # this blacklist should not grow. Do not add elements to this list.
     blacklist = [
         "tensorflow_addons/optimizers/novograd.py",
-        "tensorflow_addons/optimizers/moving_average.py",
         "tensorflow_addons/metrics/r_square.py",
         "tensorflow_addons/utils/test_utils.py",
         "tensorflow_addons/losses/contrastive.py",


### PR DESCRIPTION
Port `assign_moving_average` from TF to TFA. Remove `zero_debias` since it is not used in MovingAverage.

Related to #1735