### PR TITLE
Use tf.keras.backend.epsilon() as dtype

### DIFF
--- a/tensorflow_addons/losses/kappa_loss.py
+++ b/tensorflow_addons/losses/kappa_loss.py
@@ -113,7 +113,7 @@ class WeightedKappaLoss(tf.keras.losses.Loss):
 
     def call(self, y_true, y_pred):
         y_true = tf.cast(y_true, dtype=self.col_label_vec.dtype)
-        y_pred = tf.cast(y_pred, dtype=self.weight_mat)
+        y_pred = tf.cast(y_pred, dtype=self.weight_mat.dtype)
         batch_size = tf.shape(y_true)[0]
         cat_labels = tf.matmul(y_true, self.col_label_vec)
         cat_label_mat = tf.tile(cat_labels, [1, self.num_classes])

--- a/tensorflow_addons/losses/kappa_loss.py
+++ b/tensorflow_addons/losses/kappa_loss.py
@@ -14,6 +14,7 @@
 # ==============================================================================
 """Implements Weighted kappa loss."""
 
+import warnings
 from typing import Optional
 
 import tensorflow as tf
@@ -87,14 +88,20 @@ class WeightedKappaLoss(tf.keras.losses.Loss):
 
         super().__init__(name=name, reduction=reduction)
 
+        warnings.warn(
+            "The data type for `WeightedKappaLoss` defaults to "
+            "`tf.keras.backend.floatx()`."
+            "The argument `dtype` will be removed in Addons `0.12`.",
+            DeprecationWarning,
+        )
+
         if weightage not in ("linear", "quadratic"):
             raise ValueError("Unknown kappa weighting type.")
 
         self.weightage = weightage
         self.num_classes = num_classes
         self.epsilon = epsilon or tf.keras.backend.epsilon()
-        self.dtype = dtype
-        label_vec = tf.range(num_classes, dtype=self.dtype)
+        label_vec = tf.range(num_classes, dtype=tf.keras.backend.floatx())
         self.row_label_vec = tf.reshape(label_vec, [1, num_classes])
         self.col_label_vec = tf.reshape(label_vec, [num_classes, 1])
         col_mat = tf.tile(self.col_label_vec, [1, num_classes])
@@ -105,8 +112,8 @@ class WeightedKappaLoss(tf.keras.losses.Loss):
             self.weight_mat = (col_mat - row_mat) ** 2
 
     def call(self, y_true, y_pred):
-        y_true = tf.cast(y_true, dtype=self.dtype)
-        y_pred = tf.cast(y_pred, dtype=self.dtype)
+        y_true = tf.cast(y_true, dtype=self.col_label_vec.dtype)
+        y_pred = tf.cast(y_pred, dtype=self.weight_mat.dtype)
         batch_size = tf.shape(y_true)[0]
         cat_labels = tf.matmul(y_true, self.col_label_vec)
         cat_label_mat = tf.tile(cat_labels, [1, self.num_classes])
@@ -129,12 +136,6 @@ class WeightedKappaLoss(tf.keras.losses.Loss):
             "num_classes": self.num_classes,
             "weightage": self.weightage,
             "epsilon": self.epsilon,
-            "dtype": self.dtype.as_datatype_enum,
         }
         base_config = super().get_config()
         return {**base_config, **config}
-
-    @classmethod
-    def from_config(cls, config):
-        config["dtype"] = tf.as_dtype(config["dtype"])
-        return cls(**config)

--- a/tensorflow_addons/losses/kappa_loss.py
+++ b/tensorflow_addons/losses/kappa_loss.py
@@ -14,10 +14,13 @@
 # ==============================================================================
 """Implements Weighted kappa loss."""
 
-import tensorflow as tf
-from tensorflow_addons.utils.types import Number
-from typeguard import typechecked
+import warnings
 from typing import Optional
+
+import tensorflow as tf
+from typeguard import typechecked
+
+from tensorflow_addons.utils.types import Number
 
 
 @tf.keras.utils.register_keras_serializable(package="Addons")
@@ -85,14 +88,20 @@ class WeightedKappaLoss(tf.keras.losses.Loss):
 
         super().__init__(name=name, reduction=reduction)
 
+        warnings.warn(
+            "The data type for `WeightedKappaLoss` defaults to "
+            "`tf.keras.backend.floatx()`."
+            "The argument `dtype` will be removed in Addons `0.12`.",
+            DeprecationWarning,
+        )
+
         if weightage not in ("linear", "quadratic"):
             raise ValueError("Unknown kappa weighting type.")
 
         self.weightage = weightage
         self.num_classes = num_classes
-        self.epsilon = epsilon
-        self.dtype = dtype
-        label_vec = tf.range(num_classes, dtype=dtype)
+        self.epsilon = epsilon or tf.keras.backend.epsilon()
+        label_vec = tf.range(num_classes, dtype=tf.keras.backend.floatx())
         self.row_label_vec = tf.reshape(label_vec, [1, num_classes])
         self.col_label_vec = tf.reshape(label_vec, [num_classes, 1])
         col_mat = tf.tile(self.col_label_vec, [1, num_classes])
