### PR TITLE
Small optimization for tfa.image.transform_ops.angles_to_projective_transforms

### DIFF
--- a/tensorflow_addons/image/transform_ops.py
+++ b/tensorflow_addons/image/transform_ops.py
@@ -239,28 +239,24 @@ def angles_to_projective_transforms(
             angles = angle_or_angles
         else:
             raise ValueError("angles should have rank 0 or 1.")
+        cos_angles = tf.math.cos(angles)
+        sin_angles = tf.math.sin(angles)
         x_offset = (
             (image_width - 1)
-            - (
-                tf.math.cos(angles) * (image_width - 1)
-                - tf.math.sin(angles) * (image_height - 1)
-            )
+            - (cos_angles * (image_width - 1) - sin_angles * (image_height - 1))
         ) / 2.0
         y_offset = (
             (image_height - 1)
-            - (
-                tf.math.sin(angles) * (image_width - 1)
-                + tf.math.cos(angles) * (image_height - 1)
-            )
+            - (sin_angles * (image_width - 1) + cos_angles * (image_height - 1))
         ) / 2.0
         num_angles = tf.shape(angles)[0]
         return tf.concat(
             values=[
-                tf.math.cos(angles)[:, None],
-                -tf.math.sin(angles)[:, None],
+                cos_angles[:, None],
+                -sin_angles[:, None],
                 x_offset[:, None],
-                tf.math.sin(angles)[:, None],
-                tf.math.cos(angles)[:, None],
+                sin_angles[:, None],
+                cos_angles[:, None],
                 y_offset[:, None],
                 tf.zeros((num_angles, 2), tf.dtypes.float32),
             ],


### PR DESCRIPTION
# Description

Brief Description of the PR:

Fixes #2054.

## Type of change

- [x] Bug fix
- [ ] New Tutorial
- [ ] Updated or additional documentation
- [ ] Additional Testing
- [ ] New Activation and the changes conform to the [activation contribution guidelines](https://github.com/tensorflow/addons/blob/master/tensorflow_addons/activations/README.md#contribution-guidelines)
- [ ] New Callback and the changes conform to the [callback contribution guidelines](https://github.com/tensorflow/addons/blob/master/tensorflow_addons/callbacks/README.md#contribution-guidelines)
- [ ] New Image addition and the changes conform to the [image op contribution guidelines](https://github.com/tensorflow/addons/blob/master/tensorflow_addons/image/README.md#contribution-guidelines)
- [ ] New Layer and the changes conform to the [layer contribution guidelines](https://github.com/tensorflow/addons/blob/master/tensorflow_addons/layers/README.md#contribution-guidelines)
- [ ] New Loss and the changes conform to the [loss contribution guidelines](https://github.com/tensorflow/addons/blob/master/tensorflow_addons/losses/README.md#contribution-guidelines)
- [ ] New Metric and the changes conform to the [metric contribution guidelines](https://github.com/tensorflow/addons/blob/master/tensorflow_addons/metrics/README.md#contribution-guidelines)
- [ ] New Optimizer and the changes conform to the [optimizer contribution guidelines](https://github.com/tensorflow/addons/blob/master/tensorflow_addons/optimizers/README.md#contribution-guidelines)
- [ ] New RNN Cell and the changes conform to the [rnn contribution guidelines](https://github.com/tensorflow/addons/blob/master/tensorflow_addons/rnn/README.md#contribution-guidelines)
- [ ] New Seq2seq addition and the changes conform to the [seq2seq contribution guidelines](https://github.com/tensorflow/addons/blob/master/tensorflow_addons/seq2seq/README.md#contribution-guidelines)
- [ ] New Text addition and the changes conform to the [text op contribution guidelines](https://github.com/tensorflow/addons/blob/master/tensorflow_addons/text/README.md#contribution-guidelines)

# Checklist:

- [x] I've properly [formatted my code according to the guidelines](https://github.com/tensorflow/addons/blob/master/CONTRIBUTING.md#coding-style)
    - [x] By running Black + Flake8
    - [ ] By running pre-commit hooks
- [x] This PR addresses an already submitted issue for TensorFlow Addons
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] This PR contains modifications to C++ custom-ops

# How Has This Been Tested?
I tested this on Google Colab environment. Well here's the result :
```
# CPU (Run 1)
angles_to_projective_transforms     0065868
angles_to_projective_transforms2    0069990
angles_to_projective_transforms_tf  0257738
angles_to_projective_transforms2_tf 0260291
# CPU (Run 2)
angles_to_projective_transforms     0065672
angles_to_projective_transforms2    0069954
angles_to_projective_transforms_tf  0261689
angles_to_projective_transforms2_tf 0254197
# CPU (Run 3)
angles_to_projective_transforms     0066451
angles_to_projective_transforms2    0070442
angles_to_projective_transforms_tf  0264665
angles_to_projective_transforms2_tf 0262863
# CPU (Run 4)
angles_to_projective_transforms     0071835
angles_to_projective_transforms2    0076597
angles_to_projective_transforms_tf  0294059
angles_to_projective_transforms2_tf 0286251

# GPU
angles_to_projective_transforms     0029724
angles_to_projective_transforms2    0033601
angles_to_projective_transforms_tf  0230617
angles_to_projective_transforms2_tf 0230509

# TPU
angles_to_projective_transforms     0058424
angles_to_projective_transforms2    0061462
angles_to_projective_transforms_tf  0293018
angles_to_projective_transforms2_tf 0302889
```
(The higher the number, the better)

Description about each row :
* `angles_to_projective_transforms` : is the original function
* `angles_to_projective_transforms2` : is after the small optimization
* `angles_to_projective_transforms_tf` : is the original function with `tf.function` decoration
* `angles_to_projective_transforms2_tf` : is after the small optimization with `tf.function` decoration

Calling it directly seems have a performance increase. But if decorated with `tf.function`, it seems like it's already optimized by Tensorflow, so not really seeing performance increase there.

The full benchmark script is [here](https://gist.github.com/Smankusors/a64ef64f4e9212dbbf0c92726b3cc22a)

