### PR TITLE
Fixes up nomenclature on L1 and L2 norms in triplet losses.

### DIFF
--- a/tensorflow_addons/losses/tests/triplet_test.py
+++ b/tensorflow_addons/losses/tests/triplet_test.py
@@ -154,7 +154,11 @@ def triplet_hard_loss_np(labels, embedding, margin, dist_func, soft=False):
 @pytest.mark.parametrize("dtype", [tf.float32, tf.float16, tf.bfloat16])
 @pytest.mark.parametrize(
     "dist_func, dist_metric",
-    [(angular_distance_np, "angular"), (squared_l_2_dists, "squared-L2"), (l_2_dists, "L2")],
+    [
+        (angular_distance_np, "angular"),
+        (squared_l_2_dists, "squared-L2"),
+        (l_2_dists, "L2"),
+    ],
 )
 def test_semihard_tripled_loss_angular(dtype, dist_func, dist_metric):
     num_data = 10
@@ -193,7 +197,11 @@ def test_serialization_semihard():
 @pytest.mark.parametrize("soft", [False, True])
 @pytest.mark.parametrize(
     "dist_func, dist_metric",
-    [(angular_distance_np, "angular"), (squared_l_2_dists, "squared-L2"), (l_2_dists, "L2")],
+    [
+        (angular_distance_np, "angular"),
+        (squared_l_2_dists, "squared-L2"),
+        (l_2_dists, "L2"),
+    ],
 )
 def test_hard_tripled_loss_angular(dtype, soft, dist_func, dist_metric):
     num_data = 20

--- a/tensorflow_addons/losses/tests/triplet_test.py
+++ b/tensorflow_addons/losses/tests/triplet_test.py
@@ -51,11 +51,11 @@ def pairwise_distance_np(feature, squared=False):
     return pairwise_distances
 
 
-def l_2_dists(embs):
+def squared_l_2_dists(embs):
     return pairwise_distance_np(embs, True)
 
 
-def l_1_dists(embs):
+def l_2_dists(embs):
     return pairwise_distance_np(embs, False)
 
 
@@ -154,7 +154,7 @@ def triplet_hard_loss_np(labels, embedding, margin, dist_func, soft=False):
 @pytest.mark.parametrize("dtype", [tf.float32, tf.float16, tf.bfloat16])
 @pytest.mark.parametrize(
     "dist_func, dist_metric",
-    [(angular_distance_np, "angular"), (l_2_dists, "L2"), (l_1_dists, "L1")],
+    [(angular_distance_np, "angular"), (squared_l_2_dists, "squared-L2"), (l_2_dists, "L2")],
 )
 def test_semihard_tripled_loss_angular(dtype, dist_func, dist_metric):
     num_data = 10
@@ -193,7 +193,7 @@ def test_serialization_semihard():
 @pytest.mark.parametrize("soft", [False, True])
 @pytest.mark.parametrize(
     "dist_func, dist_metric",
-    [(angular_distance_np, "angular"), (l_2_dists, "L2"), (l_1_dists, "L1")],
+    [(angular_distance_np, "angular"), (squared_l_2_dists, "squared-L2"), (l_2_dists, "L2")],
 )
 def test_hard_tripled_loss_angular(dtype, soft, dist_func, dist_metric):
     num_data = 20

--- a/tensorflow_addons/losses/triplet.py
+++ b/tensorflow_addons/losses/triplet.py
@@ -83,8 +83,8 @@ def triplet_semihard_loss(
         be l2 normalized.
       margin: Float, margin term in the loss definition.
       distance_metric: str or function, determines distance metric:
-                       "L1" for l1-norm distance
                        "L2" for l2-norm distance
+                       "squared-L2" for squared l2-norm distance
                        "angular" for cosine similarity
                         A custom function returning a 2d adjacency
                           matrix of a chosen distance metric can
@@ -118,12 +118,12 @@ def triplet_semihard_loss(
 
     # Build pairwise squared distance matrix
 
-    if distance_metric == "L1":
+    if distance_metric == "L2":
         pdist_matrix = metric_learning.pairwise_distance(
             precise_embeddings, squared=False
         )
 
-    elif distance_metric == "L2":
+    elif distance_metric == "squared-L2":
         pdist_matrix = metric_learning.pairwise_distance(
             precise_embeddings, squared=True
         )
@@ -217,8 +217,8 @@ def triplet_hard_loss(
       margin: Float, margin term in the loss definition.
       soft: Boolean, if set, use the soft margin version.
       distance_metric: str or function, determines distance metric:
-                       "L1" for l1-norm distance
                        "L2" for l2-norm distance
+                       "squared-L2" for squared l2-norm distance
                        "angular" for cosine similarity
                         A custom function returning a 2d adjacency
                           matrix of a chosen distance metric can
@@ -249,12 +249,12 @@ def triplet_hard_loss(
     labels = tf.reshape(labels, [lshape[0], 1])
 
     # Build pairwise squared distance matrix.
-    if distance_metric == "L1":
+    if distance_metric == "L2":
         pdist_matrix = metric_learning.pairwise_distance(
             precise_embeddings, squared=False
         )
 
-    elif distance_metric == "L2":
+    elif distance_metric == "squared-L2":
         pdist_matrix = metric_learning.pairwise_distance(
             precise_embeddings, squared=True
         )


### PR DESCRIPTION
I had a hard time figuring out why my siamese model was not being able to converge, i.e., it was always converging to the pre-defined margin. After a while, I found out that the nomenclature used along the triplet losses (`L1` and `L2`) might be wrong according to their mathematical formulation.

Let's start with the package `losses/metric_learning` and function `pairwise_distance()`:

- At L34, the euclidean distances between all samples are calculated;
- According to the euclidean distance definition, it is initially calculated by summing up the square of the difference between every dimension;
- From L47 to L53, it is optionally possible to reduce the distance with a square root. Hence, we have the square root of the previously calculated distance, thus creating the L2-distance.
- On the other hand, if we decide not to square root the previously calculated distance, we are not returning the L1-distance, as we have already calculated the sum of the square of the differences. Instead, we are returning a squared version of the L2-distance, usually called `squared-L2`.

This might lead users in thinking that using the `L2` argument they are using the euclidean distance, but they are using its squared version in which, regarding some problems and architectures, will not convergence.

Therefore, this PR proposes to tackle such an issue and rename every `L1` to `L2` on the triplet losses, as well as every `L2` to `squared-L2`. Please, correct if I am wrong, but this definitely fixed my convergence problem.

Best regards,
Gustavo.