@@ -103,7 +112,7 @@ class WeightedKappaLoss(tf.keras.losses.Loss):
             self.weight_mat = (col_mat - row_mat) ** 2
 
     def call(self, y_true, y_pred):
-        y_true = tf.cast(y_true, dtype=self.dtype)
+        y_true = tf.cast(y_true, dtype=tf.keras.backend.floatx())
         batch_size = tf.shape(y_true)[0]
         cat_labels = tf.matmul(y_true, self.col_label_vec)
         cat_label_mat = tf.tile(cat_labels, [1, self.num_classes])
@@ -117,7 +126,7 @@ class WeightedKappaLoss(tf.keras.losses.Loss):
         pred_dist = tf.reduce_sum(y_pred, axis=0, keepdims=True)
         w_pred_dist = tf.matmul(self.weight_mat, pred_dist, transpose_b=True)
         denominator = tf.reduce_sum(tf.matmul(label_dist, w_pred_dist))
-        denominator /= tf.cast(batch_size, dtype=self.dtype)
+        denominator /= tf.cast(batch_size, dtype=denominator.dtype)
         loss = tf.math.divide_no_nan(numerator, denominator)
         return tf.math.log(loss + self.epsilon)
 
@@ -126,7 +135,6 @@ class WeightedKappaLoss(tf.keras.losses.Loss):
             "num_classes": self.num_classes,
             "weightage": self.weightage,
             "epsilon": self.epsilon,
-            "dtype": self.dtype,
         }
         base_config = super().get_config()
         return {**base_config, **config}

--- a/tensorflow_addons/losses/kappa_loss.py
+++ b/tensorflow_addons/losses/kappa_loss.py
@@ -112,7 +112,8 @@ class WeightedKappaLoss(tf.keras.losses.Loss):
             self.weight_mat = (col_mat - row_mat) ** 2
 
     def call(self, y_true, y_pred):
-        y_true = tf.cast(y_true, dtype=tf.keras.backend.floatx())
+        y_true = tf.cast(y_true, dtype=self.col_label_vec.dtype)
+        y_pred = tf.cast(y_pred, dtype=self.weight_mat)
         batch_size = tf.shape(y_true)[0]
         cat_labels = tf.matmul(y_true, self.col_label_vec)
         cat_label_mat = tf.tile(cat_labels, [1, self.num_classes])

--- a/tensorflow_addons/losses/tests/kappa_loss_test.py
+++ b/tensorflow_addons/losses/tests/kappa_loss_test.py
@@ -61,7 +61,7 @@ def gen_labels_and_preds(num_samples, num_classes, seed):
 def test_linear_weighted_kappa_loss(np_seed):
     y_true, y_pred = gen_labels_and_preds(50, 4, np_seed)
     kappa_loss = WeightedKappaLoss(num_classes=4, weightage="linear")
-    y_pred = y_pred.astype(kappa_loss.dtype.as_numpy_dtype)
+    y_pred = y_pred.astype(np.float32)
     loss = kappa_loss(y_true, y_pred)
     loss_np = weighted_kappa_loss_np(y_true, y_pred, weightage="linear")
     np.testing.assert_allclose(loss, loss_np, rtol=1e-5, atol=1e-5)
@@ -71,7 +71,7 @@ def test_linear_weighted_kappa_loss(np_seed):
 def test_quadratic_weighted_kappa_loss(np_seed):
     y_true, y_pred = gen_labels_and_preds(100, 3, np_seed)
     kappa_loss = WeightedKappaLoss(num_classes=3)
-    y_pred = y_pred.astype(kappa_loss.dtype.as_numpy_dtype)
+    y_pred = y_pred.astype(np.float32)
     loss = kappa_loss(y_true, y_pred)
     loss_np = weighted_kappa_loss_np(y_true, y_pred)
     np.testing.assert_allclose(loss, loss_np, rtol=1e-5, atol=1e-5)
@@ -101,11 +101,3 @@ def test_save_model(tmpdir):
     )
     model.compile(optimizer="adam", loss=WeightedKappaLoss(num_classes=6))
     model.save(str(tmpdir / "test.h5"))
-
-
-def test_dtype_config():
-    wkl = WeightedKappaLoss(num_classes=4, dtype=tf.float32)
-    config = wkl.get_config()
-    assert config["dtype"] == tf.float32.as_datatype_enum
-    new_wkl = WeightedKappaLoss.from_config(config)
-    assert new_wkl.dtype == tf.float32

--- a/tensorflow_addons/losses/tests/kappa_loss_test.py
+++ b/tensorflow_addons/losses/tests/kappa_loss_test.py
@@ -61,7 +61,7 @@ def gen_labels_and_preds(num_samples, num_classes, seed):
 def test_linear_weighted_kappa_loss(np_seed):
     y_true, y_pred = gen_labels_and_preds(50, 4, np_seed)
     kappa_loss = WeightedKappaLoss(num_classes=4, weightage="linear")
