### PR TITLE
Fix sparse novograd

### DIFF
--- a/tensorflow_addons/optimizers/novograd.py
+++ b/tensorflow_addons/optimizers/novograd.py
@@ -234,7 +234,7 @@ class NovoGrad(tf.keras.optimizers.Optimizer):
             var.handle,
             m.handle,
             coefficients["lr_t"],
-            tf.gather(grad, indices),
+            grad,
             indices,
             coefficients["beta_1_t"],
             use_locking=self._use_locking,

--- a/tensorflow_addons/optimizers/novograd.py
+++ b/tensorflow_addons/optimizers/novograd.py
@@ -222,7 +222,9 @@ class NovoGrad(tf.keras.optimizers.Optimizer):
         else:
             grad = grad / (tf.sqrt(v_t) + self.epsilon)
         grad = tf.cond(
-            tf.greater(weight_decay, 0), lambda: grad + weight_decay * var, lambda: grad
+            tf.greater(weight_decay, 0),
+            lambda: grad + weight_decay * tf.gather(var, indices),
+            lambda: grad,
         )
         grad = tf.cond(
             tf.logical_and(grad_averaging, tf.not_equal(self.iterations, 0)),

--- a/tensorflow_addons/optimizers/tests/novograd_test.py
+++ b/tensorflow_addons/optimizers/tests/novograd_test.py
@@ -146,3 +146,31 @@ def test_serialization():
     config = tf.keras.optimizers.serialize(optimizer)
     new_optimizer = tf.keras.optimizers.deserialize(config)
     assert new_optimizer.get_config() == optimizer.get_config()
+
+
+def test_sparse():
+    np.random.seed(0x2020)
+    tf.random.set_seed(0x2020)
+
+    optimizer = NovoGrad()
+
+    val_0 = np.random.random((2,))
+    val_1 = np.random.random((2,))
+
+    var_0 = tf.Variable(val_0, dtype=tf.dtypes.float32)
+    var_1 = tf.Variable(val_1, dtype=tf.dtypes.float32)
+
+    grad_0 = tf.IndexedSlices(
+        tf.constant([np.random.standard_normal()]), tf.constant([0]), tf.constant([2]),
+    )
+    grad_1 = tf.IndexedSlices(
+        tf.constant([np.random.standard_normal()]), tf.constant([1]), tf.constant([2]),
+    )
+
+    grads_and_vars = list(zip([grad_0, grad_1], [var_0, var_1]))
+
+    for _ in range(10):
+        optimizer.apply_gradients(grads_and_vars)
+
+    np.testing.assert_allclose(var_0.numpy(), [0.854698, 0.5792915])
+    np.testing.assert_allclose(var_1.numpy(), [0.4628156, 0.22476907])


### PR DESCRIPTION
Fixes #1087.

- Gathering indices is done in `resource_sparse_apply_keras_momentum`.
- Sparse weight decay isn't correct: only need to apply on the sparse `grad`, so have to use `tf.gather` to extract `indices` of `var`.
- Original tests aren't robust: though it does call `_resource_apply_sparse`, but the test cases are dense.