### PR TITLE
Add a Python alternative to seq2seq.gather_tree

### DIFF
--- a/tensorflow_addons/seq2seq/BUILD
+++ b/tensorflow_addons/seq2seq/BUILD
@@ -6,8 +6,8 @@ py_library(
     name = "seq2seq",
     srcs = glob(["*.py"]),
     data = [
-        "//tensorflow_addons/custom_ops/seq2seq:_beam_search_ops.so",
         "//tensorflow_addons:options.py",
+        "//tensorflow_addons/custom_ops/seq2seq:_beam_search_ops.so",
     ],
     deps = [
         "//tensorflow_addons/testing",

--- a/tensorflow_addons/seq2seq/BUILD
+++ b/tensorflow_addons/seq2seq/BUILD
@@ -7,6 +7,7 @@ py_library(
     srcs = glob(["*.py"]),
     data = [
         "//tensorflow_addons/custom_ops/seq2seq:_beam_search_ops.so",
+        "//tensorflow_addons:options.py",
     ],
     deps = [
         "//tensorflow_addons/testing",

--- a/tensorflow_addons/seq2seq/tests/beam_search_decoder_test.py
+++ b/tensorflow_addons/seq2seq/tests/beam_search_decoder_test.py
@@ -22,6 +22,7 @@ from tensorflow_addons.seq2seq import attention_wrapper
 from tensorflow_addons.seq2seq import beam_search_decoder, gather_tree
 
 
+@pytest.mark.usefixtures("run_custom_and_py_ops")
 def test_gather_tree():
     # (max_time = 3, batch_size = 2, beam_width = 3)
 
@@ -103,22 +104,27 @@ def _test_gather_tree_from_array(depth_ndims=0, merged_batch_beam=False):
     np.testing.assert_equal(expected_array.numpy(), sorted_array.numpy())
 
 
+@pytest.mark.usefixtures("run_custom_and_py_ops")
 def test_gather_tree_from_array_scalar():
     _test_gather_tree_from_array()
 
 
+@pytest.mark.usefixtures("run_custom_and_py_ops")
 def test_gather_tree_from_array_1d():
     _test_gather_tree_from_array(depth_ndims=1)
 
 
+@pytest.mark.usefixtures("run_custom_and_py_ops")
 def test_gather_tree_from_array_1d_with_merged_batch_beam():
     _test_gather_tree_from_array(depth_ndims=1, merged_batch_beam=True)
 
 
+@pytest.mark.usefixtures("run_custom_and_py_ops")
 def test_gather_tree_from_array_2d():
     _test_gather_tree_from_array(depth_ndims=2)
 
 
+@pytest.mark.usefixtures("run_custom_and_py_ops")
 def test_gather_tree_from_array_complex_trajectory():
     # Max. time = 7, batch = 1, beam = 5.
     array = np.expand_dims(
@@ -538,6 +544,7 @@ def test_large_beam_step():
     "cell_class", [tf.keras.layers.LSTMCell, tf.keras.layers.GRUCell]
 )
 @pytest.mark.usefixtures("maybe_run_functions_eagerly")
+@pytest.mark.usefixtures("run_custom_and_py_ops")
 def test_beam_search_decoder(
     cell_class, time_major, has_attention, with_alignment_history
 ):

--- a/tensorflow_addons/seq2seq/tests/beam_search_ops_test.py
+++ b/tensorflow_addons/seq2seq/tests/beam_search_ops_test.py
@@ -28,6 +28,7 @@ def _transpose_batch_time(x):
     return np.transpose(x, [1, 0, 2]).astype(np.int32)
 
 
+@pytest.mark.usefixtures("run_custom_and_py_ops")
 def test_gather_tree_one():
     # (max_time = 4, batch_size = 1, beams = 3)
     end_token = 10
@@ -48,6 +49,7 @@ def test_gather_tree_one():
     np.testing.assert_equal(expected_result, beams.numpy())
 
 
+@pytest.mark.usefixtures("run_custom_and_py_ops")
 def test_bad_parent_values_on_cpu():
     # (batch_size = 1, max_time = 4, beams = 3)
     # bad parent in beam 1 time 1
@@ -68,6 +70,7 @@ def test_bad_parent_values_on_cpu():
 
 
 @pytest.mark.with_device(["gpu"])
+@pytest.mark.usefixtures("run_custom_and_py_ops")
 def test_bad_parent_values_on_gpu():
     # (max_time = 4, batch_size = 1, beams = 3)
     # bad parent in beam 1 time 1; appears as a negative index at time 0
@@ -99,6 +102,7 @@ def test_bad_parent_values_on_gpu():
         np.testing.assert_equal(expected_result, beams.numpy())
 
 
+@pytest.mark.usefixtures("run_custom_and_py_ops")
 def test_gather_tree_batch():
     batch_size = 10
     beam_width = 15


### PR DESCRIPTION
This PR adds a pure Python TensorFlow implementation of `tfa.seq2seq.gather_tree`, which can be enabled with the global flag [`TF_ADDONS_PY_OP`](https://github.com/tensorflow/addons#gpu-and-cpu-custom-ops-1). This is useful when Addons custom ops are not readily available (e.g. TensorFlow Serving).

I tested the performance on a real world application: beam search decoding of a neural machine translation model. I'm using a [custom beam search implementation](https://github.com/OpenNMT/OpenNMT-tf/blob/master/opennmt/utils/decoding.py) but it is close to the `BeamSearchDecoder` included in Addons.

I did not find significant performance impact.  And I think this makes sense: the function is only used at the very end of the decoding and does not involve very complex ops.