### PR TITLE
Clean up .assign in optmizers

### DIFF
--- a/tensorflow_addons/optimizers/average_wrapper.py
+++ b/tensorflow_addons/optimizers/average_wrapper.py
@@ -120,7 +120,7 @@ class AveragedOptimizerWrapper(tf.keras.optimizers.Optimizer, metaclass=abc.ABCM
         """
         assign_op = tf.group(
             [
-                var.assign(self.get_slot(var, "average"))
+                var.assign(self.get_slot(var, "average"), use_locking=self._use_locking)
                 for var in var_list
                 if var.trainable
             ]

--- a/tensorflow_addons/optimizers/conditional_gradient.py
+++ b/tensorflow_addons/optimizers/conditional_gradient.py
@@ -178,9 +178,8 @@ class ConditionalGradient(tf.keras.optimizers.Optimizer):
             )
             s = top_singular_vector
 
-        return var.assign(
-            var * lr - (1 - lr) * lambda_ * s, use_locking=self._use_locking
-        )
+        var_update = tf.math.multiply(var, lr) - (1 - lr) * lambda_ * s
+        return var.assign(var_update, use_locking=self._use_locking)
 
     def _resource_apply_sparse(self, grad, var, indices, apply_state=None):
         var_device, var_dtype = var.device, var.dtype.base_dtype

--- a/tensorflow_addons/optimizers/conditional_gradient.py
+++ b/tensorflow_addons/optimizers/conditional_gradient.py
@@ -178,7 +178,9 @@ class ConditionalGradient(tf.keras.optimizers.Optimizer):
             )
             s = top_singular_vector
 
-        return var.assign(var * lr - (1 - lr) * lambda_ * s, use_locking=self._use_locking)
+        return var.assign(
+            var * lr - (1 - lr) * lambda_ * s, use_locking=self._use_locking
+        )
 
     def _resource_apply_sparse(self, grad, var, indices, apply_state=None):
         var_device, var_dtype = var.device, var.dtype.base_dtype

--- a/tensorflow_addons/optimizers/conditional_gradient.py
+++ b/tensorflow_addons/optimizers/conditional_gradient.py
@@ -59,7 +59,6 @@ class ConditionalGradient(tf.keras.optimizers.Optimizer):
         lambda_: Union[FloatTensorLike, Callable] = 0.01,
         epsilon: FloatTensorLike = 1e-7,
         ord: str = "fro",
-        use_locking: bool = False,
         name: str = "ConditionalGradient",
         **kwargs
     ):
@@ -75,7 +74,6 @@ class ConditionalGradient(tf.keras.optimizers.Optimizer):
                 gradient to be zero.
             ord: Order of the norm. Supported values are `'fro'`
                 and `'nuclear'`. Default is `'fro'`, which is frobenius norm.
-            use_locking: If `True`, use locks for update operations.
             name: Optional name prefix for the operations created when
                 applying gradients. Defaults to 'ConditionalGradient'.
             **kwargs: keyword arguments. Allowed to be {`clipnorm`,
@@ -96,7 +94,6 @@ class ConditionalGradient(tf.keras.optimizers.Optimizer):
                 % (supported_norms, ord)
             )
         self.ord = ord
-        self._set_hyper("use_locking", use_locking)
 
     def get_config(self):
         config = {
@@ -104,7 +101,6 @@ class ConditionalGradient(tf.keras.optimizers.Optimizer):
             "lambda_": self._serialize_hyperparameter("lambda_"),
             "epsilon": self.epsilon,
             "ord": self.ord,
-            "use_locking": self._serialize_hyperparameter("use_locking"),
         }
         base_config = super().get_config()
         return {**base_config, **config}
@@ -182,13 +178,7 @@ class ConditionalGradient(tf.keras.optimizers.Optimizer):
             )
             s = top_singular_vector
 
-        var_update_tensor = tf.math.multiply(var, lr) - (1 - lr) * lambda_ * s
-        var_update_kwargs = {
-            "resource": var.handle,
-            "value": var_update_tensor,
-        }
-        var_update_op = tf.raw_ops.AssignVariableOp(**var_update_kwargs)
-        return tf.group(var_update_op)
+        return var.assign(var * lr - (1 - lr) * lambda_ * s, use_locking=self._use_locking)
 
     def _resource_apply_sparse(self, grad, var, indices, apply_state=None):
         var_device, var_dtype = var.device, var.dtype.base_dtype

--- a/tensorflow_addons/optimizers/lamb.py
+++ b/tensorflow_addons/optimizers/lamb.py
@@ -166,7 +166,7 @@ class LAMB(tf.keras.optimizers.Optimizer):
             )
 
         var_update = var - ratio * coefficients["lr_t"] * update
-        return var.assign(var_update, use_locking=self._use_locking).op
+        return var.assign(var_update, use_locking=self._use_locking)
 
     def _resource_apply_sparse(self, grad, var, indices, apply_state=None):
         var_device, var_dtype = var.device, var.dtype.base_dtype

--- a/tensorflow_addons/optimizers/moving_average.py
+++ b/tensorflow_addons/optimizers/moving_average.py
@@ -156,16 +156,13 @@ class MovingAverage(AveragedOptimizerWrapper):
     @tf.function
     def _swap_weights(self):
         def fn_0(a, b):
-            a.assign_add(b)
-            return a
+            return a.assign_add(b, use_locking=self._use_locking)
 
         def fn_1(b, a):
-            b.assign(a - b)
-            return b
+            return b.assign(a - b, use_locking=self._use_locking)
 
         def fn_2(a, b):
-            a.assign_sub(b)
-            return a
+            return a.assign_sub(b, use_locking=self._use_locking)
 
         def swap(strategy, a, b):
             """Swap `a` and `b` and mirror to all devices."""


### PR DESCRIPTION
- Use `.assign` instead of raw ops.
- Apply `use_locking` when doing assignment
- Remove trivial `.op`

Cause they are all related to `.assign`, I put them into one PR.