### PR TITLE
Ensure cell state structure is unchanged on first AttentionWrapper call

### DIFF
--- a/tensorflow_addons/seq2seq/attention_wrapper.py
+++ b/tensorflow_addons/seq2seq/attention_wrapper.py
@@ -2046,6 +2046,9 @@ class AttentionWrapper(tf.keras.layers.AbstractRNNCell):
         cell_inputs = self._cell_input_fn(inputs, state.attention)
         cell_state = state.cell_state
         cell_output, next_cell_state = self._cell(cell_inputs, cell_state, **kwargs)
+        next_cell_state = tf.nest.pack_sequence_as(
+            cell_state, tf.nest.flatten(next_cell_state)
+        )
 
         cell_batch_size = (
             tf.compat.dimension_value(cell_output.shape[0]) or tf.shape(cell_output)[0]

--- a/tensorflow_addons/seq2seq/tests/attention_wrapper_test.py
+++ b/tensorflow_addons/seq2seq/tests/attention_wrapper_test.py
@@ -920,3 +920,15 @@ def test_attention_state_with_variable_length_input():
     layer = tf.keras.layers.RNN(cell)
 
     _ = layer(data, mask=mask)
+
+
+def test_attention_wrapper_with_gru_cell():
+    mechanism = wrapper.LuongAttention(units=3)
+    cell = tf.keras.layers.GRUCell(3)
+    cell = wrapper.AttentionWrapper(cell, mechanism)
+    memory = tf.ones([2, 5, 3])
+    inputs = tf.ones([2, 3])
+    mechanism.setup_memory(memory)
+    initial_state = cell.get_initial_state(inputs=inputs)
+    _, state = cell(inputs, initial_state)
+    tf.nest.assert_same_structure(initial_state, state)


### PR DESCRIPTION
Some RNN cells such as `GRUCell` and `SimpleRNNCell` do not return the same state structure in `get_initial_state` and in the `call` method.

This PR ensures that the returned state structure always matches the initial structure.

Fixes #1856.