-    y_pred = y_pred.astype(kappa_loss.dtype.as_numpy_dtype)
+    y_pred = y_pred.astype(np.float32)
     loss = kappa_loss(y_true, y_pred)
     loss_np = weighted_kappa_loss_np(y_true, y_pred, weightage="linear")
     np.testing.assert_allclose(loss, loss_np, rtol=1e-5, atol=1e-5)
@@ -71,7 +71,7 @@ def test_linear_weighted_kappa_loss(np_seed):
 def test_quadratic_weighted_kappa_loss(np_seed):
     y_true, y_pred = gen_labels_and_preds(100, 3, np_seed)
     kappa_loss = WeightedKappaLoss(num_classes=3)
-    y_pred = y_pred.astype(kappa_loss.dtype.as_numpy_dtype)
+    y_pred = y_pred.astype(np.float32)
     loss = kappa_loss(y_true, y_pred)
     loss_np = weighted_kappa_loss_np(y_true, y_pred)
     np.testing.assert_allclose(loss, loss_np, rtol=1e-5, atol=1e-5)
@@ -90,3 +90,12 @@ def test_config():
 def test_serialization():
     loss = WeightedKappaLoss(num_classes=3)
     tf.keras.losses.deserialize(tf.keras.losses.serialize(loss))
+
+
+def test_save_model(tmpdir):
+    model = tf.keras.models.Sequential(
+        tf.keras.layers.Input((256, 256, 3)),
+        tf.keras.layers.Dense(6, activation="softmax"),
+    )
+    model.compile(optimizer="adam", loss=WeightedKappaLoss(num_classes=6))
+    model.save(str(tmpdir / "test.h5"))

--- a/tensorflow_addons/losses/tests/kappa_loss_test.py
+++ b/tensorflow_addons/losses/tests/kappa_loss_test.py
@@ -61,7 +61,7 @@ def gen_labels_and_preds(num_samples, num_classes, seed):
 def test_linear_weighted_kappa_loss(np_seed):
     y_true, y_pred = gen_labels_and_preds(50, 4, np_seed)
     kappa_loss = WeightedKappaLoss(num_classes=4, weightage="linear")
-    y_pred = y_pred.astype(np.float32)
+    y_pred = y_pred.astype(kappa_loss.dtype.as_numpy_dtype)
     loss = kappa_loss(y_true, y_pred)
     loss_np = weighted_kappa_loss_np(y_true, y_pred, weightage="linear")
     np.testing.assert_allclose(loss, loss_np, rtol=1e-5, atol=1e-5)
@@ -71,7 +71,7 @@ def test_linear_weighted_kappa_loss(np_seed):
 def test_quadratic_weighted_kappa_loss(np_seed):
     y_true, y_pred = gen_labels_and_preds(100, 3, np_seed)
     kappa_loss = WeightedKappaLoss(num_classes=3)
-    y_pred = y_pred.astype(np.float32)
+    y_pred = y_pred.astype(kappa_loss.dtype.as_numpy_dtype)
     loss = kappa_loss(y_true, y_pred)
     loss_np = weighted_kappa_loss_np(y_true, y_pred)
     np.testing.assert_allclose(loss, loss_np, rtol=1e-5, atol=1e-5)
@@ -101,3 +101,11 @@ def test_save_model(tmpdir):
     )
     model.compile(optimizer="adam", loss=WeightedKappaLoss(num_classes=6))
     model.save(str(tmpdir / "test.h5"))
+
+
+def test_dtype_config():
+    wkl = WeightedKappaLoss(num_classes=4, dtype=tf.float32)
+    config = wkl.get_config()
+    assert config["dtype"] == tf.float32.as_datatype_enum
+    new_wkl = WeightedKappaLoss.from_config(config)
+    assert new_wkl.dtype == tf.float32

--- a/tensorflow_addons/losses/tests/kappa_loss_test.py
+++ b/tensorflow_addons/losses/tests/kappa_loss_test.py
@@ -94,8 +94,10 @@ def test_serialization():
 
 def test_save_model(tmpdir):
     model = tf.keras.models.Sequential(
-        tf.keras.layers.Input((256, 256, 3)),
-        tf.keras.layers.Dense(6, activation="softmax"),
+        [
+            tf.keras.layers.Input((256, 256, 3)),
+            tf.keras.layers.Dense(6, activation="softmax"),
+        ]
     )
     model.compile(optimizer="adam", loss=WeightedKappaLoss(num_classes=6))
     model.save(str(tmpdir / "test.h5"))


### PR DESCRIPTION
Fixes #2006.

There is no way to serialize `tf.dtypes.DType` and in `tf.keras.losses.*`, the computation dtype depends on either input (`y_true`, `y_pred`) or `tf.keras.backend.floatx()`. It terms out the most reasonable way for me is to cast values to `tf.keras.backend.floatx()` for computation because it involves something like log and div.

https://github.com/tensorflow/tensorflow/blob/v2.2.0/tensorflow/python/keras/losses.py