### PR TITLE
Add support for scheduled weight decays in RectifiedAdam.

### DIFF
--- a/tensorflow_addons/optimizers/rectified_adam.py
+++ b/tensorflow_addons/optimizers/rectified_adam.py
@@ -97,7 +97,7 @@ class RectifiedAdam(tf.keras.optimizers.Optimizer):
             epsilon: A small constant for numerical stability.
             weight_decay: A `Tensor` or a floating point value, or a schedule
                 that is a `tf.keras.optimizers.schedules.LearningRateSchedule`.
-                Weight decay for each param.
+                Weight decay for each parameter.
             amsgrad: boolean. Whether to apply AMSGrad variant of this
                 algorithm from the paper "On the Convergence of Adam and
                 beyond".
@@ -136,6 +136,7 @@ class RectifiedAdam(tf.keras.optimizers.Optimizer):
         self._set_hyper("min_lr", min_lr)
         self.epsilon = epsilon or tf.keras.backend.epsilon()
         self.amsgrad = amsgrad
+        self._has_weight_decay = weight_decay != 0.0
         self._initial_total_steps = total_steps
 
     def _create_slots(self, var_list):
@@ -219,7 +220,7 @@ class RectifiedAdam(tf.keras.optimizers.Optimizer):
             sma_t >= sma_threshold, r_t * m_corr_t / (v_corr_t + epsilon_t), m_corr_t
         )
 
-        if wd_t > 0.0:
+        if self._has_weight_decay:
             var_t += wd_t * var
 
         var_update = var.assign_sub(lr_t * var_t, use_locking=self._use_locking)
@@ -290,7 +291,7 @@ class RectifiedAdam(tf.keras.optimizers.Optimizer):
             sma_t >= sma_threshold, r_t * m_corr_t / (v_corr_t + epsilon_t), m_corr_t
         )
 
-        if wd_t > 0.0:
+        if self._has_weight_decay:
             var_t += wd_t * var
 
         with tf.control_dependencies([var_t]):

--- a/tensorflow_addons/optimizers/rectified_adam.py
+++ b/tensorflow_addons/optimizers/rectified_adam.py
@@ -16,7 +16,7 @@
 import tensorflow as tf
 from tensorflow_addons.utils.types import FloatTensorLike
 
-from typing import Union, Callable
+from typing import Union, Callable, Dict
 from typeguard import typechecked
 
 
