### PR TITLE
Crf decode cell serialize functions

### DIFF
--- a/tensorflow_addons/text/crf.py
+++ b/tensorflow_addons/text/crf.py
@@ -422,6 +422,20 @@ class CrfDecodeForwardRnnCell(tf.keras.layers.AbstractRNNCell):
         backpointers = tf.cast(backpointers, dtype=tf.int32)
         return backpointers, new_state
 
+    def get_config(self) -> dict:
+        config = {
+            "transition_params": tf.squeeze(self._transition_params, 0).numpy().tolist()
+        }
+        base_config = super(CrfDecodeForwardRnnCell, self).get_config()
+        return dict(list(base_config.items()) + list(config.items()))
+
+    @classmethod
+    def from_config(cls, config: dict) -> "CrfDecodeForwardRnnCell":
+        config["transition_params"] = np.array(
+            config["transition_params"], dtype=np.float32
+        )
+        return cls(**config)
+
 
 def crf_decode_forward(
     inputs: TensorLike,


### PR DESCRIPTION
This PR fixes #1934 by adding `get_config` and `from_config` methods to `CrfDecodeForwardRnnCell`.

A test case that fails before the implementation and passes afterwards is also added. The test uses an example similar to the issue. However, I'm unsure if instead it would make more sense to create a simpler test that instantiates the object and then reconstruct it from the methods.