### PR TITLE
Added echo state network (ESN)

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -95,6 +95,8 @@
 /tensorflow_addons/layers/tests/tlu_test.py @aakashkumarnain
 /tensorflow_addons/layers/wrappers.py @seanpmorgan
 /tensorflow_addons/layers/tests/wrappers_test.py @seanpmorgan
+/tensorflow_addons/layers/esn.py @pedrolarben
+/tensorflow_addons/layers/tests/esn_test.py @pedrolarben
 
 /tensorflow_addons/losses/contrastive.py @windqaq
 /tensorflow_addons/losses/tests/contrastive_test.py @windqaq

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -153,8 +153,8 @@
 /tensorflow_addons/optimizers/yogi.py @manzilz
 /tensorflow_addons/optimizers/tests/yogi_test.py @manzilz
 
-/tensorflow_addons/rnn/cell.py @qlzh727
-/tensorflow_addons/rnn/tests/cell_test.py @qlzh727
+/tensorflow_addons/rnn/cell.py @qlzh727 @pedrolarben
+/tensorflow_addons/rnn/tests/cell_test.py @qlzh727 @pedrolarben
 
 /tensorflow_addons/seq2seq/ @qlzh727 @guillaumekln
 

--- a/tensorflow_addons/layers/BUILD
+++ b/tensorflow_addons/layers/BUILD
@@ -10,6 +10,7 @@ py_library(
     ],
     deps = [
         "//tensorflow_addons/activations",
+        "//tensorflow_addons/rnn",
         "//tensorflow_addons/testing",
         "//tensorflow_addons/utils",
     ],

--- a/tensorflow_addons/layers/__init__.py
+++ b/tensorflow_addons/layers/__init__.py
@@ -34,3 +34,4 @@ from tensorflow_addons.layers.polynomial import PolynomialCrossing
 from tensorflow_addons.layers.sparsemax import Sparsemax
 from tensorflow_addons.layers.tlu import TLU
 from tensorflow_addons.layers.wrappers import WeightNormalization
+from tensorflow_addons.layers.esn import ESN

--- a/tensorflow_addons/layers/esn.py
+++ b/tensorflow_addons/layers/esn.py
@@ -15,7 +15,7 @@
 """Implements Echo State recurrent Network (ESN) layer."""
 
 import tensorflow as tf
-import tensorflow_addons as tfa
+from tensorflow_addons.rnn import cell as rnn_cell
 from typeguard import typechecked
 
 from tensorflow_addons.utils.types import (
@@ -108,7 +108,7 @@ class ESN(tf.keras.layers.RNN):
         unroll=False,
         **kwargs
     ):
