### PR TITLE
Fix numerical typo in the examples

### DIFF
--- a/tensorflow_addons/layers/multihead_attention.py
+++ b/tensorflow_addons/layers/multihead_attention.py
@@ -29,7 +29,7 @@ class MultiHeadAttention(tf.keras.layers.Layer):
     between them:
 
         ```python
-        mha = MultiHeadAttention(head_size=128, num_heads=128)
+        mha = MultiHeadAttention(head_size=128, num_heads=12)
 
         query = tf.random.uniform((32, 20, 200)) # (batch_size, query_elements, query_depth)
         key = tf.random.uniform((32, 15, 300)) # (batch_size, key_elements, key_depth)
@@ -41,7 +41,7 @@ class MultiHeadAttention(tf.keras.layers.Layer):
     If `value` is not given then internally `value = key` will be used:
 
          ```python
-        mha = MultiHeadAttention(head_size=128, num_heads=128)
+        mha = MultiHeadAttention(head_size=128, num_heads=12)
 
         query = tf.random.uniform((32, 20, 200)) # (batch_size, query_elements, query_depth)
         key = tf.random.uniform((32, 15, 300)) # (batch_size, key_elements, key_depth)


### PR DESCRIPTION
Changes `heads=128` to `heads=12` in the example which is more realistic.