### PR TITLE
Fixed lr/wd schedules for DecoupledWeightDecayExtension running on GPU

### DIFF
--- a/tensorflow_addons/optimizers/tests/weight_decay_optimizers_test.py
+++ b/tensorflow_addons/optimizers/tests/weight_decay_optimizers_test.py
@@ -266,6 +266,19 @@ def test_keras_fit_with_schedule():
     model.fit(x, y, epochs=1)
 
 
+@pytest.mark.with_device(["cpu", "gpu"])
+def test_weight_decay_with_piecewise_constant_decay_schedule():
+    model = tf.keras.models.Sequential([tf.keras.layers.Dense(2)])
+    loss = tf.keras.losses.SparseCategoricalCrossentropy(from_logits=True)
+    wd_schedule = tf.optimizers.schedules.PiecewiseConstantDecay([2], [1e-4, 1e-5])
+    optimizer = weight_decay_optimizers.SGDW(
+        learning_rate=1e-2, weight_decay=wd_schedule
+    )
+    model.compile(optimizer=optimizer, loss=loss, metrics=["accuracy"])
+    x, y = np.random.uniform(size=(2, 4, 1))
+    model.fit(x, y, batch_size=1, epochs=1)
+
+
 @pytest.mark.parametrize("dtype", [(tf.half, 0), (tf.float32, 1), (tf.float64, 2)])
 def test_sparse_sgdw(dtype):
     do_test(

--- a/tensorflow_addons/optimizers/weight_decay_optimizers.py
+++ b/tensorflow_addons/optimizers/weight_decay_optimizers.py
@@ -15,7 +15,6 @@
 """Base class to make optimizers weight decay ready."""
 
 import tensorflow as tf
-from tensorflow.python.ops import array_ops
 from tensorflow_addons.utils.types import FloatTensorLike
 
 from typeguard import typechecked
@@ -195,7 +194,7 @@ class DecoupledWeightDecayExtension:
         )
 
         if "weight_decay" in self._hyper:
-            wd_t = array_ops.identity(self._decayed_wd(var_dtype))
+            wd_t = tf.identity(self._decayed_wd(var_dtype))
             apply_state[(var_device, var_dtype)]["wd_t"] = wd_t
 
     def _decayed_wd(self, var_dtype):

--- a/tensorflow_addons/optimizers/weight_decay_optimizers.py
+++ b/tensorflow_addons/optimizers/weight_decay_optimizers.py
@@ -15,6 +15,7 @@
 """Base class to make optimizers weight decay ready."""
 
 import tensorflow as tf
+from tensorflow.python.ops import array_ops
 from tensorflow_addons.utils.types import FloatTensorLike
 
 from typeguard import typechecked
@@ -167,34 +168,59 @@ class DecoupledWeightDecayExtension:
         )
         return super().apply_gradients(grads_and_vars, name=name, **kwargs)
 
-    def _decay_weights_op(self, var):
+    def _decay_weights_op(self, var, apply_state=None):
         if not self._decay_var_list or var.ref() in self._decay_var_list:
-            return var.assign_sub(self._decayed_wd(var.dtype) * var, self._use_locking)
+            var_device, var_dtype = var.device, var.dtype.base_dtype
+            coefficients = (apply_state or {}).get(
+                (var_device, var_dtype)
+            ) or self._fallback_apply_state(var_device, var_dtype)
+
+            return var.assign_sub(coefficients["wd_t"] * var, self._use_locking)
         return tf.no_op()
 
-    def _decay_weights_sparse_op(self, var, indices):
+    def _decay_weights_sparse_op(self, var, indices, apply_state=None):
         if not self._decay_var_list or var.ref() in self._decay_var_list:
-            update = -self._decayed_wd(var.dtype) * tf.gather(var, indices)
+            var_device, var_dtype = var.device, var.dtype.base_dtype
+            coefficients = (apply_state or {}).get(
+                (var_device, var_dtype)
+            ) or self._fallback_apply_state(var_device, var_dtype)
+
+            update = -coefficients["wd_t"] * tf.gather(var, indices)
             return self._resource_scatter_add(var, indices, update)
         return tf.no_op()
 
+    def _prepare_local(self, var_device, var_dtype, apply_state):
+        super(DecoupledWeightDecayExtension, self)._prepare_local(
+            var_device, var_dtype, apply_state
+        )
+
+        if "weight_decay" in self._hyper:
+            wd_t = array_ops.identity(self._decayed_wd(var_dtype))
+            apply_state[(var_device, var_dtype)]["wd_t"] = wd_t
+
     def _decayed_wd(self, var_dtype):
         wd_t = self._get_hyper("weight_decay", var_dtype)
+
         if isinstance(wd_t, tf.keras.optimizers.schedules.LearningRateSchedule):
             wd_t = tf.cast(wd_t(self.iterations), var_dtype)
+
         return wd_t
 
     # Here, we overwrite the apply functions that the base optimizer calls.
     # super().apply_x resolves to the apply_x function of the BaseOptimizer.
 
-    def _resource_apply_dense(self, grad, var):
-        with tf.control_dependencies([self._decay_weights_op(var)]):
-            return super()._resource_apply_dense(grad, var)
+    def _resource_apply_dense(self, grad, var, apply_state=None):
+        with tf.control_dependencies(
+            [self._decay_weights_op(var, apply_state=apply_state)]
+        ):
+            return super()._resource_apply_dense(grad, var, apply_state=apply_state)
 
-    def _resource_apply_sparse(self, grad, var, indices):
-        decay_op = self._decay_weights_sparse_op(var, indices)
+    def _resource_apply_sparse(self, grad, var, indices, apply_state=None):
+        decay_op = self._decay_weights_sparse_op(var, indices, apply_state=apply_state)
         with tf.control_dependencies([decay_op]):
-            return super()._resource_apply_sparse(grad, var, indices)
+            return super()._resource_apply_sparse(
+                grad, var, indices, apply_state=apply_state
+            )
 
 
 @typechecked


### PR DESCRIPTION
# Description

Brief Description of the PR:

Fixes #2049 

## Type of change

- [x] Bug fix: Fixed handling of lr & wd schedules for DecoupledWeightDecayExtension when it's running on GPU

# Checklist:

- [x] I've properly [formatted my code according to the guidelines](https://github.com/tensorflow/addons/blob/master/CONTRIBUTING.md#coding-style)
    - [ ] By running Black + Flake8
    - [x] By running pre-commit hooks
- [x] This PR addresses an already submitted issue for TensorFlow Addons
- [ ] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] This PR contains modifications to C++ custom-ops

# How Has This Been Tested?

If you're adding a bugfix or new feature please describe the tests that you ran to verify your changes:
*  
I added new unit tests, and also tested the fixes it in a collab environment (see linked gist in original issue)