### PR TITLE
Added all_scores property to BeamSearchDecoderOutput to expose scores for all tokens

### DIFF
--- a/tensorflow_addons/seq2seq/tests/beam_search_decoder_test.py
+++ b/tensorflow_addons/seq2seq/tests/beam_search_decoder_test.py
@@ -636,6 +636,12 @@ def test_beam_search_decoder(
     assert _t((batch_size, max_sequence_length, beam_width)) == tuple(
         beam_search_decoder_output.scores.shape.as_list()
     )
+    assert _t((batch_size, max_sequence_length, beam_width, vocab_size)) == tuple(
+        beam_search_decoder_output.all_scores.shape.as_list()
+    )
     assert _t((batch_size, max_sequence_length, beam_width)) == tuple(
         final_outputs.predicted_ids.shape.as_list()
     )
+
+    # Check that the vocab size corresponds to the dimensions of the output.
+    assert (beam_width, vocab_size) == tuple(bsd.output_size.all_scores.as_list())

--- a/tensorflow_addons/seq2seq/tests/beam_search_decoder_test.py
+++ b/tensorflow_addons/seq2seq/tests/beam_search_decoder_test.py
@@ -303,6 +303,7 @@ def test_beam_step():
     end_token = 0
     length_penalty_weight = 0.6
     coverage_penalty_weight = 0.0
+    output_all_scores = False
 
     dummy_cell_state = tf.zeros([batch_size, beam_width])
     beam_state = beam_search_decoder.BeamSearchDecoderState(
@@ -335,6 +336,7 @@ def test_beam_step():
         end_token=end_token,
         length_penalty_weight=length_penalty_weight,
         coverage_penalty_weight=coverage_penalty_weight,
+        output_all_scores=output_all_scores,
     )
 
     outputs_, next_state_, state_, log_probs_ = [
@@ -379,6 +381,7 @@ def test_step_with_eos():
     end_token = 0
     length_penalty_weight = 0.6
     coverage_penalty_weight = 0.0
+    output_all_scores = False
 
     dummy_cell_state = tf.zeros([batch_size, beam_width])
     beam_state = beam_search_decoder.BeamSearchDecoderState(
@@ -413,6 +416,7 @@ def test_step_with_eos():
         end_token=end_token,
         length_penalty_weight=length_penalty_weight,
         coverage_penalty_weight=coverage_penalty_weight,
+        output_all_scores=output_all_scores,
     )
 
     outputs_, next_state_, state_, log_probs_ = [
@@ -455,6 +459,7 @@ def test_large_beam_step():
     end_token = 0
     length_penalty_weight = 0.6
     coverage_penalty_weight = 0.0
+    output_all_scores = False
 
     def get_probs():
         """this simulates the initialize method in BeamSearchDecoder."""
@@ -516,6 +521,7 @@ def test_large_beam_step():
         end_token=end_token,
         length_penalty_weight=length_penalty_weight,
         coverage_penalty_weight=coverage_penalty_weight,
+        output_all_scores=output_all_scores,
     )
 
     outputs_, next_state_ = [outputs, next_beam_state]


### PR DESCRIPTION
# Description

The purpose of this PR is expose the scores for all token IDs, not only the ones that are selected as `predicted_ids`. In doing so, we enable the user of the `BeamSearchDecoder` to directly access the logits as requested in #1915.

This PR also fixes documentation from #1916 that described the `scores` property as having the shape of `all_scores`. Based on the existing unit tests, it looks as though the intent is for `scores` to have the shape `[batch_size, beam_width]`, not `[batch_size, beam_width, vocab_size]`, which is what is now exposed through `all_scores`.

## Type of change

- [ ] Bug fix
- [ ] New Tutorial
- [X] Updated or additional documentation
- [ ] Additional Testing
- [ ] New Activation and the changes conform to the [activation contribution guidelines](https://github.com/tensorflow/addons/blob/master/tensorflow_addons/activations/README.md#contribution-guidelines)
- [ ] New Callback and the changes conform to the [callback contribution guidelines](https://github.com/tensorflow/addons/blob/master/tensorflow_addons/callbacks/README.md#contribution-guidelines)
- [ ] New Image addition and the changes conform to the [image op contribution guidelines](https://github.com/tensorflow/addons/blob/master/tensorflow_addons/image/README.md#contribution-guidelines)
- [ ] New Layer and the changes conform to the [layer contribution guidelines](https://github.com/tensorflow/addons/blob/master/tensorflow_addons/layers/README.md#contribution-guidelines)
- [ ] New Loss and the changes conform to the [loss contribution guidelines](https://github.com/tensorflow/addons/blob/master/tensorflow_addons/losses/README.md#contribution-guidelines)
- [ ] New Metric and the changes conform to the [metric contribution guidelines](https://github.com/tensorflow/addons/blob/master/tensorflow_addons/metrics/README.md#contribution-guidelines)
- [ ] New Optimizer and the changes conform to the [optimizer contribution guidelines](https://github.com/tensorflow/addons/blob/master/tensorflow_addons/optimizers/README.md#contribution-guidelines)
- [ ] New RNN Cell and the changes conform to the [rnn contribution guidelines](https://github.com/tensorflow/addons/blob/master/tensorflow_addons/rnn/README.md#contribution-guidelines)
- [X] New Seq2seq addition and the changes conform to the [seq2seq contribution guidelines](https://github.com/tensorflow/addons/blob/master/tensorflow_addons/seq2seq/README.md#contribution-guidelines)
- [ ] New Text addition and the changes conform to the [text op contribution guidelines](https://github.com/tensorflow/addons/blob/master/tensorflow_addons/text/README.md#contribution-guidelines)

# Checklist:

- [X] I've properly [formatted my code according to the guidelines](https://github.com/tensorflow/addons/blob/master/CONTRIBUTING.md#coding-style)
    - [ ] By running Black + Flake8
    - [ ] By running pre-commit hooks
- [ ] This PR addresses an already submitted issue for TensorFlow Addons
- [X] I have made corresponding changes to the documentation
- [X] I have added tests that prove my fix is effective or that my feature works
- [ ] This PR contains modifications to C++ custom-ops

# How Has This Been Tested?

Unit tests have been added to verify that the new property has the correct shape.
