### PR TITLE
Fix MultiHeadAttention docs

### DIFF
--- a/tensorflow_addons/layers/multihead_attention.py
+++ b/tensorflow_addons/layers/multihead_attention.py
@@ -23,9 +23,9 @@ class MultiHeadAttention(tf.keras.layers.Layer):
     r"""
     MultiHead Attention layer.
 
-    Defines the MultiHead Attention operation as defined in
+    Defines the MultiHead Attention operation as described in
     [Attention Is All You Need](https://arxiv.org/abs/1706.03762) which takes
-    in a `query`, `key` and `value` tensors returns the dot-product attention
+    in a `query`, `key`, and `value` tensors, and returns the dot-product attention
     between them:
 
         ```python
@@ -49,7 +49,7 @@ class MultiHeadAttention(tf.keras.layers.Layer):
         attention = mha([query, key]) # (batch_size, query_elements, key_depth)
         ```
 
-    Arguments
+    Arguments:
         head_size: int, dimensionality of the `query`, `key` and `value` tensors
         after the linear transformation.
         num_heads: int, number of attention heads.
@@ -70,19 +70,16 @@ class MultiHeadAttention(tf.keras.layers.Layer):
         bias_regularizer: regularizer, regularizer for the bias weights.
         bias_constraint: constraint, constraint for the bias weights.
 
-    Call Arguments
-        inputs:  List of the following tensors:
-            * `query`: Tensor of shape `(..., query_elements, query_depth)`
-            * `key`: `Tensor of shape '(..., key_elements, key_depth)`
-            * `value`: Tensor of shape `(..., key_elements, value_depth)` (optional)
+    Call Arguments:
+        inputs:  List of the tensors `[query, key, value]` where  `query` has shape `(..., query_elements, query_depth)`, `key` has shape '(..., key_elements, key_depth)`, and `value` has shape `(..., key_elements, value_depth)`. `value` is optional, if not given `key` will be used.
         mask: a binary Tensor of shape `[batch_size?, num_heads?, query_elements, key_elements]`
         which specifies which query elements can attendo to which key elements,
         `1` indicates attention and `0` indicates no attention.
 
-    Output shape
-        - `(..., query_elements, output_size)` if `output_size` is given, else
-        - `(..., query_elements, value_depth)` if `value` is given, else
-        - `(..., query_elements, key_depth)`
+    Output shape:
+        `(..., query_elements, output_size)` if `output_size` is given, else
+        `(..., query_elements, value_depth)` if `value` is given, else
+        `(..., query_elements, key_depth)`
     """
 
     def __init__(

--- a/tensorflow_addons/layers/multihead_attention.py
+++ b/tensorflow_addons/layers/multihead_attention.py
@@ -21,11 +21,11 @@ import tensorflow as tf
 @tf.keras.utils.register_keras_serializable(package="Addons")
 class MultiHeadAttention(tf.keras.layers.Layer):
     r"""
-    MultiHead Attention layer.
+    MultiHead Attentsion layer.
 
     Defines the MultiHead Attention operation as described in
     [Attention Is All You Need](https://arxiv.org/abs/1706.03762) which takes
-    in a `query`, `key`, and `value` tensors, and returns the dot-product attention
+    in the tensors `query`, `key`, and `value`, and returns the dot-product attention
     between them:
 
         ```python

--- a/tensorflow_addons/layers/multihead_attention.py
+++ b/tensorflow_addons/layers/multihead_attention.py
@@ -71,15 +71,18 @@ class MultiHeadAttention(tf.keras.layers.Layer):
         bias_constraint: constraint, constraint for the bias weights.
 
     Call Arguments:
-        inputs:  List of the tensors `[query, key, value]` where  `query` has shape `(..., query_elements, query_depth)`, `key` has shape '(..., key_elements, key_depth)`, and `value` has shape `(..., key_elements, value_depth)`. `value` is optional, if not given `key` will be used.
+        inputs:  List of `[query, key, value]` where
+            * `query`: Tensor of shape `(..., query_elements, query_depth)`
+            * `key`: `Tensor of shape '(..., key_elements, key_depth)`
+            * `value`: Tensor of shape `(..., key_elements, value_depth)`, optional, if not given `key` will be used.
         mask: a binary Tensor of shape `[batch_size?, num_heads?, query_elements, key_elements]`
         which specifies which query elements can attendo to which key elements,
         `1` indicates attention and `0` indicates no attention.
 
     Output shape:
-        `(..., query_elements, output_size)` if `output_size` is given, else
-        `(..., query_elements, value_depth)` if `value` is given, else
-        `(..., query_elements, key_depth)`
+        * `(..., query_elements, output_size)` if `output_size` is given, else
+        * `(..., query_elements, value_depth)` if `value` is given, else
+        * `(..., query_elements, key_depth)`
     """
 
     def __init__(


### PR DESCRIPTION
Docs on the site look weird due to formatting issues: https://www.tensorflow.org/addons/api_docs/python/tfa/layers/MultiHeadAttention

This PR tries to fix the formatting and also improves parts of the text a bit.