### PR TITLE
Improve support of global dtype policy in seq2seq layers

### DIFF
--- a/tensorflow_addons/conftest.py
+++ b/tensorflow_addons/conftest.py
@@ -1,6 +1,7 @@
 from tensorflow_addons.utils.test_utils import (  # noqa: F401
     maybe_run_functions_eagerly,
     run_custom_and_py_ops,
+    run_with_mixed_precision_policy,
     pytest_make_parametrize_id,
     data_format,
     set_seeds,

--- a/tensorflow_addons/seq2seq/attention_wrapper.py
+++ b/tensorflow_addons/seq2seq/attention_wrapper.py
@@ -110,8 +110,6 @@ class _BaseAttentionMechanism(AttentionMechanism, tf.keras.layers.Layer):
         """
         self.query_layer = query_layer
         self.memory_layer = memory_layer
-        if self.memory_layer is not None and "dtype" not in kwargs:
-            kwargs["dtype"] = self.memory_layer.dtype
         super().__init__(**kwargs)
         self.default_probability_fn = probability_fn
         self.probability_fn = probability_fn
@@ -556,8 +554,6 @@ class LuongAttention(_BaseAttentionMechanism):
         def wrapped_probability_fn(score, _):
             return probability_fn(score)
 
-        if dtype is None:
-            dtype = tf.float32
         memory_layer = kwargs.pop("memory_layer", None)
         if not memory_layer:
             memory_layer = tf.keras.layers.Dense(
@@ -735,8 +731,6 @@ class BahdanauAttention(_BaseAttentionMechanism):
         def wrapped_probability_fn(score, _):
             return probability_fn(score)
 
-        if dtype is None:
-            dtype = tf.float32
         query_layer = kwargs.pop("query_layer", None)
         if not query_layer:
             query_layer = tf.keras.layers.Dense(
@@ -1093,8 +1087,6 @@ class BahdanauMonotonicAttention(_BaseMonotonicAttentionMechanism):
             creation.
         """
         # Set up the monotonic probability fn with supplied parameters
-        if dtype is None:
-            dtype = tf.float32
         wrapped_probability_fn = functools.partial(
             _monotonic_probability_fn,
             sigmoid_noise=sigmoid_noise,
@@ -1274,8 +1266,6 @@ class LuongMonotonicAttention(_BaseMonotonicAttentionMechanism):
             creation.
         """
         # Set up the monotonic probability fn with supplied parameters
-        if dtype is None:
-            dtype = tf.float32
         wrapped_probability_fn = functools.partial(
             _monotonic_probability_fn,
             sigmoid_noise=sigmoid_noise,
@@ -1729,12 +1719,13 @@ class AttentionWrapper(tf.keras.layers.AbstractRNNCell):
                     "one integer per attention_mechanism, saw: %d vs %d"
                     % (len(attention_layer_sizes), len(attention_mechanisms))
                 )
+            dtype = kwargs.get("dtype", None)
             self._attention_layers = list(
                 tf.keras.layers.Dense(
                     attention_layer_size,
                     name="attention_layer",
                     use_bias=False,
-                    dtype=attention_mechanisms[i].dtype,
+                    dtype=dtype,
                 )
                 for i, attention_layer_size in enumerate(attention_layer_sizes)
             )

--- a/tensorflow_addons/seq2seq/sampler.py
+++ b/tensorflow_addons/seq2seq/sampler.py
@@ -390,6 +390,7 @@ class ScheduledEmbeddingTrainingSampler(TrainingSampler):
             sample_ids_sampling = tf.gather_nd(sample_ids, where_sampling)
             inputs_not_sampling = tf.gather_nd(base_next_inputs, where_not_sampling)
             sampled_next_inputs = self.embedding_fn(sample_ids_sampling)
+            sampled_next_inputs = tf.cast(sampled_next_inputs, inputs_not_sampling.dtype)
             base_shape = tf.shape(base_next_inputs)
             return tf.scatter_nd(
                 indices=where_sampling, updates=sampled_next_inputs, shape=base_shape

--- a/tensorflow_addons/seq2seq/sampler.py
+++ b/tensorflow_addons/seq2seq/sampler.py
@@ -390,7 +390,9 @@ class ScheduledEmbeddingTrainingSampler(TrainingSampler):
             sample_ids_sampling = tf.gather_nd(sample_ids, where_sampling)
             inputs_not_sampling = tf.gather_nd(base_next_inputs, where_not_sampling)
             sampled_next_inputs = self.embedding_fn(sample_ids_sampling)
-            sampled_next_inputs = tf.cast(sampled_next_inputs, inputs_not_sampling.dtype)
+            sampled_next_inputs = tf.cast(
+                sampled_next_inputs, inputs_not_sampling.dtype
+            )
             base_shape = tf.shape(base_next_inputs)
             return tf.scatter_nd(
                 indices=where_sampling, updates=sampled_next_inputs, shape=base_shape

--- a/tensorflow_addons/seq2seq/tests/attention_wrapper_test.py
+++ b/tensorflow_addons/seq2seq/tests/attention_wrapper_test.py
@@ -20,11 +20,9 @@ import pytest
 import numpy as np
 import tensorflow as tf
 
-from distutils.version import LooseVersion
 from tensorflow_addons.seq2seq import attention_wrapper as wrapper
 from tensorflow_addons.seq2seq import basic_decoder
 from tensorflow_addons.seq2seq import sampler as sampler_py
-from tensorflow_addons.utils import test_utils
 
 
 class DummyData:
@@ -542,8 +540,6 @@ def set_random_state_for_tf_and_np():
 
 @pytest.mark.usefixtures("run_with_mixed_precision_policy")
 def test_bahdanau_not_normalized():
-    if test_utils.is_gpu_available() and LooseVersion(tf.__version__) <= "2.2.0":
-        pytest.xfail("See https://github.com/tensorflow/tensorflow/issues/39775")
     set_random_state_for_tf_and_np()
     policy = tf.keras.mixed_precision.experimental.global_policy()
     create_attention_mechanism = wrapper.BahdanauAttention
@@ -620,8 +616,6 @@ def test_bahdanau_normalized():
 
 @pytest.mark.usefixtures("run_with_mixed_precision_policy")
 def test_luong_not_normalized():
-    if test_utils.is_gpu_available() and LooseVersion(tf.__version__) <= "2.2.0":
-        pytest.xfail("See https://github.com/tensorflow/tensorflow/issues/39775")
     set_random_state_for_tf_and_np()
     policy = tf.keras.mixed_precision.experimental.global_policy()
     create_attention_mechanism = wrapper.LuongAttention

--- a/tensorflow_addons/seq2seq/tests/attention_wrapper_test.py
+++ b/tensorflow_addons/seq2seq/tests/attention_wrapper_test.py
@@ -401,7 +401,9 @@ def _test_with_attention(
     policy = tf.keras.mixed_precision.experimental.global_policy()
     sampler = sampler_py.TrainingSampler()
     my_decoder = basic_decoder.BasicDecoder(cell=cell, sampler=sampler)
-    initial_state = cell.get_initial_state(batch_size=batch_size, dtype=policy.compute_dtype)
+    initial_state = cell.get_initial_state(
+        batch_size=batch_size, dtype=policy.compute_dtype
+    )
     final_outputs, final_state, _ = my_decoder(
         decoder_inputs,
         initial_state=initial_state,

--- a/tensorflow_addons/seq2seq/tests/attention_wrapper_test.py
+++ b/tensorflow_addons/seq2seq/tests/attention_wrapper_test.py
@@ -24,6 +24,7 @@ from distutils.version import LooseVersion
 from tensorflow_addons.seq2seq import attention_wrapper as wrapper
 from tensorflow_addons.seq2seq import basic_decoder
 from tensorflow_addons.seq2seq import sampler as sampler_py
+from tensorflow_addons.utils import test_utils
 
 
 class DummyData:

--- a/tensorflow_addons/seq2seq/tests/attention_wrapper_test.py
+++ b/tensorflow_addons/seq2seq/tests/attention_wrapper_test.py
@@ -20,6 +20,7 @@ import pytest
 import numpy as np
 import tensorflow as tf
 
+from distutils.version import LooseVersion
 from tensorflow_addons.seq2seq import attention_wrapper as wrapper
 from tensorflow_addons.seq2seq import basic_decoder
 from tensorflow_addons.seq2seq import sampler as sampler_py
@@ -540,6 +541,8 @@ def set_random_state_for_tf_and_np():
 
 @pytest.mark.usefixtures("run_with_mixed_precision_policy")
 def test_bahdanau_not_normalized():
+    if test_utils.is_gpu_available() and LooseVersion(tf.__version__) <= "2.2.0":
+        pytest.xfail("See https://github.com/tensorflow/tensorflow/issues/39775")
     set_random_state_for_tf_and_np()
     policy = tf.keras.mixed_precision.experimental.global_policy()
     create_attention_mechanism = wrapper.BahdanauAttention
@@ -616,6 +619,8 @@ def test_bahdanau_normalized():
 
 @pytest.mark.usefixtures("run_with_mixed_precision_policy")
 def test_luong_not_normalized():
+    if test_utils.is_gpu_available() and LooseVersion(tf.__version__) <= "2.2.0":
+        pytest.xfail("See https://github.com/tensorflow/tensorflow/issues/39775")
     set_random_state_for_tf_and_np()
     policy = tf.keras.mixed_precision.experimental.global_policy()
     create_attention_mechanism = wrapper.LuongAttention

--- a/tensorflow_addons/seq2seq/tests/attention_wrapper_test.py
+++ b/tensorflow_addons/seq2seq/tests/attention_wrapper_test.py
@@ -398,9 +398,10 @@ def _test_with_attention(
                 seed=1337
             )
 
+    policy = tf.keras.mixed_precision.experimental.global_policy()
     sampler = sampler_py.TrainingSampler()
     my_decoder = basic_decoder.BasicDecoder(cell=cell, sampler=sampler)
-    initial_state = cell.get_initial_state(dtype=tf.float32, batch_size=batch_size)
+    initial_state = cell.get_initial_state(batch_size=batch_size, dtype=policy.compute_dtype)
     final_outputs, final_state, _ = my_decoder(
         decoder_inputs,
         initial_state=initial_state,
@@ -427,7 +428,7 @@ def _test_with_attention(
         )
         tf.nest.assert_same_structure(
             cell.state_size,
-            cell.get_initial_state(batch_size=batch_size, dtype=tf.float32),
+            cell.get_initial_state(batch_size=batch_size, dtype=policy.compute_dtype),
         )
         # Remove the history from final_state for purposes of the
         # remainder of the tests.
@@ -535,32 +536,34 @@ def set_random_state_for_tf_and_np():
     DummyData2()
 
 
+@pytest.mark.usefixtures("run_with_mixed_precision_policy")
 def test_bahdanau_not_normalized():
     set_random_state_for_tf_and_np()
+    policy = tf.keras.mixed_precision.experimental.global_policy()
     create_attention_mechanism = wrapper.BahdanauAttention
     create_attention_kwargs = {"kernel_initializer": "ones"}
     expected_final_output = basic_decoder.BasicDecoderOutput(
         rnn_output=ResultSummary(
-            shape=(5, 3, 6), dtype=np.dtype(np.float32), mean=-0.003204414
+            shape=(5, 3, 6), dtype=policy.compute_dtype, mean=-0.003204414
         ),
         sample_id=ResultSummary(shape=(5, 3), dtype=np.dtype(np.int32), mean=3.2),
     )
     expected_final_state = wrapper.AttentionWrapperState(
         cell_state=[
-            ResultSummary(shape=(5, 9), dtype=np.dtype(np.float32), mean=0.40868404),
-            ResultSummary(shape=(5, 9), dtype=np.dtype(np.float32), mean=0.89017969),
+            ResultSummary(shape=(5, 9), dtype=policy.compute_dtype, mean=0.40868404),
+            ResultSummary(shape=(5, 9), dtype=policy.compute_dtype, mean=0.89017969),
         ],
         attention=ResultSummary(
-            shape=(5, 6), dtype=np.dtype(np.float32), mean=0.041453815
+            shape=(5, 6), dtype=policy.compute_dtype, mean=0.041453815
         ),
-        alignments=ResultSummary(shape=(5, 8), dtype=np.dtype(np.float32), mean=0.125),
+        alignments=ResultSummary(shape=(5, 8), dtype=policy.compute_dtype, mean=0.125),
         attention_state=ResultSummary(
-            shape=(5, 8), dtype=np.dtype(np.float32), mean=0.125
+            shape=(5, 8), dtype=policy.compute_dtype, mean=0.125
         ),
         alignment_history=(),
     )
     expected_final_alignment_history = ResultSummary(
-        shape=(3, 5, 8), dtype=np.dtype(np.float32), mean=0.125
+        shape=(3, 5, 8), dtype=policy.compute_dtype, mean=0.125
     )
 
     _test_with_attention(
@@ -609,27 +612,29 @@ def test_bahdanau_normalized():
     )
 
 
+@pytest.mark.usefixtures("run_with_mixed_precision_policy")
 def test_luong_not_normalized():
     set_random_state_for_tf_and_np()
+    policy = tf.keras.mixed_precision.experimental.global_policy()
     create_attention_mechanism = wrapper.LuongAttention
 
     expected_final_output = basic_decoder.BasicDecoderOutput(
         rnn_output=ResultSummary(
-            shape=(5, 3, 6), dtype=np.dtype("float32"), mean=-0.06124732
+            shape=(5, 3, 6), dtype=policy.compute_dtype, mean=-0.06124732
         ),
         sample_id=ResultSummary(shape=(5, 3), dtype=np.dtype("int32"), mean=2.73333333),
     )
     expected_final_state = wrapper.AttentionWrapperState(
         cell_state=[
-            ResultSummary(shape=(5, 9), dtype=np.dtype("float32"), mean=0.52021580),
-            ResultSummary(shape=(5, 9), dtype=np.dtype("float32"), mean=1.0964939),
+            ResultSummary(shape=(5, 9), dtype=policy.compute_dtype, mean=0.52021580),
+            ResultSummary(shape=(5, 9), dtype=policy.compute_dtype, mean=1.0964939),
         ],
         attention=ResultSummary(
-            shape=(5, 6), dtype=np.dtype("float32"), mean=-0.0318060
+            shape=(5, 6), dtype=policy.compute_dtype, mean=-0.0318060
         ),
-        alignments=ResultSummary(shape=(5, 8), dtype=np.dtype("float32"), mean=0.125),
+        alignments=ResultSummary(shape=(5, 8), dtype=policy.compute_dtype, mean=0.125),
         attention_state=ResultSummary(
-            shape=(5, 8), dtype=np.dtype("float32"), mean=0.125
+            shape=(5, 8), dtype=policy.compute_dtype, mean=0.125
         ),
         alignment_history=(),
     )

--- a/tensorflow_addons/utils/test_utils.py
+++ b/tensorflow_addons/utils/test_utils.py
@@ -100,6 +100,13 @@ def run_custom_and_py_ops(request):
     request.addfinalizer(_restore_py_ops_value)
 
 
+@pytest.fixture(scope="function", params=["float32", "mixed_float16"])
+def run_with_mixed_precision_policy(request):
+    tf.keras.mixed_precision.experimental.set_policy(request.param)
+    yield
+    tf.keras.mixed_precision.experimental.set_policy("float32")
+
+
 @pytest.fixture(scope="function", params=["channels_first", "channels_last"])
 def data_format(request):
     return request.param

--- a/tensorflow_addons/utils/test_utils.py
+++ b/tensorflow_addons/utils/test_utils.py
@@ -21,6 +21,8 @@ import numpy as np
 import pytest
 import tensorflow as tf
 
+from distutils.version import LooseVersion
+
 from tensorflow_addons import options
 from tensorflow_addons.utils import resource_loader
 
@@ -102,6 +104,8 @@ def run_custom_and_py_ops(request):
 
 @pytest.fixture(scope="function", params=["float32", "mixed_float16"])
 def run_with_mixed_precision_policy(request):
+    if is_gpu_available() and LooseVersion(tf.__version__) <= "2.2.0":
+        pytest.xfail("See https://github.com/tensorflow/tensorflow/issues/39775")
     tf.keras.mixed_precision.experimental.set_policy(request.param)
     yield
     tf.keras.mixed_precision.experimental.set_policy("float32")


### PR DESCRIPTION
The layers should not set a dtype, unless explicitly passed by the user.

Fixes #1968.