### PR TITLE
Fix ill-formatted doc in image

### DIFF
--- a/tensorflow_addons/image/dense_image_warp.py
+++ b/tensorflow_addons/image/dense_image_warp.py
@@ -195,13 +195,13 @@ def dense_image_warp(
     Apply a non-linear warp to the image, where the warp is specified by a
     dense flow field of offset vectors that define the correspondences of
     pixel values in the output image back to locations in the source image.
-    Specifically, the pixel value at output[b, j, i, c] is
-    images[b, j - flow[b, j, i, 0], i - flow[b, j, i, 1], c].
+    Specifically, the pixel value at `output[b, j, i, c]` is
+    `images[b, j - flow[b, j, i, 0], i - flow[b, j, i, 1], c]`.
 
     The locations specified by this formula do not necessarily map to an int
     index. Therefore, the pixel value is obtained by bilinear
     interpolation of the 4 nearest pixels around
-    (b, j - flow[b, j, i, 0], i - flow[b, j, i, 1]). For locations outside
+    `(b, j - flow[b, j, i, 0], i - flow[b, j, i, 1])`. For locations outside
     of the image, we use the nearest pixel values at the image boundary.
 
     PLEASE NOTE: The definition of the flow field above is different from that

--- a/tensorflow_addons/image/distort_image_ops.py
+++ b/tensorflow_addons/image/distort_image_ops.py
@@ -33,8 +33,7 @@ def random_hsv_in_yiq(
     seed: Optional[int] = None,
     name: Optional[str] = None,
 ) -> tf.Tensor:
-    """Adjust hue, saturation, value of an RGB image randomly in YIQ color
-    space.
+    """Adjust hue, saturation, value of an RGB image randomly in YIQ color space.
 
     Equivalent to `adjust_yiq_hsv()` but uses a `delta_h` randomly
     picked in the interval `[-max_delta_hue, max_delta_hue]`, a

--- a/tensorflow_addons/image/resampler_ops.py
+++ b/tensorflow_addons/image/resampler_ops.py
@@ -31,6 +31,7 @@ def resampler(
     """Resamples input data at user defined coordinates.
 
     The resampler currently only supports bilinear interpolation of 2D data.
+
     Args:
       data: Tensor of shape `[batch_size, data_height, data_width,
         data_num_channels]` containing 2D data that will be resampled.

--- a/tensorflow_addons/image/sparse_image_warp.py
+++ b/tensorflow_addons/image/sparse_image_warp.py
@@ -121,22 +121,22 @@ def sparse_image_warp(
     Apply a non-linear warp to the image, where the warp is specified by
     the source and destination locations of a (potentially small) number of
     control points. First, we use a polyharmonic spline
-    (`tf.contrib.image.interpolate_spline`) to interpolate the displacements
+    (`tfa.image.interpolate_spline`) to interpolate the displacements
     between the corresponding control points to a dense flow field.
     Then, we warp the image using this dense flow field
-    (`tf.contrib.image.dense_image_warp`).
+    (`tfa.image.dense_image_warp`).
 
-    Let t index our control points. For regularization_weight=0, we have:
+    Let t index our control points. For `regularization_weight = 0`, we have:
     warped_image[b, dest_control_point_locations[b, t, 0],
                     dest_control_point_locations[b, t, 1], :] =
     image[b, source_control_point_locations[b, t, 0],
              source_control_point_locations[b, t, 1], :].
 
-    For regularization_weight > 0, this condition is met approximately, since
+    For `regularization_weight > 0`, this condition is met approximately, since
     regularized interpolation trades off smoothness of the interpolant vs.
     reconstruction of the interpolant at the control points.
-    See `tf.contrib.image.interpolate_spline` for further documentation of the
-    interpolation_order and regularization_weight arguments.
+    See `tfa.image.interpolate_spline` for further documentation of the
+    `interpolation_order` and `regularization_weight` arguments.
 
 
     Args:


### PR DESCRIPTION
- [tfa.image.random_hsv_in_yiq](https://www.tensorflow.org/addons/api_docs/python/tfa/image/random_hsv_in_yiq): "space" is in the next line.
- [tfa.image.resampler](https://www.tensorflow.org/addons/api_docs/python/tfa/image/resampler): miss an empty line so the doc is not rendered correctly.
- [tfa.image.sparse_image_warp](https://www.tensorflow.org/addons/api_docs/python/tfa/image/sparse_image_warp): change `tf.contrib` to `tfa`.
- [tfa.image.dense_image_warp](https://www.tensorflow.org/addons/api_docs/python/tfa/image/dense_image_warp): use `` to improve the readability. 