@@ -71,11 +71,11 @@ class RectifiedAdam(tf.keras.optimizers.Optimizer):
     @typechecked
     def __init__(
         self,
-        learning_rate: Union[FloatTensorLike, Callable] = 0.001,
+        learning_rate: Union[FloatTensorLike, Callable, Dict] = 0.001,
         beta_1: FloatTensorLike = 0.9,
         beta_2: FloatTensorLike = 0.999,
         epsilon: FloatTensorLike = 1e-7,
-        weight_decay: Union[FloatTensorLike, Callable] = 0.0,
+        weight_decay: Union[FloatTensorLike, Callable, Dict] = 0.0,
         amsgrad: bool = False,
         sma_threshold: FloatTensorLike = 5.0,
         total_steps: int = 0,
@@ -118,6 +118,13 @@ class RectifiedAdam(tf.keras.optimizers.Optimizer):
                 compatibility, recommended to use `learning_rate` instead.
         """
         super().__init__(name, **kwargs)
+
+        if isinstance(learning_rate, Dict):
+            learning_rate = tf.keras.optimizers.schedules.deserialize(learning_rate)
+
+        if isinstance(weight_decay, Dict):
+            weight_decay = tf.keras.optimizers.schedules.deserialize(weight_decay)
+
         self._set_hyper("learning_rate", kwargs.get("lr", learning_rate))
         self._set_hyper("beta_1", beta_1)
         self._set_hyper("beta_2", beta_2)

--- a/tensorflow_addons/optimizers/rectified_adam.py
+++ b/tensorflow_addons/optimizers/rectified_adam.py
@@ -75,7 +75,7 @@ class RectifiedAdam(tf.keras.optimizers.Optimizer):
         beta_1: FloatTensorLike = 0.9,
         beta_2: FloatTensorLike = 0.999,
         epsilon: FloatTensorLike = 1e-7,
-        weight_decay: FloatTensorLike = 0.0,
+        weight_decay: Union[FloatTensorLike, Callable] = 0.0,
         amsgrad: bool = False,
         sma_threshold: FloatTensorLike = 5.0,
         total_steps: int = 0,
@@ -87,15 +87,17 @@ class RectifiedAdam(tf.keras.optimizers.Optimizer):
         r"""Construct a new RAdam optimizer.
 
         Args:
-            learning_rate: A `Tensor` or a floating point value. or a schedule
-                that is a `tf.keras.optimizers.schedules.LearningRateSchedule`
+            learning_rate: A `Tensor` or a floating point value, or a schedule
+                that is a `tf.keras.optimizers.schedules.LearningRateSchedule`.
                 The learning rate.
             beta_1: A float value or a constant float tensor.
                 The exponential decay rate for the 1st moment estimates.
             beta_2: A float value or a constant float tensor.
                 The exponential decay rate for the 2nd moment estimates.
             epsilon: A small constant for numerical stability.
-            weight_decay: A floating point value. Weight decay for each param.
+            weight_decay: A `Tensor` or a floating point value, or a schedule
+                that is a `tf.keras.optimizers.schedules.LearningRateSchedule`.
+                Weight decay for each param.
             amsgrad: boolean. Whether to apply AMSGrad variant of this
                 algorithm from the paper "On the Convergence of Adam and
                 beyond".
@@ -127,7 +129,6 @@ class RectifiedAdam(tf.keras.optimizers.Optimizer):
         self._set_hyper("min_lr", min_lr)
         self.epsilon = epsilon or tf.keras.backend.epsilon()
         self.amsgrad = amsgrad
-        self._initial_weight_decay = weight_decay
         self._initial_total_steps = total_steps
 
     def _create_slots(self, var_list):
@@ -146,9 +147,18 @@ class RectifiedAdam(tf.keras.optimizers.Optimizer):
             weights = weights[: len(params)]
         super().set_weights(weights)
 
+
+    def _decayed_wd(self, var_dtype):
+      wd_t = self._get_hyper("weight_decay", var_dtype)
+      if isinstance(wd_t, tf.keras.optimizers.schedules.LearningRateSchedule):
+        wd_t = tf.cast(wd_t(self.iterations), var_dtype)
+      return wd_t
+
+
     def _resource_apply_dense(self, grad, var):
         var_dtype = var.dtype.base_dtype
         lr_t = self._decayed_lr(var_dtype)
+        wd_t = self._decayed_wd(var_dtype)
         m = self.get_slot(var, "m")
         v = self.get_slot(var, "v")
         beta_1_t = self._get_hyper("beta_1", var_dtype)
@@ -204,8 +214,8 @@ class RectifiedAdam(tf.keras.optimizers.Optimizer):
             sma_t >= sma_threshold, r_t * m_corr_t / (v_corr_t + epsilon_t), m_corr_t
         )
 
-        if self._initial_weight_decay > 0.0:
-            var_t += self._get_hyper("weight_decay", var_dtype) * var
+        if wd_t > 0.0:
+            var_t += wd_t * var
 
         var_update = var.assign_sub(lr_t * var_t, use_locking=self._use_locking)
 
@@ -217,6 +227,7 @@ class RectifiedAdam(tf.keras.optimizers.Optimizer):
     def _resource_apply_sparse(self, grad, var, indices):
         var_dtype = var.dtype.base_dtype
         lr_t = self._decayed_lr(var_dtype)
+        wd_t = self._decayed_wd(var_dtype)
         beta_1_t = self._get_hyper("beta_1", var_dtype)
         beta_2_t = self._get_hyper("beta_2", var_dtype)
         epsilon_t = tf.convert_to_tensor(self.epsilon, var_dtype)
@@ -274,8 +285,8 @@ class RectifiedAdam(tf.keras.optimizers.Optimizer):
             sma_t >= sma_threshold, r_t * m_corr_t / (v_corr_t + epsilon_t), m_corr_t
         )
 
