### PR TITLE
Increase default pip timeout to improve CI reliability

### DIFF
--- a/.github/workflows/ci_test.yml
+++ b/.github/workflows/ci_test.yml
@@ -78,7 +78,7 @@ jobs:
         with:
           python-version: 3.5
       - uses: actions/checkout@v2
-      - run: pip install -r tools/install_deps/tensorflow-cpu.txt -r tools/install_deps/pytest.txt
+      - run: pip install --default-timeout=1000 -r tools/install_deps/tensorflow-cpu.txt -r tools/install_deps/pytest.txt
       - run: pip install -e ./
       - run: pytest -v -n auto --skip-custom-ops ./tensorflow_addons
   test_cpu_in_small_docker_image:

--- a/.github/workflows/make_wheel_Windows.sh
+++ b/.github/workflows/make_wheel_Windows.sh
@@ -3,7 +3,7 @@ set -e -x
 export TF_NEED_CUDA=0
 export BAZEL_VC="C:/Program Files (x86)/Microsoft Visual Studio/2019/Enterprise/VC/"
 
-python -m pip install wheel setuptools tensorflow==$TF_VERSION
+python -m pip install --default-timeout=1000 wheel setuptools tensorflow==$TF_VERSION
 bash ./tools/testing/build_and_run_tests.sh
 
 bazel.exe build \

--- a/.github/workflows/make_wheel_macOS.sh
+++ b/.github/workflows/make_wheel_macOS.sh
@@ -3,7 +3,7 @@ set -e -x
 export TF_NEED_CUDA=0
 
 python --version
-python -m pip install delocate wheel setuptools tensorflow==$TF_VERSION
+python -m pip install --default-timeout=1000 delocate wheel setuptools tensorflow==$TF_VERSION
 
 bash tools/testing/build_and_run_tests.sh
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -30,7 +30,7 @@ jobs:
           python-version: ${{ env.MIN_PY_VERSION }}
       - name: Build wheels
         run: |
-          pip install -r tools/install_deps/pytest.txt -r tools/install_deps/tensorflow-cpu.txt -r requirements.txt
+          pip install --default-timeout=1000 -r tools/install_deps/pytest.txt -r tools/install_deps/tensorflow-cpu.txt -r requirements.txt
           bash tools/install_deps/bazel_linux.sh
           python configure.py
           bazel test -c opt -k --test_timeout 300,450,1200,3600 --test_output=errors //tensorflow_addons/...

--- a/tools/docker/build_wheel.Dockerfile
+++ b/tools/docker/build_wheel.Dockerfile
@@ -26,7 +26,7 @@ RUN ln -sf $(which python$PY_VERSION) /usr/bin/python
 RUN python -m pip install --upgrade pip==19.0 auditwheel==2.0.0
 
 ARG TF_VERSION
-RUN python -m pip install tensorflow==$TF_VERSION
+RUN python -m pip install --default-timeout=1000 tensorflow==$TF_VERSION
 
 COPY tools/install_deps/ /install_deps
 RUN python -m pip install -r /install_deps/pytest.txt
@@ -67,7 +67,7 @@ RUN ls -al wheelhouse/
 FROM python:$PY_VERSION as test_wheel_in_fresh_environment
 
 ARG TF_VERSION
-RUN python -m pip install tensorflow==$TF_VERSION
+RUN python -m pip install --default-timeout=1000 tensorflow==$TF_VERSION
 
 COPY --from=make_wheel /addons/wheelhouse/ /addons/wheelhouse/
 RUN pip install /addons/wheelhouse/*.whl

--- a/tools/docker/cpu_tests.Dockerfile
+++ b/tools/docker/cpu_tests.Dockerfile
@@ -2,7 +2,7 @@
 FROM python:3.5 as build_wheel
 
 ARG TF_VERSION=2.2.0
-RUN pip install tensorflow-cpu==$TF_VERSION
+RUN pip install --default-timeout=1000 tensorflow-cpu==$TF_VERSION
 
 RUN apt-get update && apt-get install -y sudo rsync
 COPY tools/install_deps/bazel_linux.sh ./
@@ -29,7 +29,7 @@ RUN bazel-bin/build_pip_pkg artifacts
 FROM python:3.5
 
 COPY tools/install_deps/tensorflow-cpu.txt ./
-RUN pip install -r tensorflow-cpu.txt
+RUN pip install --default-timeout=1000 -r tensorflow-cpu.txt
 
 COPY --from=0 /addons/artifacts /artifacts
 

--- a/tools/docker/sanity_check.Dockerfile
+++ b/tools/docker/sanity_check.Dockerfile
@@ -23,6 +23,7 @@ FROM python:3.6 as source_code_test
 COPY tools/install_deps /install_deps
 RUN --mount=type=cache,id=cache_pip,target=/root/.cache/pip \
     cd /install_deps && pip install \
+    --default-timeout=1000 \
     -r tensorflow-cpu.txt \
     -r typedapi.txt \
     -r pytest.txt
@@ -36,7 +37,7 @@ RUN touch /ok.txt
 FROM python:3.5 as valid_build_files
 
 COPY tools/install_deps/tensorflow-cpu.txt ./
-RUN pip install -r tensorflow-cpu.txt
+RUN pip install --default-timeout=1000 -r tensorflow-cpu.txt
 
 RUN apt-get update && apt-get install sudo
 COPY tools/install_deps/bazel_linux.sh ./
@@ -81,7 +82,7 @@ RUN touch /ok.txt
 FROM python:3.6 as docs_tests
 
 COPY tools/install_deps/tensorflow-cpu.txt ./
-RUN pip install -r tensorflow-cpu.txt
+RUN pip install --default-timeout=1000 -r tensorflow-cpu.txt
 COPY requirements.txt ./
 RUN pip install -r requirements.txt
 
@@ -101,7 +102,7 @@ RUN touch /ok.txt
 FROM python:3.6 as test_editable_mode
 
 COPY tools/install_deps/tensorflow-cpu.txt ./
-RUN pip install -r tensorflow-cpu.txt
+RUN pip install --default-timeout=1000 -r tensorflow-cpu.txt
 COPY requirements.txt ./
 RUN pip install -r requirements.txt
 COPY tools/install_deps/pytest.txt ./


### PR DESCRIPTION
It seems that just about every PR we have fails once or twice due to "connection reset by peer" while pip installing TF. Certainly related to GitHub action CI, but a possible fix may be to increase the default timeout as suggested here:
https://github.com/pypa/pypi-support/issues/175#issuecomment-578834580