### PR TITLE
Remove manual type checks and fix some annotations

### DIFF
--- a/tensorflow_addons/seq2seq/attention_wrapper.py
+++ b/tensorflow_addons/seq2seq/attention_wrapper.py
@@ -1619,7 +1619,7 @@ class AttentionWrapper(tf.keras.layers.AbstractRNNCell):
     def __init__(
         self,
         cell: tf.keras.layers.Layer,
-        attention_mechanism: Union[tf.keras.layers.Layer, List[tf.keras.layers.Layer]],
+        attention_mechanism: Union[AttentionMechanism, List[AttentionMechanism]],
         attention_layer_size: Optional[Union[Number, List[Number]]] = None,
         alignment_history: bool = False,
         cell_input_fn: Optional[Callable] = None,
@@ -1728,34 +1728,14 @@ class AttentionWrapper(tf.keras.layers.AbstractRNNCell):
         if isinstance(attention_mechanism, (list, tuple)):
             self._is_multi = True
             attention_mechanisms = list(attention_mechanism)
-            for attention_mechanism in attention_mechanisms:
-                if not isinstance(attention_mechanism, AttentionMechanism):
-                    raise TypeError(
-                        "attention_mechanism must contain only instances of "
-                        "AttentionMechanism, saw type: %s"
-                        % type(attention_mechanism).__name__
-                    )
         else:
             self._is_multi = False
-            if not isinstance(attention_mechanism, AttentionMechanism):
-                raise TypeError(
-                    "attention_mechanism must be an AttentionMechanism or "
-                    "list of multiple AttentionMechanism instances, saw type: "
-                    "%s" % type(attention_mechanism).__name__
-                )
             attention_mechanisms = [attention_mechanism]
 
         if cell_input_fn is None:
 
             def cell_input_fn(inputs, attention):
                 return tf.concat([inputs, attention], -1)
-
-        else:
-            if not callable(cell_input_fn):
-                raise TypeError(
-                    "cell_input_fn must be callable, saw type: %s"
-                    % type(cell_input_fn).__name__
-                )
 
         if attention_layer_size is not None and attention_layer is not None:
             raise ValueError(

--- a/tensorflow_addons/seq2seq/basic_decoder.py
+++ b/tensorflow_addons/seq2seq/basic_decoder.py
@@ -58,14 +58,6 @@ class BasicDecoder(decoder.BaseDecoder):
           type.
         """
         keras_utils.assert_like_rnncell("cell", cell)
-        if not isinstance(sampler, sampler_py.Sampler):
-            raise TypeError("sampler must be a Sampler, received: {}".format(sampler))
-        if output_layer is not None and not isinstance(
-            output_layer, tf.keras.layers.Layer
-        ):
-            raise TypeError(
-                "output_layer must be a Layer, received: {}".format(output_layer)
-            )
         self.cell = cell
         self.sampler = sampler
         self.output_layer = output_layer

--- a/tensorflow_addons/seq2seq/beam_search_decoder.py
+++ b/tensorflow_addons/seq2seq/beam_search_decoder.py
@@ -26,7 +26,7 @@ from tensorflow_addons.utils.resource_loader import LazySO
 from tensorflow_addons.utils.types import FloatTensorLike, TensorLike
 
 from typeguard import typechecked
-from typing import Callable, Optional, Union
+from typing import Callable, Optional
 
 _beam_search_so = LazySO("custom_ops/seq2seq/_beam_search_ops.so")
 
@@ -285,12 +285,6 @@ class BeamSearchDecoderMixin:
             or `output_layer` is not an instance of `tf.keras.layers.Layer`.
         """
         keras_utils.assert_like_rnncell("cell", cell)
-        if output_layer is not None and not isinstance(
-            output_layer, tf.keras.layers.Layer
-        ):
-            raise TypeError(
-                "output_layer must be a Layer, received: %s" % type(output_layer)
-            )
         self._cell = cell
         self._output_layer = output_layer
         self._reorder_tensor_arrays = reorder_tensor_arrays
@@ -658,7 +652,7 @@ class BeamSearchDecoder(BeamSearchDecoderMixin, decoder.BaseDecoder):
         self,
         cell: tf.keras.layers.Layer,
         beam_width: int,
-        embedding_fn: Union[TensorLike, Callable, None] = None,
+        embedding_fn: Optional[Callable] = None,
         output_layer: Optional[tf.keras.layers.Layer] = None,
         length_penalty_weight: FloatTensorLike = 0.0,
         coverage_penalty_weight: FloatTensorLike = 0.0,
@@ -701,12 +695,7 @@ class BeamSearchDecoder(BeamSearchDecoderMixin, decoder.BaseDecoder):
             **kwargs,
         )
 
-        if embedding_fn is None or callable(embedding_fn):
-            self._embedding_fn = embedding_fn
-        else:
-            raise ValueError(
-                "embedding_fn is expected to be a callable, got %s" % type(embedding_fn)
-            )
+        self._embedding_fn = embedding_fn
 
     def initialize(self, embedding, start_tokens, end_token, initial_state):
         """Initialize the decoder.


### PR DESCRIPTION
We can rely on `@typechecked` to run the checks for us.

This PR also fixes some type annotations that did not match the implementation, especially regarding callables.