### PR TITLE
Make `dynamic_decode()` TFLite-convertible

### DIFF
--- a/tensorflow_addons/seq2seq/decoder.py
+++ b/tensorflow_addons/seq2seq/decoder.py
@@ -340,15 +340,18 @@ def dynamic_decode(
             # Assume the batch_size = 1 for inference.
             # So we can change 2-D TensorArray into 1-D by reshaping it.
             zero_outputs = tf.nest.map_structure(
-                lambda shape, dtype: tf.reshape(tf.zeros(
-                    _prepend_batch(decoder.batch_size, shape), dtype=dtype), [-1]),
+                lambda shape, dtype: tf.reshape(
+                    tf.zeros(_prepend_batch(decoder.batch_size, shape), dtype=dtype),
+                    [-1],
+                ),
                 decoder.output_size,
                 decoder.output_dtype,
             )
         else:
             zero_outputs = tf.nest.map_structure(
                 lambda shape, dtype: tf.zeros(
-                    _prepend_batch(decoder.batch_size, shape), dtype=dtype),
+                    _prepend_batch(decoder.batch_size, shape), dtype=dtype
+                ),
                 decoder.output_size,
                 decoder.output_dtype,
             )
@@ -534,6 +537,7 @@ def dynamic_decode(
                 # Reshape the output to the original shape.
                 def _restore_batch(x):
                     return tf.expand_dims(x, [1])
+
                 final_outputs = tf.nest.map_structure(_restore_batch, final_outputs)
 
             final_outputs = tf.nest.map_structure(_transpose_batch_time, final_outputs)

--- a/tensorflow_addons/seq2seq/decoder.py
+++ b/tensorflow_addons/seq2seq/decoder.py
@@ -337,21 +337,21 @@ def dynamic_decode(
             )
 
         if enable_tflite_convertible:
-          # Assume the batch_size = 1 for inference. 
-          # So we can change 2-D TensorArray into 1-D by reshaping it.
-          zero_outputs = tf.nest.map_structure(
-            lambda shape, dtype: tf.reshape(tf.zeros(
-                _prepend_batch(decoder.batch_size, shape), dtype=dtype), [-1]),
-            decoder.output_size,
-            decoder.output_dtype,
-          )
+            # Assume the batch_size = 1 for inference. 
+            # So we can change 2-D TensorArray into 1-D by reshaping it.
+            zero_outputs = tf.nest.map_structure(
+                lambda shape, dtype: tf.reshape(tf.zeros(
+                    _prepend_batch(decoder.batch_size, shape), dtype=dtype), [-1]),
+                decoder.output_size,
+                decoder.output_dtype,
+            )
         else:
-          zero_outputs = tf.nest.map_structure(
-              lambda shape, dtype: tf.zeros(
-                  _prepend_batch(decoder.batch_size, shape), dtype=dtype),
-              decoder.output_size,
-              decoder.output_dtype,
-          )
+            zero_outputs = tf.nest.map_structure(
+                lambda shape, dtype: tf.zeros(
+                    _prepend_batch(decoder.batch_size, shape), dtype=dtype),
+                decoder.output_size,
+                decoder.output_dtype,
+            )
 
         if maximum_iterations is not None:
             initial_finished = tf.logical_or(initial_finished, 0 >= maximum_iterations)
@@ -366,13 +366,13 @@ def dynamic_decode(
                     tf.convert_to_tensor(batch_size, name="batch_size")
                 )
                 if enable_tflite_convertible:
-                  # Since we can't use 2-D TensoArray and assume `batch_size` = 1,
-                  # We use `from_shape` dimension only.
-                  return from_shape
+                    # Since we can't use 2-D TensoArray and assume `batch_size` = 1,
+                    # we use `from_shape` dimension only.
+                    return from_shape
                 return tf.TensorShape([batch_size]).concatenate(from_shape)
 
         dynamic_size = maximum_iterations is None or not is_xla
-        # The static shape `TensoArray` is allowed in TFLite.
+        # The dynamic shape `TensoArray` is not allowed in TFLite yet.
         dynamic_size = dynamic_size and (not enable_tflite_convertible)
 
         def _create_ta(s, d):

--- a/tensorflow_addons/seq2seq/decoder.py
+++ b/tensorflow_addons/seq2seq/decoder.py
@@ -369,13 +369,13 @@ def dynamic_decode(
                     tf.convert_to_tensor(batch_size, name="batch_size")
                 )
                 if enable_tflite_convertible:
-                    # Since we can't use 2-D TensoArray and assume `batch_size` = 1,
+                    # Since we can't use 2-D TensorArray and assume `batch_size` = 1,
                     # we use `from_shape` dimension only.
                     return from_shape
                 return tf.TensorShape([batch_size]).concatenate(from_shape)
 
         dynamic_size = maximum_iterations is None or not is_xla
-        # The dynamic shape `TensoArray` is not allowed in TFLite yet.
+        # The dynamic shape `TensorArray` is not allowed in TFLite yet.
         dynamic_size = dynamic_size and (not enable_tflite_convertible)
 
         def _create_ta(s, d):

--- a/tensorflow_addons/seq2seq/decoder.py
+++ b/tensorflow_addons/seq2seq/decoder.py
@@ -337,7 +337,7 @@ def dynamic_decode(
             )
 
         if enable_tflite_convertible:
-            # Assume the batch_size = 1 for inference. 
+            # Assume the batch_size = 1 for inference.
             # So we can change 2-D TensorArray into 1-D by reshaping it.
             zero_outputs = tf.nest.map_structure(
                 lambda shape, dtype: tf.reshape(tf.zeros(
@@ -483,7 +483,7 @@ def dynamic_decode(
                 )
             else:
                 next_state = decoder_state
-                
+
             if enable_tflite_convertible:
                 # Reshape to 1-D.
                 emit = tf.nest.map_structure(lambda x: tf.reshape(x, [-1]), emit)

--- a/tensorflow_addons/seq2seq/tests/decoder_test.py
+++ b/tensorflow_addons/seq2seq/tests/decoder_test.py
@@ -21,6 +21,7 @@ import tensorflow as tf
 from tensorflow_addons.seq2seq import basic_decoder
 from tensorflow_addons.seq2seq import decoder
 from tensorflow_addons.seq2seq import sampler as sampler_py
+from tensorflow_addons.utils import test_utils
 
 
 @pytest.mark.usefixtures("maybe_run_functions_eagerly")
@@ -84,6 +85,8 @@ def test_dynamic_decode_rnn(time_major, maximum_iterations):
 
 
 def test_dynamic_decode_tflite_conversion():
+    if test_utils.is_gpu_available():
+        pytest.skip("cpu-only test")
     units = 10
     vocab_size = 20
     cell = tf.keras.layers.LSTMCell(units)


### PR DESCRIPTION
This PR adds some logics to make `dynamic_decoder()` TFLite-convertible.

Hi. I am Jae from TensorFlow Lite team.
Because TFLite doesn't support dynamic shape of `TensorArray` yet, it changes the `TensorArray`'s into static shape.
Also, 2-D `TensorArray` is not supported, so some reshaping at the input & output tensors is required.
Because TFLite assumes `batch_size = 1` at the inference, we can simply implement the above.

Thank you.