-        if self._initial_weight_decay > 0.0:
-            var_t += self._get_hyper("weight_decay", var_dtype) * var
+        if wd_t > 0.0:
+            var_t += wd_t * var
 
         with tf.control_dependencies([var_t]):
             var_update = self._resource_scatter_add(

--- a/tensorflow_addons/optimizers/rectified_adam.py
+++ b/tensorflow_addons/optimizers/rectified_adam.py
@@ -147,13 +147,11 @@ class RectifiedAdam(tf.keras.optimizers.Optimizer):
             weights = weights[: len(params)]
         super().set_weights(weights)
 
-
     def _decayed_wd(self, var_dtype):
-      wd_t = self._get_hyper("weight_decay", var_dtype)
-      if isinstance(wd_t, tf.keras.optimizers.schedules.LearningRateSchedule):
-        wd_t = tf.cast(wd_t(self.iterations), var_dtype)
-      return wd_t
-
+        wd_t = self._get_hyper("weight_decay", var_dtype)
+        if isinstance(wd_t, tf.keras.optimizers.schedules.LearningRateSchedule):
+            wd_t = tf.cast(wd_t(self.iterations), var_dtype)
+        return wd_t
 
     def _resource_apply_dense(self, grad, var):
         var_dtype = var.dtype.base_dtype

--- a/tensorflow_addons/optimizers/tests/rectified_adam_test.py
+++ b/tensorflow_addons/optimizers/tests/rectified_adam_test.py
@@ -195,19 +195,17 @@ def test_scheduler_serialization():
     lr_scheduler = tf.keras.optimizers.schedules.ExponentialDecay(1e-3, 50, 0.5)
     wd_scheduler = tf.keras.optimizers.schedules.InverseTimeDecay(2e-3, 25, 0.25)
 
-    optimizer = RectifiedAdam(
-        learning_rate=lr_scheduler, weight_decay=wd_scheduler
-    )
+    optimizer = RectifiedAdam(learning_rate=lr_scheduler, weight_decay=wd_scheduler)
     config = tf.keras.optimizers.serialize(optimizer)
     new_optimizer = tf.keras.optimizers.deserialize(config)
     assert new_optimizer.get_config() == optimizer.get_config()
 
-    assert new_optimizer.get_config()['learning_rate'] == {
-      'class_name': 'ExponentialDecay',
-      'config': lr_scheduler.get_config(),
+    assert new_optimizer.get_config()["learning_rate"] == {
+        "class_name": "ExponentialDecay",
+        "config": lr_scheduler.get_config(),
     }
 
-    assert new_optimizer.get_config()['weight_decay'] == {
-      'class_name': 'InverseTimeDecay',
-      'config': wd_scheduler.get_config(),
+    assert new_optimizer.get_config()["weight_decay"] == {
+        "class_name": "InverseTimeDecay",
+        "config": wd_scheduler.get_config(),
     }

--- a/tensorflow_addons/optimizers/tests/rectified_adam_test.py
+++ b/tensorflow_addons/optimizers/tests/rectified_adam_test.py
@@ -177,3 +177,37 @@ def test_serialization():
     config = tf.keras.optimizers.serialize(optimizer)
     new_optimizer = tf.keras.optimizers.deserialize(config)
     assert new_optimizer.get_config() == optimizer.get_config()
+
+
+@pytest.mark.usefixtures("maybe_run_functions_eagerly")
+def test_schedulers():
+    lr_scheduler = tf.keras.optimizers.schedules.ExponentialDecay(1e-3, 50, 0.5)
+    wd_scheduler = tf.keras.optimizers.schedules.InverseTimeDecay(2e-3, 25, 0.25)
+
+    run_dense_sample(
+        iterations=100,
+        expected=[[0.993192, 1.992625], [2.993369, 3.993239]],
+        optimizer=RectifiedAdam(learning_rate=lr_scheduler, weight_decay=wd_scheduler),
+    )
+
+
+def test_scheduler_serialization():
+    lr_scheduler = tf.keras.optimizers.schedules.ExponentialDecay(1e-3, 50, 0.5)
+    wd_scheduler = tf.keras.optimizers.schedules.InverseTimeDecay(2e-3, 25, 0.25)
+
+    optimizer = RectifiedAdam(
+        learning_rate=lr_scheduler, weight_decay=wd_scheduler
+    )
+    config = tf.keras.optimizers.serialize(optimizer)
+    new_optimizer = tf.keras.optimizers.deserialize(config)
+    assert new_optimizer.get_config() == optimizer.get_config()
+
+    assert new_optimizer.get_config()['learning_rate'] == {
+      'class_name': 'ExponentialDecay',
+      'config': lr_scheduler.get_config(),
+    }
+
+    assert new_optimizer.get_config()['weight_decay'] == {
+      'class_name': 'InverseTimeDecay',
+      'config': wd_scheduler.get_config(),
+    }


### PR DESCRIPTION
RAdam implements weight decay based on AdamW, and the latter supports scheduling for both learning rate and weight decays.

This patch extends existing support of Keras schedulers for the learning rate to weight decay, matching the weight decay features of AdamW.

fixes https://github.com/tensorflow/addons/issues/1908