### PR TITLE
Enable some compiler optimization tricks for correlation cost GPU ops

### DIFF
--- a/tensorflow_addons/custom_ops/layers/cc/kernels/correlation_cost_op_gpu.cu.cc
+++ b/tensorflow_addons/custom_ops/layers/cc/kernels/correlation_cost_op_gpu.cu.cc
@@ -20,6 +20,7 @@ limitations under the License.
 #include "gpu/cub/device/device_reduce.cuh"
 #include "tensorflow/core/framework/tensor.h"
 #include "tensorflow/core/framework/tensor_shape.h"
+#include "tensorflow/core/util/gpu_device_functions.h"
 #include "tensorflow/core/util/tensor_format.h"
 #include "tensorflow_addons/custom_ops/layers/cc/kernels/correlation_cost_op.h"
 
@@ -41,8 +42,9 @@ https://github.com/NVIDIA/flownet2-pytorch
 */
 
 template <unsigned int THREADS_PER_BLOCK>
-__global__ void pad_and_transpose(const float *input, float *output, int C,
-                                  int H, int W, int P) {
+__global__ void pad_and_transpose(const float* __restrict__ input,
+                                  float* __restrict__ output, int C, int H,
+                                  int W, int P) {
   // NCHW -> pad(NHWC)
   const int n = blockIdx.x;
   const int h = blockIdx.y;
@@ -51,16 +53,16 @@ __global__ void pad_and_transpose(const float *input, float *output, int C,
   const int pW = (W + 2 * P);
   const int pH = (H + 2 * P);
 
-  float value;
   for (int c = c0; c < C; c += THREADS_PER_BLOCK) {
-    value = input[n * (C * H * W) + c * (H * W) + h * W + w];
-    output[n * (C * pH * pW) + (h + P) * (pW * C) + (w + P) * C + c] = value;
+    output[n * (C * pH * pW) + (h + P) * (pW * C) + (w + P) * C + c] =
+        ldg(input + (n * (C * H * W) + c * (H * W) + h * W + w));
   }
 }
 
 template <unsigned int THREADS_PER_BLOCK>
-__global__ void pad_and_no_transpose(const float *input, float *output, int C,
-                                     int H, int W, int P) {
+__global__ void pad_and_no_transpose(const float* __restrict__ input,
+                                     float* __restrict__ output, int C, int H,
+                                     int W, int P) {
   // NHWC -> pad(NHWC)
   const int n = blockIdx.x;
   const int h = blockIdx.y;
@@ -69,19 +71,20 @@ __global__ void pad_and_no_transpose(const float *input, float *output, int C,
   const int pW = (W + 2 * P);
   const int pH = (H + 2 * P);
 
-  float value;
   for (int c = c0; c < C; c += THREADS_PER_BLOCK) {
-    value = input[n * (C * H * W) + h * (W * C) + w * C + c];
-    output[n * (C * pH * pW) + (h + P) * (pW * C) + (w + P) * C + c] = value;
+    output[n * (C * pH * pW) + (h + P) * (pW * C) + (w + P) * C + c] =
+        ldg(input + (n * (C * H * W) + h * (W * C) + w * C + c));
   }
 }
 
 template <unsigned int THREADS_PER_BLOCK>
-__global__ void Correlation_forward(float *output, int Cout, int Hout, int Wout,
-                                    float *pInput1, int Cin, int Hin, int Win,
-                                    float *pInput2, int pad, int kernel_size,
-                                    int max_displacement, int stride1,
-                                    int stride2) {
+__global__ void Correlation_forward(float* __restrict__ output, int Cout,
+                                    int Hout, int Wout,
+                                    float* __restrict__ pInput1, int Cin,
+                                    int Hin, int Win,
+                                    float* __restrict__ pInput2, int pad,
+                                    int kernel_size, int max_displacement,
+                                    int stride1, int stride2) {
   const int pWin = Win + 2 * pad;
   const int pHin = Hin + 2 * pad;
 
@@ -113,7 +116,7 @@ __global__ void Correlation_forward(float *output, int Cout, int Hout, int Wout,
                               (h1 + j) * (pWin * Cin) + (w1 + i) * Cin + ch;
             const int indx2 = n * (pHin * pWin * Cin) +
                               (h2 + j) * (pWin * Cin) + (w2 + i) * Cin + ch;
-            thread_accumulation += pInput1[indx1] * pInput2[indx2];
+            thread_accumulation += ldg(pInput1 + indx1) * ldg(pInput2 + indx2);
           }
         }
       }
@@ -135,10 +138,10 @@ __global__ void Correlation_forward(float *output, int Cout, int Hout, int Wout,
 
 template <unsigned int THREADS_PER_BLOCK>
 __global__ void Correlation_backward_input1(
-    int item, float *gradInput1, int Cin, int Hin, int Win,
-    const float *gradOutput, int Cout, int Hout, int Wout, const float *rInput2,
-    int pad_size, int kernel_size, int max_displacement, int stride1,
-    int stride2, bool is_NCHW) {
+    int item, float* __restrict__ gradInput1, int Cin, int Hin, int Win,
+    const float* __restrict__ gradOutput, int Cout, int Hout, int Wout,
+    const float* __restrict__ rInput2, int pad_size, int kernel_size,
+    int max_displacement, int stride1, int stride2, bool is_NCHW) {
   const int n = item;
   const int h = blockIdx.x * stride1 + pad_size;
   const int w = blockIdx.y * stride1 + pad_size;
@@ -186,13 +189,13 @@ __global__ void Correlation_backward_input1(
     int indx2 =
         n * (pHin * pWin * Cin) + (h + j2) * (pWin * Cin) + (w + i2) * Cin + c;
 
-    float val2 = rInput2[indx2];
+    float val2 = ldg(rInput2 + indx2);
 
     for (int j = Hmin; j <= Hmax; ++j) {
       for (int i = Wmin; i <= Wmax; ++i) {
         const int tindx =
             n * (Cout * Hout * Wout) + tc * (Hout * Wout) + j * Wout + i;
-        thread_accumulation += gradOutput[tindx] * val2;
+        thread_accumulation += ldg(gradOutput + tindx) * val2;
       }
     }
   }
@@ -216,10 +219,10 @@ __global__ void Correlation_backward_input1(
 
 template <unsigned int THREADS_PER_BLOCK>
 __global__ void Correlation_backward_input2(
-    int item, float *gradInput2, int Cin, int Hin, int Win,
-    const float *gradOutput, int Cout, int Hout, int Wout, const float *rInput1,
-    int pad_size, int kernel_size, int max_displacement, int stride1,
-    int stride2, bool is_NCHW) {
+    int item, float* __restrict__ gradInput2, int Cin, int Hin, int Win,
+    const float* __restrict__ gradOutput, int Cout, int Hout, int Wout,
+    const float* __restrict__ rInput1, int pad_size, int kernel_size,
+    int max_displacement, int stride1, int stride2, bool is_NCHW) {
   const int n = item;
   const int h = blockIdx.x * stride1 + pad_size;
   const int w = blockIdx.y * stride1 + pad_size;
@@ -242,11 +245,11 @@ __global__ void Correlation_backward_input2(
     const int i2 = (tc % displacement_size - displacement_rad) * stride2;
     const int j2 = (tc / displacement_size - displacement_rad) * stride2;
 
-    int Wmin = (w - kernel_rad - max_displacement - i2) / stride1;
-    int Hmin = (h - kernel_rad - max_displacement - j2) / stride1;
+    const int Wmin = (w - kernel_rad - max_displacement - i2) / stride1;
+    const int Hmin = (h - kernel_rad - max_displacement - j2) / stride1;
 
-    int Wmax = (w + kernel_rad - max_displacement - i2) / stride1;
-    int Hmax = (h + kernel_rad - max_displacement - j2) / stride1;
+    const int Wmax = (w + kernel_rad - max_displacement - i2) / stride1;
+    const int Hmax = (h + kernel_rad - max_displacement - j2) / stride1;
 
     if (Wmax < 0 || Hmax < 0 || Wmin >= Wout || Hmin >= Hout) {
       // assumes gradInput2 is pre-allocated and zero filled
@@ -266,13 +269,13 @@ __global__ void Correlation_backward_input2(
 
     const int indx1 =
         n * (pHin * pWin * Cin) + (h - j2) * (pWin * Cin) + (w - i2) * Cin + c;
-    const float val1 = rInput1[indx1];
+    const float val1 = ldg(rInput1 + indx1);
 
     for (int j = Hmin; j <= Hmax; ++j) {
       for (int i = Wmin; i <= Wmax; ++i) {
         const int tindx =
             n * (Cout * Hout * Wout) + tc * (Hout * Wout) + j * Wout + i;
-        thread_accumulation += gradOutput[tindx] * val1;
+        thread_accumulation += ldg(gradOutput + tindx) * val1;
       }
     }
   }
@@ -297,8 +300,8 @@ __global__ void Correlation_backward_input2(
 
 template <typename Dtype>
 struct CorrelationCostFunctor<GPUDevice, Dtype> {
-  Status operator()(OpKernelContext *context, const Tensor &input_a_t,
-                    const Tensor &input_b_t, Tensor *output_t,
+  Status operator()(OpKernelContext* context, const Tensor& input_a_t,
+                    const Tensor& input_b_t, Tensor* output_t,
                     /* params */
                     int kernel_size, int max_displacement, int stride_1,
                     int stride_2, int pad, TensorFormat data_format) {
@@ -313,17 +316,10 @@ struct CorrelationCostFunctor<GPUDevice, Dtype> {
     Tensor padded_a_t;
     Tensor padded_b_t;
     TensorShape padded_shape({N, iH + 2 * pad, iW + 2 * pad, iC});
-    Status s;
-    s = context->allocate_temp(DataTypeToEnum<Dtype>::value, padded_shape,
-                               &padded_a_t);
-    if (!TF_PREDICT_TRUE(s.ok())) {
-      return s;
-    }
-    s = context->allocate_temp(DataTypeToEnum<Dtype>::value, padded_shape,
-                               &padded_b_t);
-    if (!TF_PREDICT_TRUE(s.ok())) {
-      return s;
-    }
+    OP_REQUIRES_OK(context, context->allocate_temp(DataTypeToEnum<Dtype>::v(),
+                                                   padded_shape, &padded_a_t));
+    OP_REQUIRES_OK(context, context->allocate_temp(DataTypeToEnum<Dtype>::v(),
+                                                   padded_shape, &padded_b_t));
 
     dim3 blocks_grid(N, iH, iW);
     dim3 threads_block(THREADS_PER_BLOCK);
@@ -334,12 +330,9 @@ struct CorrelationCostFunctor<GPUDevice, Dtype> {
     const int32 oW = GetTensorDim(*output_t, FORMAT_NCHW, 'W');
 
     // set everything to zero (we zero-pad)
-    cudaMemset(padded_a_t.flat<Dtype>().data(), 0,
-               padded_a_t.NumElements() * sizeof(Dtype));
-    cudaMemset(padded_b_t.flat<Dtype>().data(), 0,
-               padded_b_t.NumElements() * sizeof(Dtype));
-    cudaMemset(output_t->flat<Dtype>().data(), 0,
-               output_t->NumElements() * sizeof(Dtype));
+    padded_a_t.flat<Dtype>().setZero();
+    padded_b_t.flat<Dtype>().setZero();
+    output_t->flat<Dtype>().setZero();
 
     const bool is_NCHW = (data_format == FORMAT_NCHW);
     if (is_NCHW) {
@@ -358,7 +351,7 @@ struct CorrelationCostFunctor<GPUDevice, Dtype> {
           iH, iW, pad);
     }
 
-    const GPUDevice &d = context->eigen_gpu_device();
+    const GPUDevice& d = context->eigen_gpu_device();
 
     dim3 threadsPerBlock(THREADS_PER_BLOCK);
     dim3 totalBlocksCorr(N, oH, oW);
@@ -376,9 +369,9 @@ struct CorrelationCostFunctor<GPUDevice, Dtype> {
 
 template <typename Dtype>
 struct CorrelationCostGradFunctor<GPUDevice, Dtype> {
-  Status operator()(OpKernelContext *context, const Tensor &input_a_t,
-                    const Tensor &input_b_t, const Tensor &topdiff_t,
-                    Tensor *output_a_gradient_t, Tensor *output_b_gradient_t,
+  Status operator()(OpKernelContext* context, const Tensor& input_a_t,
+                    const Tensor& input_b_t, const Tensor& topdiff_t,
+                    Tensor* output_a_gradient_t, Tensor* output_b_gradient_t,
                     /* params */
                     int kernel_size, int max_displacement, int stride_1,
                     int stride_2, int pad, TensorFormat data_format) {
@@ -393,17 +386,10 @@ struct CorrelationCostGradFunctor<GPUDevice, Dtype> {
     Tensor padded_a_t;
     Tensor padded_b_t;
     TensorShape padded_shape({N, iH + 2 * pad, iW + 2 * pad, iC});
-    Status s;
-    s = context->allocate_temp(DataTypeToEnum<Dtype>::value, padded_shape,
-                               &padded_a_t);
-    if (!TF_PREDICT_TRUE(s.ok())) {
-      return s;
-    }
-    s = context->allocate_temp(DataTypeToEnum<Dtype>::value, padded_shape,
-                               &padded_b_t);
-    if (!TF_PREDICT_TRUE(s.ok())) {
-      return s;
-    }
+    OP_REQUIRES_OK(context, context->allocate_temp(DataTypeToEnum<Dtype>::v(),
+                                                   padded_shape, &padded_a_t));
+    OP_REQUIRES_OK(context, context->allocate_temp(DataTypeToEnum<Dtype>::v(),
+                                                   padded_shape, &padded_b_t));
 
     dim3 blocks_grid(N, iH, iW);
     dim3 threads_block(THREADS_PER_BLOCK);
@@ -414,14 +400,10 @@ struct CorrelationCostGradFunctor<GPUDevice, Dtype> {
     const int32 oW = GetTensorDim(topdiff_t, FORMAT_NCHW, 'W');
 
     // set everything to zero (we zero-pad)
-    cudaMemset(padded_a_t.flat<Dtype>().data(), 0,
-               padded_a_t.NumElements() * sizeof(Dtype));
-    cudaMemset(padded_b_t.flat<Dtype>().data(), 0,
-               padded_b_t.NumElements() * sizeof(Dtype));
-    cudaMemset(output_a_gradient_t->flat<Dtype>().data(), 0,
-               output_a_gradient_t->NumElements() * sizeof(Dtype));
-    cudaMemset(output_b_gradient_t->flat<Dtype>().data(), 0,
-               output_b_gradient_t->NumElements() * sizeof(Dtype));
+    padded_a_t.flat<Dtype>().setZero();
+    padded_b_t.flat<Dtype>().setZero();
+    output_a_gradient_t->flat<Dtype>().setZero();
+    output_b_gradient_t->flat<Dtype>().setZero();
 
     const bool is_NCHW = (data_format == FORMAT_NCHW);
     if (is_NCHW) {
@@ -440,7 +422,7 @@ struct CorrelationCostGradFunctor<GPUDevice, Dtype> {
           iH, iW, pad);
     }
 
-    const GPUDevice &d = context->eigen_gpu_device();
+    const GPUDevice& d = context->eigen_gpu_device();
 
     dim3 threadsPerBlock(THREADS_PER_BLOCK);
     dim3 totalBlocksCorr(iH, iW, iC);

--- a/tensorflow_addons/custom_ops/layers/cc/kernels/correlation_cost_op_gpu.cu.cc
+++ b/tensorflow_addons/custom_ops/layers/cc/kernels/correlation_cost_op_gpu.cu.cc
@@ -20,7 +20,7 @@ limitations under the License.
 #include "gpu/cub/device/device_reduce.cuh"
 #include "tensorflow/core/framework/tensor.h"
 #include "tensorflow/core/framework/tensor_shape.h"
-#include "tensorflow/core/util/gpu_device_functions.h"
+#include "tensorflow/core/util/gpu_kernel_helper.h"
 #include "tensorflow/core/util/tensor_format.h"
 #include "tensorflow_addons/custom_ops/layers/cc/kernels/correlation_cost_op.h"
 

--- a/tensorflow_addons/custom_ops/layers/cc/kernels/correlation_cost_op_gpu.cu.cc
+++ b/tensorflow_addons/custom_ops/layers/cc/kernels/correlation_cost_op_gpu.cu.cc
@@ -245,11 +245,11 @@ __global__ void Correlation_backward_input2(
     const int i2 = (tc % displacement_size - displacement_rad) * stride2;
     const int j2 = (tc / displacement_size - displacement_rad) * stride2;
 
-    const int Wmin = (w - kernel_rad - max_displacement - i2) / stride1;
-    const int Hmin = (h - kernel_rad - max_displacement - j2) / stride1;
+    int Wmin = (w - kernel_rad - max_displacement - i2) / stride1;
+    int Hmin = (h - kernel_rad - max_displacement - j2) / stride1;
 
-    const int Wmax = (w + kernel_rad - max_displacement - i2) / stride1;
-    const int Hmax = (h + kernel_rad - max_displacement - j2) / stride1;
+    int Wmax = (w + kernel_rad - max_displacement - i2) / stride1;
+    int Hmax = (h + kernel_rad - max_displacement - j2) / stride1;
 
     if (Wmax < 0 || Hmax < 0 || Wmin >= Wout || Hmin >= Hout) {
       // assumes gradInput2 is pre-allocated and zero filled

--- a/tensorflow_addons/custom_ops/layers/cc/kernels/correlation_cost_op_gpu.cu.cc
+++ b/tensorflow_addons/custom_ops/layers/cc/kernels/correlation_cost_op_gpu.cu.cc
@@ -316,10 +316,10 @@ struct CorrelationCostFunctor<GPUDevice, Dtype> {
     Tensor padded_a_t;
     Tensor padded_b_t;
     TensorShape padded_shape({N, iH + 2 * pad, iW + 2 * pad, iC});
-    OP_REQUIRES_OK(context, context->allocate_temp(DataTypeToEnum<Dtype>::v(),
-                                                   padded_shape, &padded_a_t));
-    OP_REQUIRES_OK(context, context->allocate_temp(DataTypeToEnum<Dtype>::v(),
-                                                   padded_shape, &padded_b_t));
+    TF_RETURN_IF_ERROR(context->allocate_temp(DataTypeToEnum<Dtype>::v(),
+                                              padded_shape, &padded_a_t));
+    TF_RETURN_IF_ERROR(context->allocate_temp(DataTypeToEnum<Dtype>::v(),
+                                              padded_shape, &padded_b_t));
 
     dim3 blocks_grid(N, iH, iW);
     dim3 threads_block(THREADS_PER_BLOCK);
@@ -386,10 +386,10 @@ struct CorrelationCostGradFunctor<GPUDevice, Dtype> {
     Tensor padded_a_t;
     Tensor padded_b_t;
     TensorShape padded_shape({N, iH + 2 * pad, iW + 2 * pad, iC});
-    OP_REQUIRES_OK(context, context->allocate_temp(DataTypeToEnum<Dtype>::v(),
-                                                   padded_shape, &padded_a_t));
-    OP_REQUIRES_OK(context, context->allocate_temp(DataTypeToEnum<Dtype>::v(),
-                                                   padded_shape, &padded_b_t));
+    TF_RETURN_IF_ERROR(context->allocate_temp(DataTypeToEnum<Dtype>::v(),
+                                              padded_shape, &padded_a_t));
+    TF_RETURN_IF_ERROR(context->allocate_temp(DataTypeToEnum<Dtype>::v(),
+                                              padded_shape, &padded_b_t));
 
     dim3 blocks_grid(N, iH, iW);
     dim3 threads_block(THREADS_PER_BLOCK);


### PR DESCRIPTION
- apply `ldg` to read data.
- add `__restrict__` qualifier to pointer.