### PR TITLE
fix - in multhead_attention, correct the location where key & value shapes are checked

### DIFF
--- a/tensorflow_addons/layers/multihead_attention.py
+++ b/tensorflow_addons/layers/multihead_attention.py
@@ -189,6 +189,11 @@ class MultiHeadAttention(tf.keras.layers.Layer):
         key = inputs[1]
         value = inputs[2] if len(inputs) > 2 else key
 
+        if key.shape[-2] != value.shape[-2]:
+            raise ValueError(
+                "the number of elements in 'key' must be equal to the same as the number of elements in 'value'"
+            )
+
         # verify shapes
         if mask is not None:
             if len(mask.shape) < 2:
@@ -201,10 +206,7 @@ class MultiHeadAttention(tf.keras.layers.Layer):
                 raise ValueError(
                     "mask's last dimension must be equal to the number of elements in 'key'"
                 )
-            if key.shape[-2] != value.shape[-2]:
-                raise ValueError(
-                    "the number of elements in 'key' must be equal to the same as the number of elements in 'value'"
-                )
+            
 
         # Linear transformations
         query = tf.einsum("...NI , HIO -> ...NHO", query, self.query_kernel)

--- a/tensorflow_addons/layers/multihead_attention.py
+++ b/tensorflow_addons/layers/multihead_attention.py
@@ -189,12 +189,12 @@ class MultiHeadAttention(tf.keras.layers.Layer):
         key = inputs[1]
         value = inputs[2] if len(inputs) > 2 else key
 
+        # verify shapes
         if key.shape[-2] != value.shape[-2]:
             raise ValueError(
                 "the number of elements in 'key' must be equal to the same as the number of elements in 'value'"
             )
 
-        # verify shapes
         if mask is not None:
             if len(mask.shape) < 2:
                 raise ValueError("'mask' must have atleast 2 dimensions")
@@ -206,7 +206,6 @@ class MultiHeadAttention(tf.keras.layers.Layer):
                 raise ValueError(
                     "mask's last dimension must be equal to the number of elements in 'key'"
                 )
-            
 
         # Linear transformations
         query = tf.einsum("...NI , HIO -> ...NHO", query, self.query_kernel)


### PR DESCRIPTION
at present this check is done only if mask is not None whereas this should be checked irrespective of the msk