### PR TITLE
Update 0.9 branch release streategy

### DIFF
--- a/.github/workflows/make_wheel_Windows.sh
+++ b/.github/workflows/make_wheel_Windows.sh
@@ -4,11 +4,9 @@ export TF_NEED_CUDA=0
 export BAZEL_VC="C:/Program Files (x86)/Microsoft Visual Studio/2019/Enterprise/VC/"
 
 python -m pip install wheel setuptools tensorflow==$TF_VERSION
-curl -sSOL https://github.com/bazelbuild/bazel/releases/download/${BAZEL_VERSION}/bazel-${BAZEL_VERSION}-windows-x86_64.exe
-export BAZEL_PATH=/d/a/addons/addons/bazel-${BAZEL_VERSION}-windows-x86_64.exe
 bash ./tools/testing/build_and_run_tests.sh
 
-./bazel-${BAZEL_VERSION}-windows-x86_64.exe build \
+bazel.exe build \
   -c opt \
   --enable_runfiles \
   --noshow_progress \

--- a/.github/workflows/make_wheel_macOS.sh
+++ b/.github/workflows/make_wheel_macOS.sh
@@ -5,7 +5,6 @@ export TF_NEED_CUDA=0
 python3 --version
 python3 -m pip install delocate wheel setuptools tensorflow==$TF_VERSION
 
-bash tools/install_deps/bazel_macos.sh $BAZEL_VERSION
 bash tools/testing/build_and_run_tests.sh
 
 bazel build \

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,7 +15,7 @@ on:
       - r*
 
 env:
-  BAZEL_VERSION: 1.1.0
+  BAZEL_VERSION: '1.1.0'
   OLDEST_PY_VERSION: '3.5'
 
 jobs:
@@ -39,8 +39,8 @@ jobs:
     strategy:
       matrix:
         os: ['macos-latest', 'windows-latest', 'ubuntu-18.04']
-        py-version: ['3.5', '3.6', '3.7', '3.8']
-        tf-version: ['2.1.0', '2.2.0rc2']
+        py-version: ['3.5', '3.6', '3.7']
+        tf-version: ['2.1.0', '2.2.0']
       fail-fast: false
     steps:
       - if: github.event_name == 'push'
@@ -49,12 +49,15 @@ jobs:
       - uses: actions/setup-python@v1
         with:
           python-version: ${{ matrix.py-version }}
+      - name: Setup Bazel
+          # Ubuntu bazel is run inside of the docker image
+          if: matrix.os != 'ubuntu-18.04'
+          # MacOS VMs share IP addr on GH actions. This bazel installation authenticates token to prevent api rate limiting.
+          uses: jwlawson/actions-setup-bazel@784af34 # Version 1.1
+          with:
+            bazel-version: ${{ env.BAZEL_VERSION}}
+            github-api-token: ${{ secrets.GITHUB_TOKEN }}
       - name: Build wheels
-        if: |
-          (matrix.os != 'macos-latest' || matrix.py-version != '3.8')
-          && (matrix.py-version != '3.8' || matrix.tf-version != '2.1.0')
-          && (matrix.os != 'ubuntu-18.04' || matrix.tf-version != '2.2.0rc2')
-          && (github.event_name != 'pull_request' || matrix.py-version == env.OLDEST_PY_VERSION)
         env:
           OS: ${{ runner.os }}
           PY_VERSION: ${{ matrix.py-version }}
@@ -62,11 +65,6 @@ jobs:
         shell: bash
         run: bash .github/workflows/make_wheel_${OS}.sh
       - uses: actions/upload-artifact@v1
-        if: |
-          (matrix.os != 'macos-latest' || matrix.py-version != '3.8')
-          && (matrix.py-version != '3.8' || matrix.tf-version != '2.1.0')
-          && (matrix.os != 'ubuntu-18.04' || matrix.tf-version != '2.2.0rc2')
-          && (github.event_name != 'pull_request' || matrix.py-version == env.OLDEST_PY_VERSION)
         with:
           name: ${{ runner.os }}-${{ matrix.py-version }}-tf${{ matrix.tf-version }}-wheel
           path: wheelhouse
@@ -78,27 +76,17 @@ jobs:
       matrix:
         os: ['macos-latest', 'windows-latest', 'ubuntu-18.04']
         py-version: ['3.5', '3.6', '3.7']
-        tf-version: ['2.1.0', '2.2.0rc2']
+        tf-version: ['2.1.0', '2.2.0']
       fail-fast: false
     steps:
       - uses: actions/setup-python@v1
         with:
           python-version: ${{ matrix.py-version }}
       - uses: actions/download-artifact@v1
-        if: |
-          (matrix.os != 'macos-latest' || matrix.py-version != '3.8')
-          && (matrix.py-version != '3.8' || matrix.tf-version != '2.1.0')
-          && (matrix.os != 'ubuntu-18.04' || matrix.tf-version != '2.2.0rc2')
-          && (github.event_name != 'pull_request' || matrix.py-version == env.OLDEST_PY_VERSION)
         with:
           name: ${{ runner.os }}-${{ matrix.py-version }}-tf${{ matrix.tf-version }}-wheel
           path: ./wheel
       - name: Test wheel
-        if: |
-          (matrix.os != 'macos-latest' || matrix.py-version != '3.8')
-          && (matrix.py-version != '3.8' || matrix.tf-version != '2.1.0')
-          && (matrix.os != 'ubuntu-18.04' || matrix.tf-version != '2.2.0rc2')
-          && (github.event_name != 'pull_request' || matrix.py-version == env.OLDEST_PY_VERSION)
         env:
           TF_VERSION: ${{ matrix.tf-version }}
         shell: bash

--- a/tools/docker/build_wheel.Dockerfile
+++ b/tools/docker/build_wheel.Dockerfile
@@ -6,7 +6,7 @@ ENV TF_NEED_CUDA="1"
 RUN apt-get update && apt-get install patchelf
 
 ARG PY_VERSION
-RUN python$PY_VERSION -m pip install --upgrade pip setuptools auditwheel==2.0.0
+RUN python$PY_VERSION -m pip install --upgrade pip==19.0 auditwheel==2.0.0
 
 COPY tools/install_deps/ /install_deps
 ARG TF_VERSION

--- a/tools/install_deps/bazel_macos.sh
+++ b/tools/install_deps/bazel_macos.sh
@@ -1,4 +1,0 @@
-set -e -x
-wget --quiet -nc https://github.com/bazelbuild/bazel/releases/download/${1}/bazel-${1}-installer-darwin-x86_64.sh
-chmod +x bazel-${1}-installer-darwin-x86_64.sh
-./bazel-${1}-installer-darwin-x86_64.sh --user


### PR DESCRIPTION
Combines changes from #1760 and #1762 

* Use Github token for Bazel API requests
* Pin pip to 19.0 during release
* Test against 2.2.0 stable (still build against 2.1.0 though)

Unblocks #1810