### PR TITLE
Use informative list names

### DIFF
--- a/.github/workflows/notify_codeowners.py
+++ b/.github/workflows/notify_codeowners.py
@@ -11,7 +11,7 @@ import json
 
 # Github already take care
 # of notifying users with write access
-BLACKLIST = [
+WRITE_ACCESS_LIST = [
     "tensorflow/sig-addons-maintainers",
     "facaiy",
     "seanpmorgan",
@@ -46,7 +46,7 @@ def check_user(user: str, line_idx: int):
         )
     user = user[1:]
     user = user.lower()  # in github, user names are case insensitive
-    if user in BLACKLIST:
+    if user in WRITE_ACCESS_LIST:
         return None
     try:
         CLIENT.get_user(user)

--- a/tools/testing/source_code_test.py
+++ b/tools/testing/source_code_test.py
@@ -65,29 +65,28 @@ def test_case_insensitive_filesystems():
             )
 
 
-def get_lines_of_source_code(blacklist=None):
-    blacklist = blacklist or []
+def get_lines_of_source_code(allowlist=None):
+    allowlist = allowlist or []
     source_dir = os.path.join(BASE_DIR, "tensorflow_addons")
     for path in glob.glob(source_dir + "/**/*.py", recursive=True):
-        if in_blacklist(path, blacklist):
+        if in_allowlist(path, allowlist):
             continue
         with open(path) as f:
             for line_idx, line in enumerate(f):
                 yield path, line_idx, line
 
 
-def in_blacklist(file_path, blacklist):
-    for blacklisted_file in blacklist:
-        if file_path.endswith(blacklisted_file):
+def in_allowlist(file_path, allowlist):
+    for allowed_file in allowlist:
+        if file_path.endswith(allowed_file):
             return True
     return False
 
 
 def test_no_private_tf_api():
-    # TODO: remove all elements of the list and remove the blacklist
-    # Unlike the exception list for functions/classes missing types,
-    # this blacklist should not grow. Do not add elements to this list.
-    blacklist = [
+    # TODO: remove all elements of the list and remove the allowlist
+    # This allowlist should not grow. Do not add elements to this list.
+    allowlist = [
         "tensorflow_addons/optimizers/novograd.py",
         "tensorflow_addons/optimizers/moving_average.py",
         "tensorflow_addons/metrics/r_square.py",
@@ -96,7 +95,7 @@ def test_no_private_tf_api():
         "tensorflow_addons/seq2seq/attention_wrapper.py",
     ]
 
-    for file_path, line_idx, line in get_lines_of_source_code(blacklist):
+    for file_path, line_idx, line in get_lines_of_source_code(allowlist):
 
         if "import tensorflow.python" in line or "from tensorflow.python" in line:
             raise ImportError(
@@ -114,10 +113,9 @@ def test_no_private_tf_api():
 
 
 def test_no_tf_cond():
-    # TODO: remove all elements of the list and remove the blacklist
-    # Unlike the exception list for functions/classes missing types,
-    # this blacklist should not grow. Do not add elements to this list.
-    blacklist = [
+    # TODO: remove all elements of the list and remove the allowlist
+    # This allowlist should not grow. Do not add elements to this list.
+    allowlist = [
         "tensorflow_addons/text/crf.py",
         "tensorflow_addons/layers/wrappers.py",
         "tensorflow_addons/image/connected_components.py",
@@ -126,7 +124,7 @@ def test_no_tf_cond():
         "tensorflow_addons/seq2seq/sampler.py",
         "tensorflow_addons/seq2seq/beam_search_decoder.py",
     ]
-    for file_path, line_idx, line in get_lines_of_source_code(blacklist):
+    for file_path, line_idx, line in get_lines_of_source_code(allowlist):
 
         if "tf.cond(" in line:
             raise NameError(
@@ -145,13 +143,12 @@ def test_no_tf_cond():
 
 
 def test_no_experimental_api():
-    # TODO: remove all elements of the list and remove the blacklist
-    # Unlike the exception list for functions/classes missing types,
-    # this blacklist should not grow. Do not add elements to this list.
-    blacklist = [
+    # TODO: remove all elements of the list and remove the allowlist
+    # This allowlist should not grow. Do not add elements to this list.
+    allowlist = [
         "tensorflow_addons/optimizers/weight_decay_optimizers.py",
     ]
-    for file_path, line_idx, line in get_lines_of_source_code(blacklist):
+    for file_path, line_idx, line in get_lines_of_source_code(allowlist):
 
         if file_path.endswith("_test.py") or file_path.endswith("conftest.py"):
             continue
@@ -173,10 +170,9 @@ def test_no_experimental_api():
 
 
 def test_no_tf_control_dependencies():
-    # TODO: remove all elements of the list and remove the blacklist
-    # Unlike the exception list for functions/classes missing types,
-    # this blacklist should not grow. Do not add elements to this list.
-    blacklist = [
+    # TODO: remove all elements of the list and remove the allowlist
+    # This allowlist should not grow. Do not add elements to this list.
+    allowlist = [
         "tensorflow_addons/layers/wrappers.py",
         "tensorflow_addons/image/utils.py",
         "tensorflow_addons/image/dense_image_warp.py",
@@ -191,7 +187,7 @@ def test_no_tf_control_dependencies():
         "tensorflow_addons/seq2seq/beam_search_decoder.py",
         "tensorflow_addons/seq2seq/attention_wrapper.py",
     ]
-    for file_path, line_idx, line in get_lines_of_source_code(blacklist):
+    for file_path, line_idx, line in get_lines_of_source_code(allowlist):
 
         if "tf.control_dependencies(" in line:
 
@@ -212,10 +208,9 @@ def test_no_tf_control_dependencies():
 
 
 def test_no_deprecated_v1():
-    # TODO: remove all elements of the list and remove the blacklist
-    # Unlike the exception list for functions/classes missing types,
-    # this blacklist should not grow. Do not add elements to this list.
-    blacklist = [
+    # TODO: remove all elements of the list and remove the allowlist
+    # This allowlist should not grow. Do not add elements to this list.
+    allowlist = [
         "tensorflow_addons/text/skip_gram_ops.py",
         "tensorflow_addons/metrics/tests/f_scores_test.py",
         "tensorflow_addons/seq2seq/tests/basic_decoder_test.py",
@@ -223,7 +218,7 @@ def test_no_deprecated_v1():
         "tensorflow_addons/seq2seq/decoder.py",
         "tensorflow_addons/seq2seq/tests/attention_wrapper_test.py",
     ]
-    for file_path, line_idx, line in get_lines_of_source_code(blacklist):
+    for file_path, line_idx, line in get_lines_of_source_code(allowlist):
 
         if "tf.compat.v1" in line:
             raise NameError(


### PR DESCRIPTION
A number of things going on here. To start these were never really blacklists, but rather should have been denoted as whitelists. The changes are not end-user facing / code breaking and they can be replaced with more informative variable names.

It also aligns with chromium guidelines as well as a number of OSS community changes:
https://chromium.googlesource.com/chromium/src/+/master/styleguide/inclusive_code.md#racially-neutral


