### PR TITLE
Fixes up a typo in ContrastiveLoss `name` identifier.

### DIFF
--- a/tensorflow_addons/losses/contrastive.py
+++ b/tensorflow_addons/losses/contrastive.py
@@ -97,7 +97,7 @@ class ContrastiveLoss(LossFunctionWrapper):
         self,
         margin: Number = 1.0,
         reduction: str = tf.keras.losses.Reduction.SUM_OVER_BATCH_SIZE,
-        name: str = "contrasitve_loss",
+        name: str = "contrastive_loss",
     ):
         super().__init__(
             contrastive_loss, reduction=reduction, name=name, margin=margin


### PR DESCRIPTION
This PR should close the issue #1957.