### PR TITLE
fix R_Square shape issue in model.evaluate

### DIFF
--- a/tensorflow_addons/metrics/r_square.py
+++ b/tensorflow_addons/metrics/r_square.py
@@ -106,7 +106,12 @@ class RSquare(Metric):
         y_true = tf.cast(y_true, dtype=self._dtype)
         y_pred = tf.cast(y_pred, dtype=self._dtype)
         if sample_weight is None:
-            sample_weight = tf.ones_like(y_true)
+            sample_weight = 1
+        sample_weight = tf.cast(sample_weight, dtype=self._dtype)
+        sample_weight = weights_broadcast_ops.broadcast_weights(
+            weights=sample_weight, values=y_true
+        )
+
         weighted_y_true = y_true * sample_weight
         self.sum.assign_add(tf.reduce_sum(weighted_y_true, axis=0))
         self.squared_sum.assign_add(tf.reduce_sum(y_true * weighted_y_true, axis=0))

--- a/tensorflow_addons/metrics/r_square.py
+++ b/tensorflow_addons/metrics/r_square.py
@@ -106,12 +106,7 @@ class RSquare(Metric):
         y_true = tf.cast(y_true, dtype=self._dtype)
         y_pred = tf.cast(y_pred, dtype=self._dtype)
         if sample_weight is None:
-            sample_weight = 1
-        sample_weight = tf.cast(sample_weight, dtype=self._dtype)
-        sample_weight = weights_broadcast_ops.broadcast_weights(
-            weights=sample_weight, values=y_true
-        )
-
+            sample_weight = tf.ones_like(y_true)
         weighted_y_true = y_true * sample_weight
         self.sum.assign_add(tf.reduce_sum(weighted_y_true, axis=0))
         self.squared_sum.assign_add(tf.reduce_sum(y_true * weighted_y_true, axis=0))
@@ -139,4 +134,4 @@ class RSquare(Metric):
 
     def reset_states(self) -> None:
         # The state of the metric will be reset at the start of each epoch.
-        K.batch_set_value([(v, 0) for v in self.variables])
+        K.batch_set_value([(v, tf.zeros_like(v)) for v in self.variables])

--- a/tensorflow_addons/metrics/tests/r_square_test.py
+++ b/tensorflow_addons/metrics/tests/r_square_test.py
@@ -117,3 +117,14 @@ def test_r2_sklearn_comparison():
 def test_unrecognized_multioutput():
     with pytest.raises(ValueError):
         initialize_vars(multioutput="meadian")
+
+
+def test_keras_fit():
+    model = tf.keras.Sequential([tf.keras.layers.Dense(1)])
+    model.compile(loss="mse", metrics=[RSquare(y_shape=(1,))])
+    data = tf.data.Dataset.from_tensor_slices(
+        (tf.random.normal(shape=(100, 1)), tf.random.normal(shape=(100, 1)))
+    )
+    data = data.batch(10)
+    model.fit(x=data)
+    model.fit(x=data, validation_data=data)

--- a/tensorflow_addons/metrics/tests/r_square_test.py
+++ b/tensorflow_addons/metrics/tests/r_square_test.py
@@ -126,5 +126,4 @@ def test_keras_fit():
         (tf.random.normal(shape=(100, 1)), tf.random.normal(shape=(100, 1)))
     )
     data = data.batch(10)
-    model.fit(x=data)
     model.fit(x=data, validation_data=data)


### PR DESCRIPTION
# Description

The `R_Square` metric was broken when calling `model.evaluate` or `model.fit` with `validation_data` set. This was due to a tensor shape mismatch.

Fixes # (issue)

## Type of change


- [x] Bug fix
- [ ] New Tutorial
- [ ] Updated or additional documentation
- [ ] Additional Testing
- [ ] New Activation (Requires creating an issue first)
    - [ ] The changes conform to the [contribution guidelines](https://github.com/tensorflow/addons/blob/master/tensorflow_addons/activations/README.md#contribution-guidelines)
- [ ] New Callback (Requires creating an issue first)
    - [ ] The changes conform to the [contribution guidelines](https://github.com/tensorflow/addons/blob/master/tensorflow_addons/callbacks/README.md#contribution-guidelines)
- [ ] New Image addition (Requires creating an issue first)
    - [ ] The changes conform to the [contribution guidelines](https://github.com/tensorflow/addons/blob/master/tensorflow_addons/image/README.md#contribution-guidelines)
- [ ] New Layer (Requires creating an issue first)
    - [ ] The changes conform to the [contribution guidelines](https://github.com/tensorflow/addons/blob/master/tensorflow_addons/layers/README.md#contribution-guidelines)
- [ ] New Loss (Requires creating an issue first)
    - [ ] The changes conform to the [contribution guidelines](https://github.com/tensorflow/addons/blob/master/tensorflow_addons/losses/README.md#contribution-guidelines)
- [ ] New Metric (Requires creating an issue first)
    - [ ] The changes conform to the [contribution guidelines](https://github.com/tensorflow/addons/blob/master/tensorflow_addons/metrics/README.md#contribution-guidelines)
- [ ] New Optimizer (Requires creating an issue first)
    - [ ] The changes conform to the [contribution guidelines](https://github.com/tensorflow/addons/blob/master/tensorflow_addons/optimizers/README.md#contribution-guidelines)
- [ ] New RNN Cell (Requires creating an issue first)
    - [ ] The changes conform to the [contribution guidelines](https://github.com/tensorflow/addons/blob/master/tensorflow_addons/rnn/README.md#contribution-guidelines)
- [ ] New Seq2seq addition (Requires creating an issue first)
    - [ ] The changes conform to the [contribution guidelines](https://github.com/tensorflow/addons/blob/master/tensorflow_addons/seq2seq/README.md#contribution-guidelines)
- [ ] New Text addition (Requires creating an issue first)
    - [ ] The changes conform to the [contribution guidelines](https://github.com/tensorflow/addons/blob/master/tensorflow_addons/text/README.md#contribution-guidelines)


# How Has This Been Tested?

If you're adding a bugfix or new feature please describe the tests that you ran to verify your changes:
*  I added to `metrics/test/r_square_test.py`:
```python
def test_keras_fit():
    model = tf.keras.Sequential([tf.keras.layers.Dense(1)])
    model.compile(loss="mse", metrics=[RSquare(y_shape=(1,))])
    data = tf.data.Dataset.from_tensor_slices(
        (tf.random.normal(shape=(100, 1)), tf.random.normal(shape=(100, 1)))
    )
    data = data.batch(10)
    model.fit(x=data)
    model.fit(x=data, validation_data=data)
```


# Checklist:

- [x] I've properly [formatted my code according to the guidelines](https://github.com/tensorflow/addons/blob/master/CONTRIBUTING.md#coding-style)
    - [ ] By running Black + Flake8
    - [x] By running pre-commit hooks
- [ ] This PR addresses an already submitted issue for TensorFlow Addons
- [ ] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] This PR contains modifications to C++ custom-ops