-        cell = tfa.rnn.ESNCell(
+        cell = rnn_cell.ESNCell(
             units,
             connectivity=connectivity,
             leaky=leaky,

--- a/tensorflow_addons/layers/esn.py
+++ b/tensorflow_addons/layers/esn.py
@@ -15,7 +15,7 @@
 """Implements Echo State recurrent Network (ESN) layer."""
 
 import tensorflow as tf
-from tensorflow_addons.rnn import cell as rnn_cell
+import tensorflow_addons as tfa
 from typeguard import typechecked
 
 from tensorflow_addons.utils.types import (
@@ -108,7 +108,7 @@ class ESN(tf.keras.layers.RNN):
         unroll=False,
         **kwargs
     ):
-        cell = rnn_cell.ESNCell(
+        cell = tfa.rnn.cell.ESNCell(
             units,
             connectivity=connectivity,
             leaky=leaky,

--- a/tensorflow_addons/layers/esn.py
+++ b/tensorflow_addons/layers/esn.py
@@ -108,7 +108,7 @@ class ESN(tf.keras.layers.RNN):
         unroll=False,
         **kwargs
     ):
-        cell = tfa.rnn.cell.ESNCell(
+        cell = tfa.rnn.ESNCell(
             units,
             connectivity=connectivity,
             leaky=leaky,

--- a/tensorflow_addons/layers/esn.py
+++ b/tensorflow_addons/layers/esn.py
@@ -15,7 +15,7 @@
 """Implements Echo State recurrent Network (ESN) layer."""
 
 import tensorflow as tf
-import tensorflow_addons as tfa
+from tensorflow_addons.rnn import ESNCell
 from typeguard import typechecked
 
 from tensorflow_addons.utils.types import (
@@ -108,7 +108,7 @@ class ESN(tf.keras.layers.RNN):
         unroll=False,
         **kwargs
     ):
-        cell = tfa.rnn.cell.ESNCell(
+        cell = ESNCell(
             units,
             connectivity=connectivity,
             leaky=leaky,

--- a/tensorflow_addons/layers/esn.py
+++ b/tensorflow_addons/layers/esn.py
@@ -1,0 +1,206 @@
+# Copyright 2020 The TensorFlow Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ==============================================================================
+"""Implements Echo State recurrent Network (ESN) layer."""
+
+import tensorflow as tf
+import tensorflow_addons as tfa
+from typeguard import typechecked
+
+from tensorflow_addons.utils.types import (
+    Activation,
+    FloatTensorLike,
+    TensorLike,
+    Initializer,
+)
+
+
+@tf.keras.utils.register_keras_serializable(package="Addons")
+class ESN(tf.keras.layers.RNN):
+    """Echo State Network layer.
+
+        This implements the recurrent layer using the ESNCell.
+
+        This is based on the paper
+            H. Jaeger
+            "The "echo state" approach to analysing and training recurrent neural networks". GMD Report148, German National Research Center for Information Technology, 2001.
+
+
+      Arguments:
+        units: Positive integer, dimensionality of the reservoir.
+        connectivity: Float between 0 and 1.
+            Connection probability between two reservoir units.
+            Default: 0.1.
+        leaky: Float between 0 and 1.
+            Leaking rate of the reservoir.
+            If you pass 1, it's the special case the model does not have leaky integration.
+            Default: 1.
+        spectral_radius: Float between 0 and 1.
+            Desired spectral radius of recurrent weight matrix.
+            Default: 0.9.
+        use_norm2: Boolean, whether to use norm2 as an approximation of the spectral radius.
+            It  avoids to compute the eigenvalues which has an exponential complexity.
+            Default: False.
+        use_bias: Boolean, whether the layer uses a bias vector.
+            Default: True.
+        activation: Activation function to use.
+          Default: hyperbolic tangent (`tanh`).
+          If you pass `None`, no activation is applied
+          (ie. "linear" activation: `a(x) = x`).
+        kernel_initializer: Initializer for the `kernel` weights matrix,
+            used for the linear transformation of the inputs.
+            Default: `glorot_uniform`.
+        recurrent_initializer: Initializer for the `recurrent_kernel` weights matrix,
+            used for the linear transformation of the recurrent state.
+            Default: `glorot_uniform`.
+        bias_initializer: Initializer for the bias vector.
+            Default: `zeros`.
+        return_sequences: Boolean. Whether to return the last output.
+          in the output sequence, or the full sequence.
+        go_backwards: Boolean (default False).
+          If True, process the input sequence backwards and return the
+          reversed sequence.
+        unroll: Boolean (default False).
+          If True, the network will be unrolled,
+          else a symbolic loop will be used.
+          Unrolling can speed-up a RNN,
+          although it tends to be more memory-intensive.
+          Unrolling is only suitable for short sequences.
+
+      Call arguments:
+        inputs: A 3D tensor.
+        mask: Binary tensor of shape `(samples, timesteps)` indicating whether
+          a given timestep should be masked.
+        training: Python boolean indicating whether the layer should behave in
+          training mode or in inference mode. This argument is passed to the cell
+          when calling it. This is only relevant if `dropout` or
+          `recurrent_dropout` is used.
+        initial_state: List of initial state tensors to be passed to the first
+          call of the cell.
+     """
+
+    @typechecked
+    def __init__(
+        self,
+        units: TensorLike,
+        connectivity: FloatTensorLike = 0.1,
+        leaky: FloatTensorLike = 1,
+        spectral_radius: FloatTensorLike = 0.9,
+        use_norm2: bool = False,
+        use_bias: bool = True,
+        activation: Activation = "tanh",
+        kernel_initializer: Initializer = "glorot_uniform",
+        recurrent_initializer: Initializer = "glorot_uniform",
+        bias_initializer: Initializer = "zeros",
+        return_sequences=False,
+        go_backwards=False,
+        unroll=False,
+        **kwargs
+    ):
+        cell = tfa.rnn.cell.ESNCell(
+            units,
+            connectivity=connectivity,
+            leaky=leaky,
+            spectral_radius=spectral_radius,
+            use_norm2=use_norm2,
+            use_bias=use_bias,
+            activation=activation,
+            kernel_initializer=kernel_initializer,
+            recurrent_initializer=recurrent_initializer,
+            bias_initializer=bias_initializer,
+            dtype=kwargs.get("dtype"),
+        )
+        super(ESN, self).__init__(
+            cell,
+            return_sequences=return_sequences,
+            go_backwards=go_backwards,
+            unroll=unroll,
+            **kwargs,
+        )
+
+    def call(
+        self, inputs, mask=None, training=None, initial_state=None, constants=None
+    ):
+        return super(ESN, self).call(
+            inputs,
+            mask=mask,
+            training=training,
+            initial_state=initial_state,
+            constants=None,
+        )
+
+    @property
+    def units(self):
+        return self.cell.units
+
+    @property
+    def connectivity(self):
+        return self.cell.connectivity
+
+    @property
+    def leaky(self):
+        return self.cell.leaky
+
+    @property
+    def spectral_radius(self):
+        return self.cell.spectral_radius
+
+    @property
+    def use_norm2(self):
+        return self.cell.use_norm2
+
+    @property
+    def use_bias(self):
+        return self.cell.use_bias
+
+    @property
+    def activation(self):
+        return self.cell.activation
+
+    @property
+    def kernel_initializer(self):
+        return self.cell.kernel_initializer
+
+    @property
+    def recurrent_initializer(self):
+        return self.cell.recurrent_initializer
+
+    @property
+    def bias_initializer(self):
+        return self.cell.bias_initializer
+
+    def get_config(self):
+        config = {
+            "units": self.units,
+            "connectivity": self.connectivity,
+            "leaky": self.leaky,
+            "spectral_radius": self.spectral_radius,
+            "use_norm2": self.use_norm2,
+            "use_bias": self.use_bias,
+            "activation": tf.keras.activations.serialize(self.activation),
+            "kernel_initializer": tf.keras.initializers.serialize(
+                self.kernel_initializer
+            ),
+            "recurrent_initializer": tf.keras.initializers.serialize(
+                self.recurrent_initializer
+            ),
+            "bias_initializer": tf.keras.initializers.serialize(self.bias_initializer),
+        }
+        base_config = super(ESN, self).get_config()
+        del base_config["cell"]
+        return {**base_config, **config}
+
+    @classmethod
+    def from_config(cls, config):
+        return cls(**config)

--- a/tensorflow_addons/layers/tests/esn_test.py
+++ b/tensorflow_addons/layers/tests/esn_test.py
@@ -1,0 +1,66 @@
+# Copyright 2020 The TensorFlow Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ==============================================================================
+"""Tests for Echo State recurrent Network (ESN)."""
+
+import pytest
+import numpy as np
+import tensorflow as tf
+from tensorflow_addons.layers.esn import ESN
+from tensorflow_addons.utils import test_utils
+
+
+@pytest.mark.usefixtures("maybe_run_functions_eagerly")
+@pytest.mark.parametrize("dtype", [np.float16, np.float32, np.float64])
+def test_random(dtype):
+    inp = np.asanyarray(
+        [[[1.0, 1.0, 1.0, 1.0]], [[2.0, 2.0, 2.0, 2.0]], [[3.0, 3.0, 3.0, 3.0]]]
+    ).astype(dtype)
+    out = np.asarray([[2.5, 2.5, 2.5], [4.5, 4.5, 4.5], [6.5, 6.5, 6.5]]).astype(dtype)
+
+    const_initializer = tf.constant_initializer(0.5)
+    kwargs = {
+        "units": 3,
+        "connectivity": 1,
+        "leaky": 1,
+        "spectral_radius": 0.9,
+        "use_norm2": True,
+        "use_bias": True,
+        "activation": None,
+        "kernel_initializer": const_initializer,
+        "recurrent_initializer": const_initializer,
+        "bias_initializer": const_initializer,
+        "dtype": dtype,
+    }
+
+    test_utils.layer_test(ESN, kwargs=kwargs, input_data=inp, expected_output=out)
+
+
+@pytest.mark.parametrize("dtype", [np.float16, np.float32, np.float64])
+def test_serialization(dtype):
+    esn = ESN(
+        units=3,
+        connectivity=1,
+        leaky=1,
+        spectral_radius=0.9,
+        use_norm2=False,
+        use_bias=True,
+        activation=None,
+        kernel_initializer="ones",
+        recurrent_initializer="ones",
+        bias_initializer="ones",
+    )
+    serialized_esn = tf.keras.layers.serialize(esn)
+    new_layer = tf.keras.layers.deserialize(serialized_esn)
+    assert esn.get_config() == new_layer.get_config()

--- a/tensorflow_addons/rnn/__init__.py
+++ b/tensorflow_addons/rnn/__init__.py
@@ -17,3 +17,4 @@
 from tensorflow_addons.rnn.cell import LayerNormLSTMCell
 from tensorflow_addons.rnn.cell import NASCell
 from tensorflow_addons.rnn.cell import LayerNormSimpleRNNCell
+from tensorflow_addons.rnn.cell import ESNCell

--- a/tensorflow_addons/rnn/cell.py
+++ b/tensorflow_addons/rnn/cell.py
@@ -727,7 +727,9 @@ class ESNCell(keras.layers.AbstractRNNCell):
                 )
             else:
                 abs_eig_values = tf.abs(tf.linalg.eig(recurrent_weights)[0])
-                scaling_factor = self.spectral_radius / tf.reduce_max(abs_eig_values)
+                scaling_factor = tf.math.divide_no_nan(
+                    self.spectral_radius, tf.reduce_max(abs_eig_values)
+                )
 
             recurrent_weights = tf.multiply(recurrent_weights, scaling_factor)
 

--- a/tensorflow_addons/rnn/cell.py
+++ b/tensorflow_addons/rnn/cell.py
@@ -619,3 +619,174 @@ class LayerNormSimpleRNNCell(keras.layers.SimpleRNNCell):
 
         ln_config["layernorm_epsilon"] = ln_config.pop("epsilon")
         return dict(list(cell_config.items()) + list(ln_config.items()))
+
+
+@tf.keras.utils.register_keras_serializable(package="Addons")
+class ESNCell(keras.layers.AbstractRNNCell):
+    """Echo State recurrent Network (ESN) cell.
+
+    This implements the recurrent cell from the paper:
+        H. Jaeger
+        "The "echo state" approach to analysing and training recurrent neural networks". GMD Report148, German National Research Center for Information Technology, 2001.
+
+    Arguments:
+        units: Positive integer, dimensionality in the reservoir.
+        connectivity: Float between 0 and 1.
+            Connection probability between two reservoir units.
+            Default: 0.1.
+        leaky: Float between 0 and 1.
+            Leaking rate of the reservoir.
+            If you pass 1, it's the special case the model does not have leaky integration.
+            Default: 1.
+        spectral_radius: Float between 0 and 1.
+            Desired spectral radius of recurrent weight matrix.
+            Default: 0.9.
+        use_norm2: Boolean, whether to use norm2 as an approximation of the spectral radius.
+            It  avoids to compute the eigenvalues which has an exponential complexity.
+            Default: False.
+        use_bias: Boolean, whether the layer uses a bias vector.
+            Default: True.
+        activation: Activation function to use.
+            Default: hyperbolic tangent (`tanh`).
+        kernel_initializer: Initializer for the `kernel` weights matrix,
+            used for the linear transformation of the inputs.
+            Default: `glorot_uniform`.
+        recurrent_initializer: Initializer for the `recurrent_kernel` weights matrix,
+            used for the linear transformation of the recurrent state.
+            Default: `glorot_uniform`.
+        bias_initializer: Initializer for the bias vector.
+            Default: `zeros`.
+    Call arguments:
+        inputs: A 2D tensor (batch x num_units).
+        states: List of state tensors corresponding to the previous timestep.
+    """
+
+    @typechecked
+    def __init__(
+        self,
+        units: TensorLike,
+        connectivity: FloatTensorLike = 0.1,
+        leaky: FloatTensorLike = 1,
+        spectral_radius: FloatTensorLike = 0.9,
+        use_norm2: bool = False,
+        use_bias: bool = True,
+        activation: Activation = "tanh",
+        kernel_initializer: Initializer = "glorot_uniform",
+        recurrent_initializer: Initializer = "glorot_uniform",
+        bias_initializer: Initializer = "zeros",
+        **kwargs
+    ):
+        super().__init__(**kwargs)
+        self.units = units
+        self.connectivity = connectivity
+        self.leaky = leaky
+        self.spectral_radius = spectral_radius
+        self.use_norm2 = use_norm2
+        self.use_bias = use_bias
+        self.activation = tf.keras.activations.get(activation)
+        self.kernel_initializer = tf.keras.initializers.get(kernel_initializer)
+        self.recurrent_initializer = tf.keras.initializers.get(recurrent_initializer)
+        self.bias_initializer = tf.keras.initializers.get(bias_initializer)
+
+        self._state_size = units
+        self._output_size = units
+
+    @property
+    def state_size(self):
+        return self._state_size
+
+    @property
+    def output_size(self):
+        return self._output_size
+
+    def build(self, inputs_shape):
+        input_size = tf.compat.dimension_value(tf.TensorShape(inputs_shape)[-1])
+        if input_size is None:
+            raise ValueError("Could not infer input size from inputs.get_shape()[-1]")
+
+        def _esn_recurrent_initializer(shape, dtype, partition_info=None):
+            recurrent_weights = tf.keras.initializers.get(self.recurrent_initializer)(
+                shape, dtype
+            )
+
+            connectivity_mask = tf.cast(
+                tf.math.less_equal(tf.random.uniform(shape), self.connectivity,), dtype
+            )
+            recurrent_weights = tf.math.multiply(recurrent_weights, connectivity_mask)
+
+            # Satisfy the necessary condition for the echo state property `max(eig(W)) < 1`
+            if self.use_norm2:
+                # This condition is approximated scaling the norm 2 of the reservoir matrix
+                # which is an upper bound of the spectral radius.
+                recurrent_norm2 = tf.math.sqrt(
+                    tf.math.reduce_sum(tf.math.square(recurrent_weights))
+                )
+                is_norm2_0 = tf.cast(tf.math.equal(recurrent_norm2, 0), dtype)
+                scaling_factor = self.spectral_radius / (
+                    recurrent_norm2 + 1 * is_norm2_0
+                )
+            else:
+                abs_eig_values = tf.abs(tf.linalg.eig(recurrent_weights)[0])
+                scaling_factor = self.spectral_radius / tf.reduce_max(abs_eig_values)
+
+            recurrent_weights = tf.multiply(recurrent_weights, scaling_factor)
+
+            return recurrent_weights
+
+        self.recurrent_kernel = self.add_weight(
+            name="recurrent_kernel",
+            shape=[self.units, self.units],
+            initializer=_esn_recurrent_initializer,
+            trainable=False,
+            dtype=self.dtype,
+        )
+        self.kernel = self.add_weight(
+            name="kernel",
+            shape=[input_size, self.units],
+            initializer=self.kernel_initializer,
+            trainable=False,
+            dtype=self.dtype,
+        )
+
+        if self.use_bias:
+            self.bias = self.add_weight(
+                name="bias",
+                shape=[self.units],
+                initializer=self.bias_initializer,
+                trainable=False,
+                dtype=self.dtype,
+            )
+
+        self.built = True
+
+    def call(self, inputs, state):
+        in_matrix = tf.concat([inputs, state[0]], axis=1)
+        weights_matrix = tf.concat([self.kernel, self.recurrent_kernel], axis=0)
+
+        output = tf.linalg.matmul(in_matrix, weights_matrix)
+        if self.use_bias:
+            output = output + self.bias
+        output = self.activation(output)
+        output = (1 - self.leaky) * state[0] + self.leaky * output
+
+        return output, output
+
+    def get_config(self):
+        config = {
+            "units": self.units,
+            "connectivity": self.connectivity,
+            "leaky": self.leaky,
+            "spectral_radius": self.spectral_radius,
+            "use_norm2": self.use_norm2,
+            "use_bias": self.use_bias,
+            "activation": tf.keras.activations.serialize(self.activation),
+            "kernel_initializer": tf.keras.initializers.serialize(
+                self.kernel_initializer
+            ),
+            "recurrent_initializer": tf.keras.initializers.serialize(
+                self.recurrent_initializer
+            ),
+            "bias_initializer": tf.keras.initializers.serialize(self.bias_initializer),
+        }
+        base_config = super().get_config()
+        return {**base_config, **config}

--- a/tensorflow_addons/rnn/tests/cell_test.py
+++ b/tensorflow_addons/rnn/tests/cell_test.py
@@ -457,7 +457,7 @@ def test_esn_echo_state_property_eig():
     )
     cell.build((3, 3))
     recurrent_weights = tf.constant(cell.get_weights()[0])
-    max_eig = tf.reduce_max(tf.abs(tf.linalg.eig(recurrent_weights)[0]))
+    max_eig = tf.reduce_max(tf.abs(tf.linalg.eig(recurrent_weights)))
     assert max_eig < 1, "max(eig(W)) < 1"
 
 

--- a/tensorflow_addons/rnn/tests/cell_test.py
+++ b/tensorflow_addons/rnn/tests/cell_test.py
@@ -410,3 +410,136 @@ def test_configs_layernorm():
     cell2 = LayerNormSimpleRNNCell(**config1)
     config2 = cell2.get_config()
     assert config1 == config2
+
+
+def test_base_esn():
+    units = 3
+    expected_output = np.array(
+        [[2.77, 2.77, 2.77], [4.77, 4.77, 4.77], [6.77, 6.77, 6.77],], dtype=np.float32,
+    )
+
+    const_initializer = tf.constant_initializer(0.5)
+    cell = rnn_cell.ESNCell(
+        units=units,
+        connectivity=1,
+        leaky=1,
+        spectral_radius=0.9,
+        use_norm2=True,
+        use_bias=True,
+        activation=None,
+        kernel_initializer=const_initializer,
+        recurrent_initializer=const_initializer,
+        bias_initializer=const_initializer,
+    )
+
+    inputs = tf.constant(
+        np.array(
+            [[1.0, 1.0, 1.0, 1.0], [2.0, 2.0, 2.0, 2.0], [3.0, 3.0, 3.0, 3.0]],
+            dtype=np.float32,
+        ),
+        dtype=tf.float32,
+    )
+    state_value = tf.constant(
+        0.3 * np.ones((units, units), dtype=np.float32), dtype=tf.float32
+    )
+    init_state = [state_value, state_value]
+    output, state = cell(inputs, init_state)
+
+    np.testing.assert_allclose(output, expected_output, 1e-5)
+    np.testing.assert_allclose(state, expected_output, 1e-5)
+
+
+def test_esn_echo_state_property_eig():
+    use_norm2 = False
+    units = 3
+    cell = rnn_cell.ESNCell(
+        units=units, use_norm2=use_norm2, recurrent_initializer="ones",
+    )
+    cell.build((3, 3))
+    recurrent_weights = tf.constant(cell.get_weights()[0])
+    max_eig = tf.reduce_max(tf.abs(tf.linalg.eig(recurrent_weights)[0]))
+    assert max_eig < 1, "max(eig(W)) < 1"
+
+
+def test_esn_echo_state_property_norm2():
+    use_norm2 = True
+    units = 3
+    cell = rnn_cell.ESNCell(
+        units=units, use_norm2=use_norm2, recurrent_initializer="ones",
+    )
+    cell.build((3, 3))
+    recurrent_weights = tf.constant(cell.get_weights()[0])
+    max_eig = tf.reduce_max(tf.abs(tf.linalg.eig(recurrent_weights)[0]))
+    assert max_eig < 1, "max(eig(W)) < 1"
+
+
+def test_esn_connectivity():
+    units = 1000
+    connectivity = 0.5
+    cell = rnn_cell.ESNCell(
+        units=units,
+        connectivity=connectivity,
+        use_norm2=True,
+        recurrent_initializer="ones",
+    )
+    cell.build((3, 3))
+    recurrent_weights = tf.constant(cell.get_weights()[0])
+    num_non_zero = tf.math.count_nonzero(recurrent_weights)
+    actual_connectivity = tf.divide(num_non_zero, units ** 2)
+    np.testing.assert_allclose(
+        np.asarray([actual_connectivity]), np.asanyarray([connectivity]), 1e-2
+    )
+
+
+def test_esn_keras_rnn():
+    cell = rnn_cell.ESNCell(10)
+    seq_input = tf.convert_to_tensor(
+        np.random.rand(2, 3, 5), name="seq_input", dtype=tf.float32
+    )
+    rnn_layer = keras.layers.RNN(cell=cell)
+    rnn_outputs = rnn_layer(seq_input)
+    assert rnn_outputs.shape == (2, 10)
+
+
+def test_esn_config():
+    cell = rnn_cell.ESNCell(
+        units=3,
+        connectivity=1,
+        leaky=1,
+        spectral_radius=0.9,
+        use_norm2=False,
+        use_bias=True,
+        activation="tanh",
+        kernel_initializer="glorot_uniform",
+        recurrent_initializer="glorot_uniform",
+        bias_initializer="glorot_uniform",
+        name="esn_cell_3",
+    )
+
+    expected_config = {
+        "name": "esn_cell_3",
+        "trainable": True,
+        "dtype": "float32",
+        "units": 3,
+        "connectivity": 1,
+        "leaky": 1,
+        "spectral_radius": 0.9,
+        "use_norm2": False,
+        "use_bias": True,
+        "activation": tf.keras.activations.serialize(tf.keras.activations.get("tanh")),
+        "kernel_initializer": tf.keras.initializers.serialize(
+            tf.keras.initializers.get("glorot_uniform")
+        ),
+        "recurrent_initializer": tf.keras.initializers.serialize(
+            tf.keras.initializers.get("glorot_uniform")
+        ),
+        "bias_initializer": tf.keras.initializers.serialize(
+            tf.keras.initializers.get("glorot_uniform")
+        ),
+    }
+    config = cell.get_config()
+    assert config == expected_config
+
+    restored_cell = rnn_cell.ESNCell.from_config(config)
+    restored_config = restored_cell.get_config()
+    assert config == restored_config

--- a/tensorflow_addons/rnn/tests/cell_test.py
+++ b/tensorflow_addons/rnn/tests/cell_test.py
@@ -453,11 +453,14 @@ def test_esn_echo_state_property_eig():
     use_norm2 = False
     units = 3
     cell = rnn_cell.ESNCell(
-        units=units, use_norm2=use_norm2, recurrent_initializer="ones",
+        units=units,
+        use_norm2=use_norm2,
+        recurrent_initializer="ones",
+        connectivity=1.0,
     )
     cell.build((3, 3))
-    recurrent_weights = tf.constant(cell.get_weights()[0])
-    max_eig = tf.reduce_max(tf.abs(tf.linalg.eig(recurrent_weights)))
+    recurrent_weights = tf.constant(cell.get_weights()[0], dtype=tf.float32)
+    max_eig = tf.reduce_max(tf.abs(tf.linalg.eig(recurrent_weights)[0]))
     assert max_eig < 1, "max(eig(W)) < 1"
 
 
@@ -465,7 +468,7 @@ def test_esn_echo_state_property_norm2():
     use_norm2 = True
     units = 3
     cell = rnn_cell.ESNCell(
-        units=units, use_norm2=use_norm2, recurrent_initializer="ones",
+        units=units, use_norm2=use_norm2, recurrent_initializer="ones", connectivity=1.0
     )
     cell.build((3, 3))
     recurrent_weights = tf.constant(cell.get_weights()[0])


### PR DESCRIPTION
Hello, 
I have been working with recurrent neural networks. I needed an implementation of Echo State Networks (ESN) for tensorflow. I found some implementations, but none of them was compatible with tensorflow2, so I implemented it. I think it would be great to add ESN to tensorflow_addons so everybody can use it. 

> "Echo state networks (ESN) provide an architecture and supervised learning principle for recurrent neural networks (RNNs). The main idea is (i) to drive a random, large, fixed recurrent neural network with the input signal, thereby inducing in each neuron within this "reservoir" network a nonlinear response signal, and (ii) combine a desired output signal by a trainable linear combination of all of these response signals". 
>Herbert Jaeger, Jacobs University Bremen, Bremen, Germany 

<img src="https://tu-dresden.de/ing/elektrotechnik/ias/stks/ressourcen/bilder/forschung/neural-modeling/@@images/63f5b202-a3da-471d-bc11-3c6ee1d81a84.png" alt="Echo state network scheme by Peter Birkholz" width="40%" /><br><br>

**References**

- The “echo state” approach to analysing and training recurrent neural networks-with an erratum note. [Herbert Jaeger](https://scholar.google.de/citations?user=0uztVbMAAAAJ&hl=en), 2001. Cited by 2281. [[pdf]](https://www.researchgate.net/profile/Herbert_Jaeger3/publication/215385037_The_echo_state_approach_to_analysing_and_training_recurrent_neural_networks-with_an_erratum_note'/links/566a003508ae62b05f027be3/The-echo-state-approach-to-analysing-and-training-recurrent-neural-networks-with-an-erratum-note.pdf)
- [ESN implementation for tensorflow 1.12](https://github.com/m-colombo/Tensorflow-EchoStateNetwork)
- ESN implementations for pytorch: [EchoTorch](https://github.com/nschaetti/EchoTorch), [pytorch-esn](https://github.com/stefanonardo/pytorch-esn)


