### PR TITLE
TYPO: Add missing spaces in some multi-line messages

### DIFF
--- a/build_deps/toolchains/gpu/cuda_configure.bzl
+++ b/build_deps/toolchains/gpu/cuda_configure.bzl
@@ -108,7 +108,7 @@ def _get_win_cuda_defines(repository_ctx):
     vc_path = find_vc_path(repository_ctx)
     if not vc_path:
         auto_configure_fail(
-            "Visual C++ build tools not found on your machine." +
+            "Visual C++ build tools not found on your machine. " +
             "Please check your installation following https://docs.bazel.build/versions/master/windows.html#using",
         )
         return {}

--- a/tensorflow_addons/register.py
+++ b/tensorflow_addons/register.py
@@ -83,7 +83,7 @@ def register_custom_kernels() -> None:
     if not all_shared_objects:
         raise FileNotFoundError(
             "No shared objects files were found in the custom ops "
-            "directory in Tensorflow Addons, check your installation again,"
+            "directory in Tensorflow Addons, check your installation again, "
             "or, if you don't need custom ops, call `tfa.register_all(custom_kernels=False)`"
             " instead."
         )
@@ -94,7 +94,7 @@ def register_custom_kernels() -> None:
         raise RuntimeError(
             "One of the shared objects ({}) could not be loaded. This may be "
             "due to a number of reasons (incompatible TensorFlow version, buiding from "
-            "source with different flags, broken install of TensorFlow Addons...). If you"
+            "source with different flags, broken install of TensorFlow Addons...). If you "
             "wanted to register the shared objects because you needed them when loading your "
             "model, you should fix your install of TensorFlow Addons. If you don't "
             "use custom ops in your model, you can skip registering custom ops with "


### PR DESCRIPTION
Getting an error message, I've noticed that two words were joined because a space had been forgotten in the message composed of continued multi-line strings.
I've added it, looked around for similar issues and found two more. (I don't vouch to have found all, tho'.)

Furthermore, it seems that multi-line messages are assembled incoherently within the project, sometimes spaces are at the end of lines to be continued, sometimes at the beginnings, furthermore sometimes `\n` stands alone, sometimes with a preceding space. I would suggest to have a standardization to follow here. (My suggestion would be space at the end of an individual line, and no spaces preceding `\n`).