### PR TITLE
Duplicate descriptions also to functions

### DIFF
--- a/tensorflow_addons/losses/focal_loss.py
+++ b/tensorflow_addons/losses/focal_loss.py
@@ -94,7 +94,17 @@ def sigmoid_focal_crossentropy(
     gamma: FloatTensorLike = 2.0,
     from_logits: bool = False,
 ) -> tf.Tensor:
-    """
+    """Implements the focal loss function.
+
+    Focal loss was first introduced in the RetinaNet paper
+    (https://arxiv.org/pdf/1708.02002.pdf). Focal loss is extremely useful for
+    classification when you have highly imbalanced classes. It down-weights
+    well-classified examples and focuses on hard examples. The loss value is
+    much high for a sample which is misclassified by the classifier as compared
+    to the loss value corresponding to a well-classified example. One of the
+    best use-cases of focal loss is its usage in object detection where the
+    imbalance between the background class and other classes is extremely high.
+
     Args
         y_true: true targets tensor.
         y_pred: predictions tensor.

--- a/tensorflow_addons/losses/giou_loss.py
+++ b/tensorflow_addons/losses/giou_loss.py
@@ -63,7 +63,14 @@ class GIoULoss(LossFunctionWrapper):
 
 @tf.keras.utils.register_keras_serializable(package="Addons")
 def giou_loss(y_true: TensorLike, y_pred: TensorLike, mode: str = "giou") -> tf.Tensor:
-    """
+    """Implements the GIoU loss function.
+
+    GIoU loss was first introduced in the
+    [Generalized Intersection over Union:
+    A Metric and A Loss for Bounding Box Regression]
+    (https://giou.stanford.edu/GIoU.pdf).
+    GIoU is an enhancement for models which use IoU in object detection.
+
     Args:
         y_true: true targets tensor. The coordinates of the each bounding
             box in boxes are encoded as [y_min, x_min, y_max, x_max].


### PR DESCRIPTION
Currently [documentation](https://www.tensorflow.org/addons/api_docs/python/tfa/losses#functions) looks slightly broken, for some losses

![image](https://user-images.githubusercontent.com/775466/87257495-b0003500-c49b-11ea-8693-785903911fe8.png)

Not a big fan of repeating docs in two places, but it looks like a consistent behaviour we do in other places as well.

Also, not sure if it also makes sense to adjust usage examples and bring to the added docs