### PR TITLE
Update context checks in dynamic_decode

### DIFF
--- a/tensorflow_addons/seq2seq/decoder.py
+++ b/tensorflow_addons/seq2seq/decoder.py
@@ -291,7 +291,7 @@ def dynamic_decode(
       training: Python boolean. Indicates whether the layer should behave
           in training  mode or in inference mode. Only relevant
           when `dropout` or `recurrent_dropout` is used.
-      scope: Optional variable scope to use.
+      scope: Optional name scope to use.
       **kwargs: dict, other keyword arguments for dynamic_decode. It might
         contain arguments for `BaseDecoder` to initialize, which takes all
         tensor inputs during call().
@@ -302,19 +302,10 @@ def dynamic_decode(
     Raises:
       ValueError: if `maximum_iterations` is provided but is not a scalar.
     """
-    with tf.compat.v1.variable_scope(scope, "decoder") as varscope:
-        # Determine context types.
-        ctxt = tf.compat.v1.get_default_graph()._get_control_flow_context()
-        is_xla = control_flow_util.GetContainingXLAContext(ctxt) is not None
-        in_while_loop = control_flow_util.GetContainingWhileContext(ctxt) is not None
-        # Properly cache variable values inside the while_loop.
-        # Don't set a caching device when running in a loop, since it is
-        # possible that train steps could be wrapped in a tf.while_loop. In that
-        # scenario caching prevents forward computations in loop iterations from
-        # re-reading the updated weights.
-        if not tf.executing_eagerly() and not in_while_loop:
-            if varscope.caching_device is None:
-                varscope.set_caching_device(lambda op: op.device)
+    with tf.name_scope(scope or "decoder"):
+        is_xla = not tf.executing_eagerly() and control_flow_util.GraphOrParentsInXlaContext(
+            tf.compat.v1.get_default_graph()
+        )
 
         if maximum_iterations is not None:
             maximum_iterations = tf.convert_to_tensor(
@@ -322,6 +313,8 @@ def dynamic_decode(
             )
             if maximum_iterations.shape.ndims != 0:
                 raise ValueError("maximum_iterations must be a scalar")
+        elif is_xla:
+            raise ValueError("maximum_iterations is required for XLA compilation.")
 
         if isinstance(decoder, Decoder):
             initial_finished, initial_inputs, initial_state = decoder.initialize()
@@ -341,8 +334,6 @@ def dynamic_decode(
             decoder.output_dtype,
         )
 
-        if is_xla and maximum_iterations is None:
-            raise ValueError("maximum_iterations is required for XLA compilation.")
         if maximum_iterations is not None:
             initial_finished = tf.logical_or(initial_finished, 0 >= maximum_iterations)
         initial_sequence_lengths = tf.zeros_like(initial_finished, dtype=tf.int32)


### PR DESCRIPTION
There are several things here:

- The XLA check is updated to match what is done in `tf.keras.backend.rnn` and also mentionned in https://github.com/tensorflow/tensorflow/commit/e67e29e3c8a150be847e17bbfe4f5d399e7b08ea

- As far as I know, setting a caching device on the variable scope only impacts variables created with `tf.compat.v1.get_variable` which is no longer used in V2. The current check was wrong in V2 anyway (see https://github.com/tensorflow/tensorflow/commit/e67e29e3c8a150be847e17bbfe4f5d399e7b08ea)

- If we don't need to configure the variable scope, we can change it to a name scope which has the same effect in V2.