### PR TITLE
Add PR template

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,50 @@
+# Description
+
+Please include a summary of the change and which issue is fixed. 
+
+Fixes # (issue)
+
+## Type of change
+
+
+- [ ] Bug fix
+- [ ] New Tutorial
+- [ ] Updated or additional documentation
+- [ ] Additional Testing
+- [ ] New Activation (Requires creating an issue first)
+    - [ ] The changes conform to the [contribution guidelines](https://github.com/tensorflow/addons/blob/master/tensorflow_addons/activations/README.md#contribution-guidelines)
+- [ ] New Callback (Requires creating an issue first)
+    - [ ] The changes conform to the [contribution guidelines](https://github.com/tensorflow/addons/blob/master/tensorflow_addons/callbacks/README.md#contribution-guidelines)
+- [ ] New Image addition (Requires creating an issue first)
+    - [ ] The changes conform to the [contribution guidelines](https://github.com/tensorflow/addons/blob/master/tensorflow_addons/image/README.md#contribution-guidelines)
+- [ ] New Layer (Requires creating an issue first)
+    - [ ] The changes conform to the [contribution guidelines](https://github.com/tensorflow/addons/blob/master/tensorflow_addons/layers/README.md#contribution-guidelines)
+- [ ] New Loss (Requires creating an issue first)
+    - [ ] The changes conform to the [contribution guidelines](https://github.com/tensorflow/addons/blob/master/tensorflow_addons/losses/README.md#contribution-guidelines)
+- [ ] New Metric (Requires creating an issue first)
+    - [ ] The changes conform to the [contribution guidelines](https://github.com/tensorflow/addons/blob/master/tensorflow_addons/metrics/README.md#contribution-guidelines)
+- [ ] New Optimizer (Requires creating an issue first)
+    - [ ] The changes conform to the [contribution guidelines](https://github.com/tensorflow/addons/blob/master/tensorflow_addons/optimizers/README.md#contribution-guidelines)
+- [ ] New RNN Cell (Requires creating an issue first)
+    - [ ] The changes conform to the [contribution guidelines](https://github.com/tensorflow/addons/blob/master/tensorflow_addons/rnn/README.md#contribution-guidelines)
+- [ ] New Seq2seq addition (Requires creating an issue first)
+    - [ ] The changes conform to the [contribution guidelines](https://github.com/tensorflow/addons/blob/master/tensorflow_addons/seq2seq/README.md#contribution-guidelines)
+- [ ] New Text addition (Requires creating an issue first)
+    - [ ] The changes conform to the [contribution guidelines](https://github.com/tensorflow/addons/blob/master/tensorflow_addons/text/README.md#contribution-guidelines)
+
+
+# How Has This Been Tested?
+
+If you're adding a bugfix or new feature please describe the tests that you ran to verify your changes:
+*  
+
+
+# Checklist:
+
+- [ ] I've properly [formatted my code according to the guidelines](https://github.com/tensorflow/addons/blob/master/CONTRIBUTING.md#coding-style)
+    - [ ] By running Black + Flake8
+    - [ ] By running pre-commit hooks
+- [ ] This PR addresses an already submitted issue for TensorFlow Addons
+- [ ] I have made corresponding changes to the documentation
+- [ ] I have added tests that prove my fix is effective or that my feature works
+- [ ] This PR contains modifications to C++ custom-ops


### PR DESCRIPTION
Closes #1815 

It would be great to break these out into several templates that are more specific to the contribution. However, from what I gather that would require users to navigate to the URL of the specific PR template which seems unlikely to happen. 

LMK if there are other things we want covered here or a better way to present the contribution guidelines (It may be a bit unwieldy when editing the markdown instead of viewing the rendered file.