### PR TITLE
Remove squadrick from subpackage CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -4,12 +4,12 @@
 # Subpackage Owners
 
 /tensorflow_addons/activations/ @facaiy @seanpmorgan
-/tensorflow_addons/callbacks/ @squadrick @shun-lin
+/tensorflow_addons/callbacks/ @shun-lin
 /tensorflow_addons/image/ @windqaq @facaiy
 /tensorflow_addons/layers/ @seanpmorgan @facaiy
 /tensorflow_addons/losses/ @facaiy @windqaq
-/tensorflow_addons/metrics/ @squadrick
-/tensorflow_addons/optimizers/ @facaiy @windqaq @squadrick
+/tensorflow_addons/metrics/
+/tensorflow_addons/optimizers/ @facaiy @windqaq
 /tensorflow_addons/rnn/ @qlzh727
 /tensorflow_addons/seq2seq/ @qlzh727 @guillaumekln
 /tensorflow_addons/text/ @seanpmorgan @facaiy


### PR DESCRIPTION
`metrics` is currently without any owners.

cc @tensorflow/sig-addons-maintainers 
