### PR TITLE
Install setuptools first

### DIFF
--- a/tools/docker/build_wheel.Dockerfile
+++ b/tools/docker/build_wheel.Dockerfile
@@ -23,6 +23,8 @@ RUN mv /usr/bin/lsb_release2 /usr/bin/lsb_release
 ARG PY_VERSION
 RUN ln -sf $(which python$PY_VERSION) /usr/bin/python
 
+RUN python -m pip install setuptools
+
 RUN python -m pip install --upgrade pip==19.0 auditwheel==2.0.0
 
 ARG TF_VERSION


### PR DESCRIPTION
Build broke yesterday because `setuptools` does not present in dist-packages of python3.5 on linux. Try to investigate and fix it :-(

https://github.com/tensorflow/addons/pull/1994/checks?check_run_id=867618216