### PR TITLE
Update shape usage to TensorFlow 2 style

### DIFF
--- a/tensorflow_addons/seq2seq/decoder.py
+++ b/tensorflow_addons/seq2seq/decoder.py
@@ -320,7 +320,7 @@ def dynamic_decode(
             maximum_iterations = tf.convert_to_tensor(
                 maximum_iterations, dtype=tf.int32, name="maximum_iterations"
             )
-            if maximum_iterations.get_shape().ndims != 0:
+            if maximum_iterations.shape.ndims != 0:
                 raise ValueError("maximum_iterations must be a scalar")
 
         if isinstance(decoder, Decoder):

--- a/tensorflow_addons/seq2seq/loss.py
+++ b/tensorflow_addons/seq2seq/loss.py
@@ -90,12 +90,12 @@ def sequence_loss(
       ValueError: logits does not have 3 dimensions or targets does not have 2
                   dimensions or weights does not have 2 dimensions.
     """
-    if len(logits.get_shape()) != 3:
+    if len(logits.shape) != 3:
         raise ValueError(
             "Logits must be a " "[batch_size x sequence_length x logits] tensor"
         )
 
-    targets_rank = len(targets.get_shape())
+    targets_rank = len(targets.shape)
     if targets_rank != 2 and targets_rank != 3:
         raise ValueError(
             "Targets must be either a [batch_size x sequence_length] tensor "
@@ -104,7 +104,7 @@ def sequence_loss(
             + "where the third axis is a one-hot representation of the labels"
         )
 
-    if len(weights.get_shape()) != 2:
+    if len(weights.shape) != 2:
         raise ValueError("Weights must be a [batch_size x sequence_length] tensor")
 
     if average_across_timesteps and sum_over_timesteps:

--- a/tensorflow_addons/seq2seq/sampler.py
+++ b/tensorflow_addons/seq2seq/sampler.py
@@ -237,14 +237,14 @@ class TrainingSampler(Sampler):
             self.sequence_length = tf.convert_to_tensor(
                 sequence_length, name="sequence_length"
             )
-            if self.sequence_length.get_shape().ndims != 1:
+            if self.sequence_length.shape.ndims != 1:
                 raise ValueError(
                     "Expected sequence_length to be vector, but received "
-                    "shape: %s" % self.sequence_length.get_shape()
+                    "shape: %s" % self.sequence_length.shape
                 )
         elif mask is not None:
             mask = tf.convert_to_tensor(mask)
-            if mask.get_shape().ndims != 2:
+            if mask.shape.ndims != 2:
                 raise ValueError(
                     "Expected mask to a 2D tensor, but received shape: %s" % mask
                 )
@@ -344,10 +344,10 @@ class ScheduledEmbeddingTrainingSampler(TrainingSampler):
             self.sampling_probability = tf.convert_to_tensor(
                 sampling_probability, name="sampling_probability"
             )
-        if self.sampling_probability.get_shape().ndims not in (0, 1):
+        if self.sampling_probability.shape.ndims not in (0, 1):
             raise ValueError(
                 "sampling_probability must be either a scalar or a vector. "
-                "saw shape: %s" % (self.sampling_probability.get_shape())
+                "saw shape: %s" % (self.sampling_probability.shape)
             )
         self.seed = seed
         self.scheduling_seed = scheduling_seed
@@ -441,10 +441,10 @@ class ScheduledOutputTrainingSampler(TrainingSampler):
             self.sampling_probability = tf.convert_to_tensor(
                 sampling_probability, name="sampling_probability"
             )
-        if self.sampling_probability.get_shape().ndims not in (0, 1):
+        if self.sampling_probability.shape.ndims not in (0, 1):
             raise ValueError(
                 "sampling_probability must be either a scalar or a vector. "
-                "saw shape: %s" % (self.sampling_probability.get_shape())
+                "saw shape: %s" % (self.sampling_probability.shape)
             )
 
         self.seed = seed
@@ -605,10 +605,10 @@ class GreedyEmbeddingSampler(Sampler):
         self.end_token = tf.convert_to_tensor(
             end_token, dtype=tf.int32, name="end_token"
         )
-        if self.start_tokens.get_shape().ndims != 1:
+        if self.start_tokens.shape.ndims != 1:
             raise ValueError("start_tokens must be a vector")
         self._batch_size = tf.size(start_tokens)
-        if self.end_token.get_shape().ndims != 0:
+        if self.end_token.shape.ndims != 0:
             raise ValueError("end_token must be a scalar")
         self.start_inputs = self.embedding_fn(self.start_tokens)
 
@@ -821,7 +821,7 @@ def categorical_sample(logits, dtype=tf.int32, sample_shape=(), seed=None):
 
 def _unstack_ta(inp):
     return tf.TensorArray(
-        dtype=inp.dtype, size=tf.shape(inp)[0], element_shape=inp.get_shape()[1:]
+        dtype=inp.dtype, size=tf.shape(inp)[0], element_shape=inp.shape[1:]
     ).unstack(inp)
 
 

--- a/tensorflow_addons/seq2seq/tests/attention_wrapper_test.py
+++ b/tensorflow_addons/seq2seq/tests/attention_wrapper_test.py
@@ -338,9 +338,7 @@ def _test_with_attention(
         attention_depth = sum(
             attention_layer.compute_output_shape(
                 [batch_size, cell_depth + encoder_output_depth]
-            )
-            .dims[-1]
-            .value
+            )[-1]
             for attention_layer in attention_layers
         )
     else:
@@ -414,26 +412,18 @@ def _test_with_attention(
 
     expected_time = max(decoder_sequence_length)
     assert (batch_size, expected_time, attention_depth) == tuple(
-        final_outputs.rnn_output.get_shape().as_list()
+        final_outputs.rnn_output.shape.as_list()
     )
-    assert (batch_size, expected_time) == tuple(
-        final_outputs.sample_id.get_shape().as_list()
-    )
+    assert (batch_size, expected_time) == tuple(final_outputs.sample_id.shape.as_list())
 
-    assert (batch_size, attention_depth) == tuple(
-        final_state.attention.get_shape().as_list()
-    )
-    assert (batch_size, cell_depth) == tuple(
-        final_state.cell_state[0].get_shape().as_list()
-    )
-    assert (batch_size, cell_depth) == tuple(
-        final_state.cell_state[1].get_shape().as_list()
-    )
+    assert (batch_size, attention_depth) == tuple(final_state.attention.shape.as_list())
+    assert (batch_size, cell_depth) == tuple(final_state.cell_state[0].shape.as_list())
+    assert (batch_size, cell_depth) == tuple(final_state.cell_state[1].shape.as_list())
 
     if alignment_history:
         state_alignment_history = final_state.alignment_history.stack()
         assert (expected_time, batch_size, encoder_max_time) == tuple(
-            state_alignment_history.get_shape().as_list()
+            state_alignment_history.shape.as_list()
         )
         tf.nest.assert_same_structure(
             cell.state_size,

--- a/tensorflow_addons/seq2seq/tests/basic_decoder_test.py
+++ b/tensorflow_addons/seq2seq/tests/basic_decoder_test.py
@@ -68,12 +68,12 @@ def test_step_with_training_helper_output_layer(use_output_layer):
     assert len(first_state) == 2
     assert len(step_state) == 2
     assert type(step_outputs) is basic_decoder.BasicDecoderOutput
-    assert (batch_size, expected_output_depth) == step_outputs[0].get_shape()
-    assert (batch_size,) == step_outputs[1].get_shape()
-    assert (batch_size, cell_depth) == first_state[0].get_shape()
-    assert (batch_size, cell_depth) == first_state[1].get_shape()
-    assert (batch_size, cell_depth) == step_state[0].get_shape()
-    assert (batch_size, cell_depth) == step_state[1].get_shape()
+    assert (batch_size, expected_output_depth) == step_outputs[0].shape
+    assert (batch_size,) == step_outputs[1].shape
+    assert (batch_size, cell_depth) == first_state[0].shape
+    assert (batch_size, cell_depth) == first_state[1].shape
+    assert (batch_size, cell_depth) == step_state[0].shape
+    assert (batch_size, cell_depth) == step_state[1].shape
 
     if use_output_layer:
         # The output layer was accessed
@@ -157,12 +157,12 @@ def test_step_with_training_helper_masked_input(use_mask):
     assert len(first_state) == 2
     assert len(step_state) == 2
     assert type(step_outputs) is basic_decoder.BasicDecoderOutput
-    assert (batch_size, expected_output_depth) == step_outputs[0].get_shape()
-    assert (batch_size,) == step_outputs[1].get_shape()
-    assert (batch_size, cell_depth) == first_state[0].get_shape()
-    assert (batch_size, cell_depth) == first_state[1].get_shape()
-    assert (batch_size, cell_depth) == step_state[0].get_shape()
-    assert (batch_size, cell_depth) == step_state[1].get_shape()
+    assert (batch_size, expected_output_depth) == step_outputs[0].shape
+    assert (batch_size,) == step_outputs[1].shape
+    assert (batch_size, cell_depth) == first_state[0].shape
+    assert (batch_size, cell_depth) == first_state[1].shape
+    assert (batch_size, cell_depth) == step_state[0].shape
+    assert (batch_size, cell_depth) == step_state[1].shape
 
     assert len(output_layer.variables) == 1
 
@@ -223,12 +223,12 @@ def test_step_with_greedy_embedding_helper():
     assert len(first_state) == 2
     assert len(step_state) == 2
     assert isinstance(step_outputs, basic_decoder.BasicDecoderOutput)
-    assert (batch_size, cell_depth) == step_outputs[0].get_shape()
-    assert (batch_size,) == step_outputs[1].get_shape()
-    assert (batch_size, cell_depth) == first_state[0].get_shape()
-    assert (batch_size, cell_depth) == first_state[1].get_shape()
-    assert (batch_size, cell_depth) == step_state[0].get_shape()
-    assert (batch_size, cell_depth) == step_state[1].get_shape()
+    assert (batch_size, cell_depth) == step_outputs[0].shape
+    assert (batch_size,) == step_outputs[1].shape
+    assert (batch_size, cell_depth) == first_state[0].shape
+    assert (batch_size, cell_depth) == first_state[1].shape
+    assert (batch_size, cell_depth) == step_state[0].shape
+    assert (batch_size, cell_depth) == step_state[1].shape
 
     eval_result = {
         "batch_size": batch_size_t,
@@ -290,12 +290,12 @@ def test_step_with_sample_embedding_helper():
     assert len(first_state) == 2
     assert len(step_state) == 2
     assert isinstance(step_outputs, basic_decoder.BasicDecoderOutput)
-    assert (batch_size, cell_depth) == step_outputs[0].get_shape()
-    assert (batch_size,) == step_outputs[1].get_shape()
-    assert (batch_size, cell_depth) == first_state[0].get_shape()
-    assert (batch_size, cell_depth) == first_state[1].get_shape()
-    assert (batch_size, cell_depth) == step_state[0].get_shape()
-    assert (batch_size, cell_depth) == step_state[1].get_shape()
+    assert (batch_size, cell_depth) == step_outputs[0].shape
+    assert (batch_size,) == step_outputs[1].shape
+    assert (batch_size, cell_depth) == first_state[0].shape
+    assert (batch_size, cell_depth) == first_state[1].shape
+    assert (batch_size, cell_depth) == step_state[0].shape
+    assert (batch_size, cell_depth) == step_state[1].shape
 
     eval_result = {
         "batch_size": batch_size_t,
@@ -358,13 +358,13 @@ def test_step_with_scheduled_embedding_training_helper():
     assert len(first_state) == 2
     assert len(step_state) == 2
     assert isinstance(step_outputs, basic_decoder.BasicDecoderOutput)
-    assert (batch_size, vocabulary_size) == step_outputs[0].get_shape()
-    assert (batch_size,) == step_outputs[1].get_shape()
-    assert (batch_size, vocabulary_size) == first_state[0].get_shape()
-    assert (batch_size, vocabulary_size) == first_state[1].get_shape()
-    assert (batch_size, vocabulary_size) == step_state[0].get_shape()
-    assert (batch_size, vocabulary_size) == step_state[1].get_shape()
-    assert (batch_size, input_depth) == step_next_inputs.get_shape()
+    assert (batch_size, vocabulary_size) == step_outputs[0].shape
+    assert (batch_size,) == step_outputs[1].shape
+    assert (batch_size, vocabulary_size) == first_state[0].shape
+    assert (batch_size, vocabulary_size) == first_state[1].shape
+    assert (batch_size, vocabulary_size) == step_state[0].shape
+    assert (batch_size, vocabulary_size) == step_state[1].shape
+    assert (batch_size, input_depth) == step_next_inputs.shape
 
     eval_result = {
         "batch_size": batch_size_t.numpy(),
@@ -467,12 +467,12 @@ def test_step_with_scheduled_output_training_helper(
     assert len(first_state) == 2
     assert len(step_state) == 2
     assert isinstance(step_outputs, basic_decoder.BasicDecoderOutput)
-    assert (batch_size, cell_depth) == step_outputs[0].get_shape()
-    assert (batch_size,) == step_outputs[1].get_shape()
-    assert (batch_size, cell_depth) == first_state[0].get_shape()
-    assert (batch_size, cell_depth) == first_state[1].get_shape()
-    assert (batch_size, cell_depth) == step_state[0].get_shape()
-    assert (batch_size, cell_depth) == step_state[1].get_shape()
+    assert (batch_size, cell_depth) == step_outputs[0].shape
+    assert (batch_size,) == step_outputs[1].shape
+    assert (batch_size, cell_depth) == first_state[0].shape
+    assert (batch_size, cell_depth) == first_state[1].shape
+    assert (batch_size, cell_depth) == step_state[0].shape
+    assert (batch_size, cell_depth) == step_state[1].shape
 
     fetches = {
         "batch_size": batch_size_t.numpy(),
@@ -587,12 +587,12 @@ def test_step_with_inference_helper_categorical():
     assert len(first_state) == 2
     assert len(step_state) == 2
     assert isinstance(step_outputs, basic_decoder.BasicDecoderOutput)
-    assert (batch_size, cell_depth) == step_outputs[0].get_shape()
-    assert (batch_size,) == step_outputs[1].get_shape()
-    assert (batch_size, cell_depth) == first_state[0].get_shape()
-    assert (batch_size, cell_depth) == first_state[1].get_shape()
-    assert (batch_size, cell_depth) == step_state[0].get_shape()
-    assert (batch_size, cell_depth) == step_state[1].get_shape()
+    assert (batch_size, cell_depth) == step_outputs[0].shape
+    assert (batch_size,) == step_outputs[1].shape
+    assert (batch_size, cell_depth) == first_state[0].shape
+    assert (batch_size, cell_depth) == first_state[1].shape
+    assert (batch_size, cell_depth) == step_state[0].shape
+    assert (batch_size, cell_depth) == step_state[1].shape
 
     eval_result = {
         "batch_size": batch_size_t.numpy(),
@@ -662,12 +662,12 @@ def test_step_with_inference_helper_multilabel():
     assert len(first_state) == 2
     assert len(step_state) == 2
     assert isinstance(step_outputs, basic_decoder.BasicDecoderOutput)
-    assert (batch_size, cell_depth) == step_outputs[0].get_shape()
-    assert (batch_size, cell_depth) == step_outputs[1].get_shape()
-    assert (batch_size, cell_depth) == first_state[0].get_shape()
-    assert (batch_size, cell_depth) == first_state[1].get_shape()
-    assert (batch_size, cell_depth) == step_state[0].get_shape()
-    assert (batch_size, cell_depth) == step_state[1].get_shape()
+    assert (batch_size, cell_depth) == step_outputs[0].shape
+    assert (batch_size, cell_depth) == step_outputs[1].shape
+    assert (batch_size, cell_depth) == first_state[0].shape
+    assert (batch_size, cell_depth) == first_state[1].shape
+    assert (batch_size, cell_depth) == step_state[0].shape
+    assert (batch_size, cell_depth) == step_state[1].shape
 
     eval_result = {
         "batch_size": batch_size_t.numpy(),

--- a/tensorflow_addons/seq2seq/tests/beam_search_decoder_test.py
+++ b/tensorflow_addons/seq2seq/tests/beam_search_decoder_test.py
@@ -604,10 +604,10 @@ def test_dynamic_decode_rnn(time_major, has_attention, with_alignment_history):
     beam_search_decoder_output = final_outputs.beam_search_decoder_output
     expected_seq_length = 3 if tf.executing_eagerly() else None
     assert _t((batch_size, expected_seq_length, beam_width)) == tuple(
-        beam_search_decoder_output.scores.get_shape().as_list()
+        beam_search_decoder_output.scores.shape.as_list()
     )
     assert _t((batch_size, expected_seq_length, beam_width)) == tuple(
-        final_outputs.predicted_ids.get_shape().as_list()
+        final_outputs.predicted_ids.shape.as_list()
     )
 
     eval_results = {

--- a/tensorflow_addons/seq2seq/tests/decoder_test.py
+++ b/tensorflow_addons/seq2seq/tests/decoder_test.py
@@ -60,7 +60,7 @@ def test_dynamic_decode_rnn(time_major, maximum_iterations):
             return (shape[1], shape[0]) + shape[2:]
         return shape
 
-    assert (batch_size,) == tuple(final_sequence_length.get_shape().as_list())
+    assert (batch_size,) == tuple(final_sequence_length.shape.as_list())
     # Mostly a smoke test
     time_steps = max_out
     expected_length = sequence_length


### PR DESCRIPTION
* Prefer `shape` attribute over `get_shape` method
* Remove usage of `tf.compat.dimension_value` (we only support TF 2)
* Remove usage of deprecated attribute `TensorShape.dims`