### PR TITLE
added test for normalize_data_format in keras_utils

### DIFF
--- a/tensorflow_addons/utils/tests/keras_utils_test.py
+++ b/tensorflow_addons/utils/tests/keras_utils_test.py
@@ -22,6 +22,16 @@ import tensorflow as tf
 from tensorflow_addons.utils import keras_utils
 
 
+def test_normalize_data_format():
+    assert keras_utils.normalize_data_format("Channels_Last") == "channels_last"
+    assert keras_utils.normalize_data_format("CHANNELS_FIRST") == "channels_first"
+
+    try:
+        keras_utils.normalize_data_format("invalid")
+    except ValueError:
+        pass
+
+
 def test_normalize_tuple():
     assert (2, 2, 2) == keras_utils.normalize_tuple(2, n=3, name="strides")
     assert (2, 1, 2) == keras_utils.normalize_tuple((2, 1, 2), n=3, name="strides")

--- a/tensorflow_addons/utils/tests/keras_utils_test.py
+++ b/tensorflow_addons/utils/tests/keras_utils_test.py
@@ -26,10 +26,8 @@ def test_normalize_data_format():
     assert keras_utils.normalize_data_format("Channels_Last") == "channels_last"
     assert keras_utils.normalize_data_format("CHANNELS_FIRST") == "channels_first"
 
-    try:
+    with pytest.raises(ValueError, match="The `data_format` argument must be one of"):
         keras_utils.normalize_data_format("invalid")
-    except ValueError:
-        pass
 
 
 def test_normalize_tuple():


### PR DESCRIPTION
Hi,
There was a missing test for a method in tensorflow_addons/utils/keras_utils.py so here it is.