### PR TITLE
Set shape for dense image warp

### DIFF
--- a/tensorflow_addons/conftest.py
+++ b/tensorflow_addons/conftest.py
@@ -1,5 +1,6 @@
 from tensorflow_addons.utils.test_utils import (  # noqa: F401
     maybe_run_functions_eagerly,
+    only_run_functions_eagerly,
     run_custom_and_py_ops,
     run_with_mixed_precision_policy,
     pytest_make_parametrize_id,

--- a/tensorflow_addons/image/dense_image_warp.py
+++ b/tensorflow_addons/image/dense_image_warp.py
@@ -249,4 +249,5 @@ def dense_image_warp(
         # image grid.
         interpolated = interpolate_bilinear(image, query_points_flattened)
         interpolated = tf.reshape(interpolated, [batch_size, height, width, channels])
+        interpolated.set_shape(image.shape)
         return interpolated

--- a/tensorflow_addons/image/tests/dense_image_warp_test.py
+++ b/tensorflow_addons/image/tests/dense_image_warp_test.py
@@ -251,3 +251,11 @@ def test_unknown_shapes():
     shapes_to_try = [[3, 4, 5, 6], [1, 2, 2, 1]]
     for shape in shapes_to_try:
         _check_interpolation_correctness(shape, "float32", "float32", True)
+
+
+@pytest.mark.usefixtures("only_run_functions_eagerly")
+def test_symbolic_tensor_shape():
+    image = tf.keras.layers.Input(shape=(7, 7, 192))
+    flow = tf.ones((1, 7, 7, 2))
+    interp = dense_image_warp(image, flow)
+    np.testing.assert_array_equal(interp.shape.as_list(), [None, 7, 7, 192])

--- a/tensorflow_addons/utils/test_utils.py
+++ b/tensorflow_addons/utils/test_utils.py
@@ -88,6 +88,12 @@ def maybe_run_functions_eagerly(request):
     request.addfinalizer(finalizer)
 
 
+@pytest.fixture(scope="function")
+def only_run_functions_eagerly(request):
+    tf.config.experimental_run_functions_eagerly(True)
+    request.addfinalizer(finalizer)
+
+
 @pytest.fixture(scope="function", params=["custom_ops", "py_ops"])
 def run_custom_and_py_ops(request):
     previous_py_ops_value = options.TF_ADDONS_PY_OPS


### PR DESCRIPTION
Closes #1969. Because feeding keras symbolic tensor into `tf.function` only supports when `tf.config.experimental_run_functions_eagerly(True)`, I create a new fixture.