### PR TITLE
Added echo state network (ESN) recurrent cell

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -153,8 +153,8 @@
 /tensorflow_addons/optimizers/yogi.py @manzilz
 /tensorflow_addons/optimizers/tests/yogi_test.py @manzilz
 
-/tensorflow_addons/rnn/cell.py @qlzh727
-/tensorflow_addons/rnn/tests/cell_test.py @qlzh727
+/tensorflow_addons/rnn/cell.py @qlzh727 @pedrolarben
+/tensorflow_addons/rnn/tests/cell_test.py @qlzh727 @pedrolarben
 
 /tensorflow_addons/seq2seq/ @qlzh727 @guillaumekln
 

--- a/tensorflow_addons/rnn/__init__.py
+++ b/tensorflow_addons/rnn/__init__.py
@@ -17,3 +17,4 @@
 from tensorflow_addons.rnn.cell import LayerNormLSTMCell
 from tensorflow_addons.rnn.cell import NASCell
 from tensorflow_addons.rnn.cell import LayerNormSimpleRNNCell
+from tensorflow_addons.rnn.cell import ESNCell

--- a/tensorflow_addons/rnn/cell.py
+++ b/tensorflow_addons/rnn/cell.py
@@ -668,10 +668,10 @@ class ESNCell(keras.layers.AbstractRNNCell):
     @typechecked
     def __init__(
         self,
-        units: TensorLike,
-        connectivity: FloatTensorLike = 0.1,
-        leaky: FloatTensorLike = 1,
-        spectral_radius: FloatTensorLike = 0.9,
+        units: int,
+        connectivity: float = 0.1,
+        leaky: float = 1,
+        spectral_radius: float = 0.9,
         use_norm2: bool = False,
         use_bias: bool = True,
         activation: Activation = "tanh",

--- a/tensorflow_addons/rnn/cell.py
+++ b/tensorflow_addons/rnn/cell.py
@@ -638,12 +638,14 @@ class ESNCell(keras.layers.AbstractRNNCell):
             Default: 0.1.
         leaky: Float between 0 and 1.
             Leaking rate of the reservoir.
-            If you pass 1, it's the special case the model does not have leaky integration.
+            If you pass 1, it is the special case the model does not have leaky
+            integration.
             Default: 1.
         spectral_radius: Float between 0 and 1.
             Desired spectral radius of recurrent weight matrix.
             Default: 0.9.
-        use_norm2: Boolean, whether to use norm2 as an approximation of the spectral radius.
+        use_norm2: Boolean, whether to use the p-norm function (with p=2) as an upper
+            bound of the spectral radius so that the echo state property is satisfied.
             It  avoids to compute the eigenvalues which has an exponential complexity.
             Default: False.
         use_bias: Boolean, whether the layer uses a bias vector.

--- a/tensorflow_addons/rnn/cell.py
+++ b/tensorflow_addons/rnn/cell.py
@@ -704,7 +704,10 @@ class ESNCell(keras.layers.AbstractRNNCell):
     def build(self, inputs_shape):
         input_size = tf.compat.dimension_value(tf.TensorShape(inputs_shape)[-1])
         if input_size is None:
-            raise ValueError("Could not infer input size from inputs.get_shape()[-1]")
+            raise ValueError(
+                "Could not infer input size from inputs.get_shape()[-1]. Shape received is %s"
+                % inputs_shape
+            )
 
         def _esn_recurrent_initializer(shape, dtype, partition_info=None):
             recurrent_weights = tf.keras.initializers.get(self.recurrent_initializer)(

--- a/tensorflow_addons/rnn/cell.py
+++ b/tensorflow_addons/rnn/cell.py
@@ -627,7 +627,9 @@ class ESNCell(keras.layers.AbstractRNNCell):
 
     This implements the recurrent cell from the paper:
         H. Jaeger
-        "The "echo state" approach to analysing and training recurrent neural networks". GMD Report148, German National Research Center for Information Technology, 2001.
+        "The "echo state" approach to analysing and training recurrent neural networks".
+        GMD Report148, German National Research Center for Information Technology, 2001.
+        https://www.researchgate.net/publication/215385037
 
     Arguments:
         units: Positive integer, dimensionality in the reservoir.

--- a/tensorflow_addons/rnn/cell.py
+++ b/tensorflow_addons/rnn/cell.py
@@ -619,3 +619,176 @@ class LayerNormSimpleRNNCell(keras.layers.SimpleRNNCell):
 
         ln_config["layernorm_epsilon"] = ln_config.pop("epsilon")
         return dict(list(cell_config.items()) + list(ln_config.items()))
+
+
+@tf.keras.utils.register_keras_serializable(package="Addons")
+class ESNCell(keras.layers.AbstractRNNCell):
+    """Echo State recurrent Network (ESN) cell.
+
+    This implements the recurrent cell from the paper:
+        H. Jaeger
+        "The "echo state" approach to analysing and training recurrent neural networks". GMD Report148, German National Research Center for Information Technology, 2001.
+
+    Arguments:
+        units: Positive integer, dimensionality in the reservoir.
+        connectivity: Float between 0 and 1.
+            Connection probability between two reservoir units.
+            Default: 0.1.
+        leaky: Float between 0 and 1.
+            Leaking rate of the reservoir.
+            If you pass 1, it's the special case the model does not have leaky integration.
+            Default: 1.
+        spectral_radius: Float between 0 and 1.
+            Desired spectral radius of recurrent weight matrix.
+            Default: 0.9.
+        use_norm2: Boolean, whether to use norm2 as an approximation of the spectral radius.
+            It  avoids to compute the eigenvalues which has an exponential complexity.
+            Default: False.
+        use_bias: Boolean, whether the layer uses a bias vector.
+            Default: True.
+        activation: Activation function to use.
+            Default: hyperbolic tangent (`tanh`).
+        kernel_initializer: Initializer for the `kernel` weights matrix,
+            used for the linear transformation of the inputs.
+            Default: `glorot_uniform`.
+        recurrent_initializer: Initializer for the `recurrent_kernel` weights matrix,
+            used for the linear transformation of the recurrent state.
+            Default: `glorot_uniform`.
+        bias_initializer: Initializer for the bias vector.
+            Default: `zeros`.
+    Call arguments:
+        inputs: A 2D tensor (batch x num_units).
+        states: List of state tensors corresponding to the previous timestep.
+    """
+
+    @typechecked
+    def __init__(
+        self,
+        units: TensorLike,
+        connectivity: FloatTensorLike = 0.1,
+        leaky: FloatTensorLike = 1,
+        spectral_radius: FloatTensorLike = 0.9,
+        use_norm2: bool = False,
+        use_bias: bool = True,
+        activation: Activation = "tanh",
+        kernel_initializer: Initializer = "glorot_uniform",
+        recurrent_initializer: Initializer = "glorot_uniform",
+        bias_initializer: Initializer = "zeros",
+        **kwargs
+    ):
+        super().__init__(**kwargs)
+        self.units = units
+        self.connectivity = connectivity
+        self.leaky = leaky
+        self.spectral_radius = spectral_radius
+        self.use_norm2 = use_norm2
+        self.use_bias = use_bias
+        self.activation = tf.keras.activations.get(activation)
+        self.kernel_initializer = tf.keras.initializers.get(kernel_initializer)
+        self.recurrent_initializer = tf.keras.initializers.get(recurrent_initializer)
+        self.bias_initializer = tf.keras.initializers.get(bias_initializer)
+
+        self._state_size = units
+        self._output_size = units
+
+    @property
+    def state_size(self):
+        return self._state_size
+
+    @property
+    def output_size(self):
+        return self._output_size
+
+    def build(self, inputs_shape):
+        input_size = tf.compat.dimension_value(tf.TensorShape(inputs_shape)[-1])
+        if input_size is None:
+            raise ValueError("Could not infer input size from inputs.get_shape()[-1]")
+
+        def _esn_recurrent_initializer(shape, dtype, partition_info=None):
+            recurrent_weights = tf.keras.initializers.get(self.recurrent_initializer)(
+                shape, dtype
+            )
+
+            connectivity_mask = tf.cast(
+                tf.math.less_equal(tf.random.uniform(shape), self.connectivity,), dtype
+            )
+            recurrent_weights = tf.math.multiply(recurrent_weights, connectivity_mask)
+
+            # Satisfy the necessary condition for the echo state property `max(eig(W)) < 1`
+            if self.use_norm2:
+                # This condition is approximated scaling the norm 2 of the reservoir matrix
+                # which is an upper bound of the spectral radius.
+                recurrent_norm2 = tf.math.sqrt(
+                    tf.math.reduce_sum(tf.math.square(recurrent_weights))
+                )
+                is_norm2_0 = tf.cast(tf.math.equal(recurrent_norm2, 0), dtype)
+                scaling_factor = self.spectral_radius / (
+                    recurrent_norm2 + 1 * is_norm2_0
+                )
+            else:
+                abs_eig_values = tf.abs(tf.linalg.eig(recurrent_weights)[0])
+                scaling_factor = tf.math.divide_no_nan(
+                    self.spectral_radius, tf.reduce_max(abs_eig_values)
+                )
+
+            recurrent_weights = tf.multiply(recurrent_weights, scaling_factor)
+
+            return recurrent_weights
+
+        self.recurrent_kernel = self.add_weight(
+            name="recurrent_kernel",
+            shape=[self.units, self.units],
+            initializer=_esn_recurrent_initializer,
+            trainable=False,
+            dtype=self.dtype,
+        )
+        self.kernel = self.add_weight(
+            name="kernel",
+            shape=[input_size, self.units],
+            initializer=self.kernel_initializer,
+            trainable=False,
+            dtype=self.dtype,
+        )
+
+        if self.use_bias:
+            self.bias = self.add_weight(
+                name="bias",
+                shape=[self.units],
+                initializer=self.bias_initializer,
+                trainable=False,
+                dtype=self.dtype,
+            )
+
+        self.built = True
+
+    def call(self, inputs, state):
+        in_matrix = tf.concat([inputs, state[0]], axis=1)
+        weights_matrix = tf.concat([self.kernel, self.recurrent_kernel], axis=0)
+
+        output = tf.linalg.matmul(in_matrix, weights_matrix)
+        if self.use_bias:
+            output = output + self.bias
+        output = self.activation(output)
+        output = (1 - self.leaky) * state[0] + self.leaky * output
+
+        return output, output
+
+    def get_config(self):
+        config = {
+            "units": self.units,
+            "connectivity": self.connectivity,
+            "leaky": self.leaky,
+            "spectral_radius": self.spectral_radius,
+            "use_norm2": self.use_norm2,
+            "use_bias": self.use_bias,
+            "activation": tf.keras.activations.serialize(self.activation),
+            "kernel_initializer": tf.keras.initializers.serialize(
+                self.kernel_initializer
+            ),
+            "recurrent_initializer": tf.keras.initializers.serialize(
+                self.recurrent_initializer
+            ),
+            "bias_initializer": tf.keras.initializers.serialize(self.bias_initializer),
+        }
+        base_config = super().get_config()
+        return {**base_config, **config}

--- a/tensorflow_addons/rnn/tests/cell_test.py
+++ b/tensorflow_addons/rnn/tests/cell_test.py
@@ -410,3 +410,139 @@ def test_configs_layernorm():
     cell2 = LayerNormSimpleRNNCell(**config1)
     config2 = cell2.get_config()
     assert config1 == config2
+
+
+def test_base_esn():
+    units = 3
+    expected_output = np.array(
+        [[2.77, 2.77, 2.77], [4.77, 4.77, 4.77], [6.77, 6.77, 6.77],], dtype=np.float32,
+    )
+
+    const_initializer = tf.constant_initializer(0.5)
+    cell = rnn_cell.ESNCell(
+        units=units,
+        connectivity=1,
+        leaky=1,
+        spectral_radius=0.9,
+        use_norm2=True,
+        use_bias=True,
+        activation=None,
+        kernel_initializer=const_initializer,
+        recurrent_initializer=const_initializer,
+        bias_initializer=const_initializer,
+    )
+
+    inputs = tf.constant(
+        np.array(
+            [[1.0, 1.0, 1.0, 1.0], [2.0, 2.0, 2.0, 2.0], [3.0, 3.0, 3.0, 3.0]],
+            dtype=np.float32,
+        ),
+        dtype=tf.float32,
+    )
+    state_value = tf.constant(
+        0.3 * np.ones((units, units), dtype=np.float32), dtype=tf.float32
+    )
+    init_state = [state_value, state_value]
+    output, state = cell(inputs, init_state)
+
+    np.testing.assert_allclose(output, expected_output, 1e-5)
+    np.testing.assert_allclose(state, expected_output, 1e-5)
+
+
+def test_esn_echo_state_property_eig():
+    use_norm2 = False
+    units = 3
+    cell = rnn_cell.ESNCell(
+        units=units,
+        use_norm2=use_norm2,
+        recurrent_initializer="ones",
+        connectivity=1.0,
+    )
+    cell.build((3, 3))
+    recurrent_weights = tf.constant(cell.get_weights()[0], dtype=tf.float32)
+    max_eig = tf.reduce_max(tf.abs(tf.linalg.eig(recurrent_weights)[0]))
+    assert max_eig < 1, "max(eig(W)) < 1"
+
+
+def test_esn_echo_state_property_norm2():
+    use_norm2 = True
+    units = 3
+    cell = rnn_cell.ESNCell(
+        units=units, use_norm2=use_norm2, recurrent_initializer="ones", connectivity=1.0
+    )
+    cell.build((3, 3))
+    recurrent_weights = tf.constant(cell.get_weights()[0])
+    max_eig = tf.reduce_max(tf.abs(tf.linalg.eig(recurrent_weights)[0]))
+    assert max_eig < 1, "max(eig(W)) < 1"
+
+
+def test_esn_connectivity():
+    units = 1000
+    connectivity = 0.5
+    cell = rnn_cell.ESNCell(
+        units=units,
+        connectivity=connectivity,
+        use_norm2=True,
+        recurrent_initializer="ones",
+    )
+    cell.build((3, 3))
+    recurrent_weights = tf.constant(cell.get_weights()[0])
+    num_non_zero = tf.math.count_nonzero(recurrent_weights)
+    actual_connectivity = tf.divide(num_non_zero, units ** 2)
+    np.testing.assert_allclose(
+        np.asarray([actual_connectivity]), np.asanyarray([connectivity]), 1e-2
+    )
+
+
+def test_esn_keras_rnn():
+    cell = rnn_cell.ESNCell(10)
+    seq_input = tf.convert_to_tensor(
+        np.random.rand(2, 3, 5), name="seq_input", dtype=tf.float32
+    )
+    rnn_layer = keras.layers.RNN(cell=cell)
+    rnn_outputs = rnn_layer(seq_input)
+    assert rnn_outputs.shape == (2, 10)
+
+
+def test_esn_config():
+    cell = rnn_cell.ESNCell(
+        units=3,
+        connectivity=1,
+        leaky=1,
+        spectral_radius=0.9,
+        use_norm2=False,
+        use_bias=True,
+        activation="tanh",
+        kernel_initializer="glorot_uniform",
+        recurrent_initializer="glorot_uniform",
+        bias_initializer="glorot_uniform",
+        name="esn_cell_3",
+    )
+
+    expected_config = {
+        "name": "esn_cell_3",
+        "trainable": True,
+        "dtype": "float32",
+        "units": 3,
+        "connectivity": 1,
+        "leaky": 1,
+        "spectral_radius": 0.9,
+        "use_norm2": False,
+        "use_bias": True,
+        "activation": tf.keras.activations.serialize(tf.keras.activations.get("tanh")),
+        "kernel_initializer": tf.keras.initializers.serialize(
+            tf.keras.initializers.get("glorot_uniform")
+        ),
+        "recurrent_initializer": tf.keras.initializers.serialize(
+            tf.keras.initializers.get("glorot_uniform")
+        ),
+        "bias_initializer": tf.keras.initializers.serialize(
+            tf.keras.initializers.get("glorot_uniform")
+        ),
+    }
+    config = cell.get_config()
+    assert config == expected_config
+
+    restored_cell = rnn_cell.ESNCell.from_config(config)
+    restored_config = restored_cell.get_config()
+    assert config == restored_config

--- a/tensorflow_addons/rnn/tests/cell_test.py
+++ b/tensorflow_addons/rnn/tests/cell_test.py
@@ -504,6 +504,18 @@ def test_esn_keras_rnn():
     assert rnn_outputs.shape == (2, 10)
 
 
+def test_esn_keras_rnn_e2e():
+    inputs = np.random.random((2, 3, 4))
+    targets = np.abs(np.random.random((2, 5)))
+    targets /= targets.sum(axis=-1, keepdims=True)
+    cell = rnn_cell.ESNCell(5)
+    model = keras.models.Sequential()
+    model.add(keras.layers.Masking(input_shape=(3, 4)))
+    model.add(keras.layers.RNN(cell))
+    model.compile(loss="categorical_crossentropy", optimizer="rmsprop")
+    model.fit(inputs, targets, epochs=1, batch_size=2, verbose=1)
+
+
 def test_esn_config():
     cell = rnn_cell.ESNCell(
         units=3,


### PR DESCRIPTION
Part of https://github.com/tensorflow/addons/pull/1809

I have been working with recurrent neural networks. I needed an implementation of Echo State Networks (ESN) for tensorflow. I found some implementations, but none of them was compatible with tensorflow2, so I implemented it. I think it would be great to add ESN to tensorflow_addons so everybody can use it. 

This pull request add the recurrent ESNCell.

> "Echo state networks (ESN) provide an architecture and supervised learning principle for recurrent neural networks (RNNs). The main idea is (i) to drive a random, large, fixed recurrent neural network with the input signal, thereby inducing in each neuron within this "reservoir" network a nonlinear response signal, and (ii) combine a desired output signal by a trainable linear combination of all of these response signals". 
>Herbert Jaeger, Jacobs University Bremen, Bremen, Germany 

<img src="https://tu-dresden.de/ing/elektrotechnik/ias/stks/ressourcen/bilder/forschung/neural-modeling/@@images/63f5b202-a3da-471d-bc11-3c6ee1d81a84.png" alt="Echo state network scheme by Peter Birkholz" width="40%" /><br><br>

**References**

- The “echo state” approach to analysing and training recurrent neural networks-with an erratum note. [Herbert Jaeger](https://scholar.google.de/citations?user=0uztVbMAAAAJ&hl=en), 2001. Cited by 2281. [[pdf]](https://www.researchgate.net/profile/Herbert_Jaeger3/publication/215385037_The_echo_state_approach_to_analysing_and_training_recurrent_neural_networks-with_an_erratum_note'/links/566a003508ae62b05f027be3/The-echo-state-approach-to-analysing-and-training-recurrent-neural-networks-with-an-erratum-note.pdf)
- [ESN implementation for tensorflow 1.12](https://github.com/m-colombo/Tensorflow-EchoStateNetwork)
- ESN implementations for pytorch: [EchoTorch](https://github.com/nschaetti/EchoTorch), [pytorch-esn](https://github.com/stefanonardo/pytorch-esn)


