### PR TITLE
Added support for noisy dense layers.

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -105,6 +105,8 @@
 /tensorflow_addons/layers/tests/esn_test.py @pedrolarben
 /tensorflow_addons/layers/snake.py @failure-to-thrive
 /tensorflow_addons/layers/tests/snake_test.py @failure-to-thrive
+/tensorflow_addons/layers/noisy_dense.py @leonshams
+/tensorflow_addons/layers/noisy_dense_test.py @leonshams
 
 /tensorflow_addons/losses/contrastive.py @windqaq
 /tensorflow_addons/losses/tests/contrastive_test.py @windqaq

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,190 +1,245 @@
-# TensorFlow Addons Codeowners
+# Copyright 2020 The TensorFlow Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ==============================================================================
 
-#####################################################################################
-# Subpackage Owners
+import tensorflow as tf
+from tensorflow.keras import (
+    activations,
+    initializers,
+    regularizers,
+    constraints,
+)
+from tensorflow.keras import backend as K
+from tensorflow.keras.layers import InputSpec
 
-/tensorflow_addons/activations/ @facaiy @seanpmorgan
-/tensorflow_addons/callbacks/ @shun-lin
-/tensorflow_addons/image/ @windqaq @facaiy
-/tensorflow_addons/layers/ @seanpmorgan @facaiy
-/tensorflow_addons/losses/ @facaiy @windqaq
-/tensorflow_addons/metrics/ @marload
-/tensorflow_addons/optimizers/ @facaiy @windqaq
-/tensorflow_addons/rnn/ @qlzh727
-/tensorflow_addons/seq2seq/ @qlzh727 @guillaumekln
-/tensorflow_addons/text/ @seanpmorgan @facaiy
 
-/tensorflow_addons/custom_ops/image/ @windqaq @facaiy
-/tensorflow_addons/custom_ops/seq2seq/ @qlzh727
-/tensorflow_addons/custom_ops/text/ @seanpmorgan @facaiy
+@tf.keras.utils.register_keras_serializable(package="Addons")
+class NoisyDense(tf.keras.layers.Layer):
+    """Like normal dense layer (https://github.com/tensorflow/tensorflow/blob/v2.3.0/tensorflow/python/keras/layers/core.py#L1067-L1233)
+  but random noisy is added to the weights matrix. But as the network improves the random noise is decayed until it is insignificant.
+  A `NoisyDense` layer implements the operation:
+  `output = activation(dot(input, µ_kernel + (σ_kernel * ε_kernel)) + bias)`
+  where `activation` is the element-wise activation function
+  passed as the `activation` argument, `µ_kernel` is your average weights matrix
+  created by the layer, σ_kernel is a weights matrix that controls the importance of
+  the ε_kernel which is just random noise, and `bias` is a bias vector created by the layer
+  (only applicable if `use_bias` is `True`).
+  Example:
+  >>> # Create a `Sequential` model and add a Dense layer as the first layer.
+  >>> model = tf.keras.models.Sequential()
+  >>> model.add(tf.keras.Input(shape=(16,)))
+  >>> model.add(NoisyDense(32, activation='relu'))
+  >>> # Now the model will take as input arrays of shape (None, 16)
+  >>> # and output arrays of shape (None, 32).
+  >>> # Note that after the first layer, you don't need to specify
+  >>> # the size of the input anymore:
+  >>> model.add(NoisyDense(32))
+  >>> model.output_shape
+  (None, 32)
+  Arguments:
+    units: Positive integer, dimensionality of the output space.
+    activation: Activation function to use.
+      If you don't specify anything, no activation is applied
+      (ie. "linear" activation: `a(x) = x`).
+    use_bias: Boolean, whether the layer uses a bias vector.
+    kernel_regularizer: Regularizer function applied to
+      the `kernel` weights matrix.
+    bias_regularizer: Regularizer function applied to the bias vector.
+    activity_regularizer: Regularizer function applied to
+      the output of the layer (its "activation").
+    kernel_constraint: Constraint function applied to
+      the `kernel` weights matrix.
+    bias_constraint: Constraint function applied to the bias vector.
+  Input shape:
+    N-D tensor with shape: `(batch_size, ..., input_dim)`.
+    The most common situation would be
+    a 2D input with shape `(batch_size, input_dim)`.
+  Output shape:
+    N-D tensor with shape: `(batch_size, ..., units)`.
+    For instance, for a 2D input with shape `(batch_size, input_dim)`,
+    the output would have shape `(batch_size, units)`.
+  """
 
-#####################################################################################
-# Submodule Owners
-# These will not always trigger a GitHub review because submodule owners do not
-# always have write access. However, a bot will notify them of the needed review.
+    def __init__(
+        self,
+        units,
+        activation=None,
+        use_bias=True,
+        kernel_regularizer=None,
+        bias_regularizer=None,
+        activity_regularizer=None,
+        kernel_constraint=None,
+        bias_constraint=None,
+        **kwargs
+    ):
+        super(NoisyDense, self).__init__(
+            activity_regularizer=activity_regularizer, **kwargs
+        )
 
-/tensorflow_addons/activations/gelu.py @aakashkumarnain @windqaq
-/tensorflow_addons/activations/tests/gelu_test.py @aakashkumarnain @windqaq
-/tensorflow_addons/activations/hardshrink.py @windqaq
-/tensorflow_addons/activations/tests/hardshrink_test.py @windqaq
-/tensorflow_addons/activations/lisht.py @windqaq
-/tensorflow_addons/activations/tests/lisht_test.py @windqaq
-/tensorflow_addons/activations/mish.py @windqaq @digantamisra98
-/tensorflow_addons/activations/tests/mish_test.py @windqaq @digantamisra98
-/tensorflow_addons/activations/rrelu.py @fsx950223
-/tensorflow_addons/activations/tests/rrelu_test.py @fsx950223
-/tensorflow_addons/activations/softshrink.py @windqaq
-/tensorflow_addons/activations/tests/softshrink_test.py @windqaq
-/tensorflow_addons/activations/sparsemax.py @andreasmadsen
-/tensorflow_addons/activations/tests/sparsemax_test.py @andreasmadsen
-/tensorflow_addons/activations/tanhshrink.py @fsx950223
-/tensorflow_addons/activations/tests/tanhshrink_test.py @fsx950223
-/tensorflow_addons/activations/snake.py @failure-to-thrive
-/tensorflow_addons/activations/tests/snake_test.py @failure-to-thrive
+        self.units = int(units) if not isinstance(units, int) else units
+        self.activation = activations.get(activation)
+        self.use_bias = use_bias
+        self.kernel_regularizer = regularizers.get(kernel_regularizer)
+        self.bias_regularizer = regularizers.get(bias_regularizer)
+        self.kernel_constraint = constraints.get(kernel_constraint)
+        self.bias_constraint = constraints.get(bias_constraint)
 
-/tensorflow_addons/callbacks/average_model_checkpoint.py @squadrick
-/tensorflow_addons/callbacks/time_stopping.py @shun-lin
-/tensorflow_addons/callbacks/tests/time_stopping_test.py @shun-lin
-/tensorflow_addons/callbacks/tqdm_progress_bar.py @shun-lin
-/tensorflow_addons/callbacks/tests/tqdm_progress_bar_test.py @shun-lin
+        self.input_spec = InputSpec(min_ndim=2)
+        self.supports_masking = True
 
-/tensorflow_addons/image/color_ops.py @abhichou4
-/tensorflow_addons/image/tests/color_ops_test.py @abhichou4
-/tensorflow_addons/image/connected_components.py @sayoojbk
-/tensorflow_addons/image/tests/connected_components_test.py @sayoojbk
-/tensorflow_addons/image/cutout_ops.py @fsx950223
-/tensorflow_addons/image/tests/cutout_ops_test.py @fsx950223
-/tensorflow_addons/image/dense_image_warp.py @windQAQ
-/tensorflow_addons/image/tests/dense_image_warp_test.py @windQAQ
-/tensorflow_addons/image/distance_transform.py @mels630
-/tensorflow_addons/image/tests/distance_transform_test.py @mels630
-/tensorflow_addons/image/distort_image_ops.py @windqaq
-/tensorflow_addons/image/tests/distort_image_ops_test.py @windqaq
-/tensorflow_addons/image/filters.py @mainak431 @ghosalsattam
-/tensorflow_addons/image/tests/filters_test.py @mainak431 @ghosalsattam
-/tensorflow_addons/image/interpolate_spline.py
-/tensorflow_addons/image/tests/interpolate_spline_test.py
-/tensorflow_addons/image/resampler_ops.py @autoih
-/tensorflow_addons/image/tests/resampler_ops_test.py @autoih
-/tensorflow_addons/image/sparse_image_warp.py
-/tensorflow_addons/image/tests/sparse_image_warp_test.py
-/tensorflow_addons/image/transform_ops.py @mels630
-/tensorflow_addons/image/tests/transform_ops_test.py @mels630
-/tensorflow_addons/image/translate_ops.py @sayoojbk
-/tensorflow_addons/image/tests/translate_ops_test.py @sayoojbk
+    def build(self, input_shape):
+        # Make sure dtype is correct
+        dtype = tf.dtypes.as_dtype(self.dtype or K.floatx())
+        if not (dtype.is_floating or dtype.is_complex):
+            raise TypeError(
+                "Unable to build `Dense` layer with non-floating point "
+                "dtype %s" % (dtype,)
+            )
 
-/tensorflow_addons/layers/adaptive_pooling.py @Susmit-A
-/tensorflow_addons/layers/tests/adaptive_pooling_test.py @Susmit-A
-/tensorflow_addons/layers/gelu.py @aakashkumarnain
-/tensorflow_addons/layers/tests/gelu_test.py @aakashkumarnain
-/tensorflow_addons/layers/maxout.py @failure-to-thrive
-/tensorflow_addons/layers/tests/maxout_test.py @failure-to-thrive
-/tensorflow_addons/layers/multihead_attention.py @cgarciae
-/tensorflow_addons/layers/tests/multihead_attention_test.py @cgarciae
-/tensorflow_addons/layers/netvlad.py @joel-shor
-/tensorflow_addons/layers/tests/netvlad_test.py @joel-shor
-/tensorflow_addons/layers/normalizations.py @smokrow
-/tensorflow_addons/layers/tests/normalizations_test.py @smokrow
-/tensorflow_addons/layers/optical_flow.py @failure-to-thrive
-/tensorflow_addons/layers/tests/optical_flow_test.py @failure-to-thrive
-/tensorflow_addons/layers/poincare.py @rahulunair
-/tensorflow_addons/layers/tests/poincare_test.py @rahulunair
-/tensorflow_addons/layers/polynomial.py @tanzhenyu
-/tensorflow_addons/layers/tests/polynomial_test.py @tanzhenyu
-/tensorflow_addons/layers/sparsemax.py @andreasmadsen
-/tensorflow_addons/layers/tests/sparsemax_test.py @andreasmadsen
-/tensorflow_addons/layers/spectral_normalization.py @charlielito
-/tensorflow_addons/layers/tests/spectral_normalization_test.py @charlielito
-/tensorflow_addons/layers/spatial_pyramid_pooling.py @Susmit-A
-/tensorflow_addons/layers/tests/spatial_pyramid_pooling_test.py @Susmit-A
-/tensorflow_addons/layers/tlu.py @aakashkumarnain
-/tensorflow_addons/layers/tests/tlu_test.py @aakashkumarnain
-/tensorflow_addons/layers/wrappers.py @seanpmorgan
-/tensorflow_addons/layers/tests/wrappers_test.py @seanpmorgan
-/tensorflow_addons/layers/esn.py @pedrolarben
-/tensorflow_addons/layers/tests/esn_test.py @pedrolarben
-/tensorflow_addons/layers/snake.py @failure-to-thrive
-/tensorflow_addons/layers/tests/snake_test.py @failure-to-thrive
-/tensorflow_addons/layers/noisy_dense.py @leonshams
-/tensorflow_addons/layers/tests/noisy_dense_test.py @leonshams
+        input_shape = tf.TensorShape(input_shape)
+        self.last_dim = tf.compat.dimension_value(input_shape[-1])
+        sqrt_dim = self.last_dim ** (1 / 2)
+        if self.last_dim is None:
+            raise ValueError(
+                "The last dimension of the inputs to `Dense` "
+                "should be defined. Found `None`."
+            )
+        self.input_spec = InputSpec(min_ndim=2, axes={-1: self.last_dim})
 
-/tensorflow_addons/losses/contrastive.py @windqaq
-/tensorflow_addons/losses/tests/contrastive_test.py @windqaq
-/tensorflow_addons/losses/focal_loss.py @aakashkumarnain @ssaishruthi
-/tensorflow_addons/losses/tests/focal_loss_test.py @aakashkumarnain @ssaishruthi
-/tensorflow_addons/losses/giou_loss.py @fsx950223
-/tensorflow_addons/losses/tests/giou_loss_test.py @fsx950223
-/tensorflow_addons/losses/lifted.py @rahulunair
-/tensorflow_addons/losses/tests/lifted_test.py @rahulunair
-/tensorflow_addons/losses/metric_learning.py
-/tensorflow_addons/losses/npairs.py @windqaq
-/tensorflow_addons/losses/tests/npairs_test.py @windqaq
-/tensorflow_addons/losses/quantiles.py @romainbrault
-/tensorflow_addons/losses/tests/quantiles_test.py @romainbrault
-/tensorflow_addons/losses/sparsemax_loss.py @andreasmadsen
-/tensorflow_addons/losses/tests/sparsemax_loss_test.py @andreasmadsen
-/tensorflow_addons/losses/triplet.py @lc0
-/tensorflow_addons/losses/tests/triplet_test.py @lc0
-/tensorflow_addons/losses/kappa_loss.py @wenmin-wu
-/tensorflow_addons/losses/tests/kappa_loss_test.py @wenmin-wu
+        self.σ_init = initializers.Constant(value=0.5 / sqrt_dim)
+        self.µ_init = initializers.RandomUniform(
+            minval=-1 / sqrt_dim, maxval=1 / sqrt_dim
+        )
 
-/tensorflow_addons/metrics/cohens_kappa.py @aakashkumarnain
-/tensorflow_addons/metrics/tests/cohens_kappa_test.py @aakashkumarnain
-/tensorflow_addons/metrics/f_scores.py @ssaishruthi @marload
-/tensorflow_addons/metrics/tests/f_scores_test.py @ssaishruthi @marload
-/tensorflow_addons/metrics/hamming.py @ssaishruthi
-/tensorflow_addons/metrics/tests/hamming_test.py @ssaishruthi
-/tensorflow_addons/metrics/matthews_correlation_coefficient.py @autoih @marload
-/tensorflow_addons/metrics/tests/matthews_correlation_coefficient_test.py @autoih @marload
-/tensorflow_addons/metrics/multilabel_confusion_matrix.py @ssaishruthi
-/tensorflow_addons/metrics/tests/multilabel_confusion_matrix_test.py @ssaishruthi
-/tensorflow_addons/metrics/r_square.py @ssaishruthi @marload
-/tensorflow_addons/metrics/tests/r_square_test.py @ssaishruthi @marload
-/tensorflow_addons/metrics/geometric_mean.py @marload
-/tensorflow_addons/metrics/tests/geometric_mean_test.py @marload
+        # Learnable parameters
+        # Agent will learn to decay σ as it improves creating a sort of learned epsilon decay
+        self.σ_kernel = self.add_weight(
+            "σ_kernel",
+            shape=[self.last_dim, self.units],
+            initializer=self.σ_init,
+            regularizer=self.kernel_regularizer,
+            constraint=self.kernel_constraint,
+            dtype=self.dtype,
+            trainable=True,
+        )
 
-/tensorflow_addons/optimizers/average_wrapper.py @squadrick
-/tensorflow_addons/optimizers/conditional_gradient.py @pkan2 @lokhande-vishnu
-/tensorflow_addons/optimizers/tests/conditional_gradient_test.py @pkan2 @lokhande-vishnu
-/tensorflow_addons/optimizers/cyclical_learning_rate.py @raphaelmeudec
-/tensorflow_addons/optimizers/tests/cyclical_learning_rate_test.py @raphaelmeudec
-/tensorflow_addons/optimizers/lamb.py @junjiek
-/tensorflow_addons/optimizers/tests/lamb_test.py @junjiek
-/tensorflow_addons/optimizers/lazy_adam.py @ssaishruthi
-/tensorflow_addons/optimizers/tests/lazy_adam_test.py @ssaishruthi
-/tensorflow_addons/optimizers/lookahead.py @cyberzhg
-/tensorflow_addons/optimizers/tests/lookahead_test.py @cyberzhg
-/tensorflow_addons/optimizers/moving_average.py @squadrick
-/tensorflow_addons/optimizers/tests/moving_average_test.py @squadrick
-/tensorflow_addons/optimizers/novograd.py @shreyashpatodia
-/tensorflow_addons/optimizers/tests/novograd_test.py @shreyashpatodia
-/tensorflow_addons/optimizers/proximal_adagrad.py @WindQAQ
-/tensorflow_addons/optimizers/tests/proximal_adagrad_test.py @WindQAQ
-/tensorflow_addons/optimizers/rectified_adam.py @cyberzhg
-/tensorflow_addons/optimizers/tests/rectified_adam_test.py @cyberzhg
-/tensorflow_addons/optimizers/stochastic_weight_averaging.py @shreyashpatodia
-/tensorflow_addons/optimizers/tests/stochastic_weight_averaging_test.py @shreyashpatodia
-/tensorflow_addons/optimizers/weight_decay_optimizers.py @philjd
-/tensorflow_addons/optimizers/tests/weight_decay_optimizers_test.py @philjd
-/tensorflow_addons/optimizers/yogi.py @manzilz
-/tensorflow_addons/optimizers/tests/yogi_test.py @manzilz
+        self.µ_kernel = self.add_weight(
+            "µ_kernel",
+            shape=[self.last_dim, self.units],
+            initializer=self.µ_init,
+            regularizer=self.kernel_regularizer,
+            constraint=self.kernel_constraint,
+            dtype=self.dtype,
+            trainable=True,
+        )
 
-/tensorflow_addons/rnn/esn_cell.py @pedrolarben
-/tensorflow_addons/rnn/tests/esn_cell_test.py @pedrolarben
-/tensorflow_addons/rnn/layer_norm_lstm_cell.py @qlzh727
-/tensorflow_addons/rnn/tests/layer_norm_lstm_cell_test.py @qlzh727
-/tensorflow_addons/rnn/layer_norm_simple_rnn_cell.py @qlzh727
-/tensorflow_addons/rnn/tests/layer_norm_simple_rnn_cell_test.py @qlzh727
-/tensorflow_addons/rnn/nas_cell.py @qlzh727
-/tensorflow_addons/rnn/tests/nas_cell_test.py @qlzh727
-/tensorflow_addons/rnn/peephole_lstm_cell.py @qlzh727
-/tensorflow_addons/rnn/tests/peephole_lstm_cell_test.py @qlzh727
+        if self.use_bias:
+            self.σ_bias = self.add_weight(
+                "σ_bias",
+                shape=[self.units,],
+                initializer=self.σ_init,
+                regularizer=self.bias_regularizer,
+                constraint=self.bias_constraint,
+                dtype=self.dtype,
+                trainable=True,
+            )
 
-/tensorflow_addons/seq2seq/ @qlzh727 @guillaumekln
+            self.µ_bias = self.add_weight(
+                "µ_bias",
+                shape=[self.units,],
+                initializer=self.µ_init,
+                regularizer=self.bias_regularizer,
+                constraint=self.bias_constraint,
+                dtype=self.dtype,
+                trainable=True,
+            )
 
-/tensorflow_addons/text/crf.py @squadrick
-/tensorflow_addons/text/tests/crf_test.py @squadrick
-/tensorflow_addons/text/parse_time_op.py @helinwang
-/tensorflow_addons/text/tests/parse_time_op_test.py @helinwang
-/tensorflow_addons/text/skip_gram_ops.py @rahulunair
-/tensorflow_addons/text/tests/skip_gram_ops_test.py @rahulunair
+        self.built = True
+
+    @staticmethod
+    def _scale_noise(x):
+        return tf.sign(x) * tf.sqrt(tf.abs(x))
+
+    def call(self, inputs):
+        dtype = self._compute_dtype_object
+        if inputs.dtype.base_dtype != dtype.base_dtype:
+            inputs = tf.cast(inputs, dtype=dtype)
+
+        # Fixed parameters added as the noise
+        ε_i = tf.random.normal([self.last_dim, self.units], dtype=dtype)
+        ε_j = tf.random.normal([self.units,], dtype=dtype)
+
+        # Creates the factorised Gaussian noise
+        f = NoisyDense._scale_noise
+        ε_kernel = f(ε_i) * f(ε_j)
+        ε_bias = f(ε_j)
+
+        # Performs: y = (µw + σw · εw)x + µb + σb · εb
+        # to calculate the output
+        kernel = self.µ_kernel + (self.σ_kernel * ε_kernel)
+
+        if inputs.dtype.base_dtype != dtype.base_dtype:
+            inputs = tf.cast(inputs, dtype=dtype)
+
+        rank = inputs.shape.rank
+        if rank == 2 or rank is None:
+            if isinstance(inputs, tf.sparse.SparseTensor):
+                outputs = tf.sparse.sparse_dense_matmul(inputs, kernel)
+            else:
+                outputs = tf.linalg.matmul(inputs, kernel)
+        # Broadcast kernel to inputs.
+        else:
+            outputs = tf.tensordot(inputs, kernel, [[rank - 1], [0]])
+            # Reshape the output back to the original ndim of the input.
+            if not tf.executing_eagerly():
+                shape = inputs.shape.as_list()
+                output_shape = shape[:-1] + [kernel.shape[-1]]
+                outputs.set_shape(output_shape)
+
+        if self.use_bias:
+            noisy_bias = self.µ_bias + (self.σ_bias * ε_bias)
+            outputs = tf.nn.bias_add(outputs, noisy_bias)
+
+        if self.activation is not None:
+            outputs = self.activation(outputs)
+
+        return outputs
+
+    def compute_output_shape(self, input_shape):
+        input_shape = tf.TensorShape(input_shape)
+        input_shape = input_shape.with_rank_at_least(2)
+        if tf.compat.dimension_value(input_shape[-1]) is None:
+            raise ValueError(
+                "The innermost dimension of input_shape must be defined, but saw: %s"
+                % input_shape
+            )
+        return input_shape[:-1].concatenate(self.units)
+
+    def get_config(self):
+        config = super(NoisyDense, self).get_config()
+        config.update(
+            {
+                "units": self.units,
+                "activation": activations.serialize(self.activation),
+                "use_bias": self.use_bias,
+                "kernel_regularizer": regularizers.serialize(self.kernel_regularizer),
+                "bias_regularizer": regularizers.serialize(self.bias_regularizer),
+                "activity_regularizer": regularizers.serialize(
+                    self.activity_regularizer
+                ),
+                "kernel_constraint": constraints.serialize(self.kernel_constraint),
+                "bias_constraint": constraints.serialize(self.bias_constraint),
+            }
+        )
+        return config

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,245 +1,190 @@
-# Copyright 2020 The TensorFlow Authors. All Rights Reserved.
-#
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-#     http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
-# ==============================================================================
+# TensorFlow Addons Codeowners
 
-import tensorflow as tf
-from tensorflow.keras import (
-    activations,
-    initializers,
-    regularizers,
-    constraints,
-)
-from tensorflow.keras import backend as K
-from tensorflow.keras.layers import InputSpec
+#####################################################################################
+# Subpackage Owners
 
+/tensorflow_addons/activations/ @facaiy @seanpmorgan
+/tensorflow_addons/callbacks/ @shun-lin
+/tensorflow_addons/image/ @windqaq @facaiy
+/tensorflow_addons/layers/ @seanpmorgan @facaiy
+/tensorflow_addons/losses/ @facaiy @windqaq
+/tensorflow_addons/metrics/ @marload
+/tensorflow_addons/optimizers/ @facaiy @windqaq
+/tensorflow_addons/rnn/ @qlzh727
+/tensorflow_addons/seq2seq/ @qlzh727 @guillaumekln
+/tensorflow_addons/text/ @seanpmorgan @facaiy
 
-@tf.keras.utils.register_keras_serializable(package="Addons")
-class NoisyDense(tf.keras.layers.Layer):
-    """Like normal dense layer (https://github.com/tensorflow/tensorflow/blob/v2.3.0/tensorflow/python/keras/layers/core.py#L1067-L1233)
-  but random noisy is added to the weights matrix. But as the network improves the random noise is decayed until it is insignificant.
-  A `NoisyDense` layer implements the operation:
-  `output = activation(dot(input, µ_kernel + (σ_kernel * ε_kernel)) + bias)`
-  where `activation` is the element-wise activation function
-  passed as the `activation` argument, `µ_kernel` is your average weights matrix
-  created by the layer, σ_kernel is a weights matrix that controls the importance of
-  the ε_kernel which is just random noise, and `bias` is a bias vector created by the layer
-  (only applicable if `use_bias` is `True`).
-  Example:
-  >>> # Create a `Sequential` model and add a Dense layer as the first layer.
-  >>> model = tf.keras.models.Sequential()
-  >>> model.add(tf.keras.Input(shape=(16,)))
-  >>> model.add(NoisyDense(32, activation='relu'))
-  >>> # Now the model will take as input arrays of shape (None, 16)
-  >>> # and output arrays of shape (None, 32).
-  >>> # Note that after the first layer, you don't need to specify
-  >>> # the size of the input anymore:
-  >>> model.add(NoisyDense(32))
-  >>> model.output_shape
-  (None, 32)
-  Arguments:
-    units: Positive integer, dimensionality of the output space.
-    activation: Activation function to use.
-      If you don't specify anything, no activation is applied
-      (ie. "linear" activation: `a(x) = x`).
-    use_bias: Boolean, whether the layer uses a bias vector.
-    kernel_regularizer: Regularizer function applied to
-      the `kernel` weights matrix.
-    bias_regularizer: Regularizer function applied to the bias vector.
-    activity_regularizer: Regularizer function applied to
-      the output of the layer (its "activation").
-    kernel_constraint: Constraint function applied to
-      the `kernel` weights matrix.
-    bias_constraint: Constraint function applied to the bias vector.
-  Input shape:
-    N-D tensor with shape: `(batch_size, ..., input_dim)`.
-    The most common situation would be
-    a 2D input with shape `(batch_size, input_dim)`.
-  Output shape:
-    N-D tensor with shape: `(batch_size, ..., units)`.
-    For instance, for a 2D input with shape `(batch_size, input_dim)`,
-    the output would have shape `(batch_size, units)`.
-  """
+/tensorflow_addons/custom_ops/image/ @windqaq @facaiy
+/tensorflow_addons/custom_ops/seq2seq/ @qlzh727
+/tensorflow_addons/custom_ops/text/ @seanpmorgan @facaiy
 
-    def __init__(
-        self,
-        units,
-        activation=None,
-        use_bias=True,
-        kernel_regularizer=None,
-        bias_regularizer=None,
-        activity_regularizer=None,
-        kernel_constraint=None,
-        bias_constraint=None,
-        **kwargs
-    ):
-        super(NoisyDense, self).__init__(
-            activity_regularizer=activity_regularizer, **kwargs
-        )
+#####################################################################################
+# Submodule Owners
+# These will not always trigger a GitHub review because submodule owners do not
+# always have write access. However, a bot will notify them of the needed review.
 
-        self.units = int(units) if not isinstance(units, int) else units
-        self.activation = activations.get(activation)
-        self.use_bias = use_bias
-        self.kernel_regularizer = regularizers.get(kernel_regularizer)
-        self.bias_regularizer = regularizers.get(bias_regularizer)
-        self.kernel_constraint = constraints.get(kernel_constraint)
-        self.bias_constraint = constraints.get(bias_constraint)
+/tensorflow_addons/activations/gelu.py @aakashkumarnain @windqaq
+/tensorflow_addons/activations/tests/gelu_test.py @aakashkumarnain @windqaq
+/tensorflow_addons/activations/hardshrink.py @windqaq
+/tensorflow_addons/activations/tests/hardshrink_test.py @windqaq
+/tensorflow_addons/activations/lisht.py @windqaq
+/tensorflow_addons/activations/tests/lisht_test.py @windqaq
+/tensorflow_addons/activations/mish.py @windqaq @digantamisra98
+/tensorflow_addons/activations/tests/mish_test.py @windqaq @digantamisra98
+/tensorflow_addons/activations/rrelu.py @fsx950223
+/tensorflow_addons/activations/tests/rrelu_test.py @fsx950223
+/tensorflow_addons/activations/softshrink.py @windqaq
+/tensorflow_addons/activations/tests/softshrink_test.py @windqaq
+/tensorflow_addons/activations/sparsemax.py @andreasmadsen
+/tensorflow_addons/activations/tests/sparsemax_test.py @andreasmadsen
+/tensorflow_addons/activations/tanhshrink.py @fsx950223
+/tensorflow_addons/activations/tests/tanhshrink_test.py @fsx950223
+/tensorflow_addons/activations/snake.py @failure-to-thrive
+/tensorflow_addons/activations/tests/snake_test.py @failure-to-thrive
 
-        self.input_spec = InputSpec(min_ndim=2)
-        self.supports_masking = True
+/tensorflow_addons/callbacks/average_model_checkpoint.py @squadrick
+/tensorflow_addons/callbacks/time_stopping.py @shun-lin
+/tensorflow_addons/callbacks/tests/time_stopping_test.py @shun-lin
+/tensorflow_addons/callbacks/tqdm_progress_bar.py @shun-lin
+/tensorflow_addons/callbacks/tests/tqdm_progress_bar_test.py @shun-lin
 
-    def build(self, input_shape):
-        # Make sure dtype is correct
-        dtype = tf.dtypes.as_dtype(self.dtype or K.floatx())
-        if not (dtype.is_floating or dtype.is_complex):
-            raise TypeError(
-                "Unable to build `Dense` layer with non-floating point "
-                "dtype %s" % (dtype,)
-            )
+/tensorflow_addons/image/color_ops.py @abhichou4
+/tensorflow_addons/image/tests/color_ops_test.py @abhichou4
+/tensorflow_addons/image/connected_components.py @sayoojbk
+/tensorflow_addons/image/tests/connected_components_test.py @sayoojbk
+/tensorflow_addons/image/cutout_ops.py @fsx950223
+/tensorflow_addons/image/tests/cutout_ops_test.py @fsx950223
+/tensorflow_addons/image/dense_image_warp.py @windQAQ
+/tensorflow_addons/image/tests/dense_image_warp_test.py @windQAQ
+/tensorflow_addons/image/distance_transform.py @mels630
+/tensorflow_addons/image/tests/distance_transform_test.py @mels630
+/tensorflow_addons/image/distort_image_ops.py @windqaq
+/tensorflow_addons/image/tests/distort_image_ops_test.py @windqaq
+/tensorflow_addons/image/filters.py @mainak431 @ghosalsattam
+/tensorflow_addons/image/tests/filters_test.py @mainak431 @ghosalsattam
+/tensorflow_addons/image/interpolate_spline.py
+/tensorflow_addons/image/tests/interpolate_spline_test.py
+/tensorflow_addons/image/resampler_ops.py @autoih
+/tensorflow_addons/image/tests/resampler_ops_test.py @autoih
+/tensorflow_addons/image/sparse_image_warp.py
+/tensorflow_addons/image/tests/sparse_image_warp_test.py
+/tensorflow_addons/image/transform_ops.py @mels630
+/tensorflow_addons/image/tests/transform_ops_test.py @mels630
+/tensorflow_addons/image/translate_ops.py @sayoojbk
+/tensorflow_addons/image/tests/translate_ops_test.py @sayoojbk
 
-        input_shape = tf.TensorShape(input_shape)
-        self.last_dim = tf.compat.dimension_value(input_shape[-1])
-        sqrt_dim = self.last_dim ** (1 / 2)
-        if self.last_dim is None:
-            raise ValueError(
-                "The last dimension of the inputs to `Dense` "
-                "should be defined. Found `None`."
-            )
-        self.input_spec = InputSpec(min_ndim=2, axes={-1: self.last_dim})
+/tensorflow_addons/layers/adaptive_pooling.py @Susmit-A
+/tensorflow_addons/layers/tests/adaptive_pooling_test.py @Susmit-A
+/tensorflow_addons/layers/gelu.py @aakashkumarnain
+/tensorflow_addons/layers/tests/gelu_test.py @aakashkumarnain
+/tensorflow_addons/layers/maxout.py @failure-to-thrive
+/tensorflow_addons/layers/tests/maxout_test.py @failure-to-thrive
+/tensorflow_addons/layers/multihead_attention.py @cgarciae
+/tensorflow_addons/layers/tests/multihead_attention_test.py @cgarciae
+/tensorflow_addons/layers/netvlad.py @joel-shor
+/tensorflow_addons/layers/tests/netvlad_test.py @joel-shor
+/tensorflow_addons/layers/normalizations.py @smokrow
+/tensorflow_addons/layers/tests/normalizations_test.py @smokrow
+/tensorflow_addons/layers/optical_flow.py @failure-to-thrive
+/tensorflow_addons/layers/tests/optical_flow_test.py @failure-to-thrive
+/tensorflow_addons/layers/poincare.py @rahulunair
+/tensorflow_addons/layers/tests/poincare_test.py @rahulunair
+/tensorflow_addons/layers/polynomial.py @tanzhenyu
+/tensorflow_addons/layers/tests/polynomial_test.py @tanzhenyu
+/tensorflow_addons/layers/sparsemax.py @andreasmadsen
+/tensorflow_addons/layers/tests/sparsemax_test.py @andreasmadsen
+/tensorflow_addons/layers/spectral_normalization.py @charlielito
+/tensorflow_addons/layers/tests/spectral_normalization_test.py @charlielito
+/tensorflow_addons/layers/spatial_pyramid_pooling.py @Susmit-A
+/tensorflow_addons/layers/tests/spatial_pyramid_pooling_test.py @Susmit-A
+/tensorflow_addons/layers/tlu.py @aakashkumarnain
+/tensorflow_addons/layers/tests/tlu_test.py @aakashkumarnain
+/tensorflow_addons/layers/wrappers.py @seanpmorgan
+/tensorflow_addons/layers/tests/wrappers_test.py @seanpmorgan
+/tensorflow_addons/layers/esn.py @pedrolarben
+/tensorflow_addons/layers/tests/esn_test.py @pedrolarben
+/tensorflow_addons/layers/snake.py @failure-to-thrive
+/tensorflow_addons/layers/tests/snake_test.py @failure-to-thrive
+/tensorflow_addons/layers/noisy_dense.py @leonshams
+/tensorflow_addons/layers/tests/noisy_dense_test.py @leonshams
 
-        self.σ_init = initializers.Constant(value=0.5 / sqrt_dim)
-        self.µ_init = initializers.RandomUniform(
-            minval=-1 / sqrt_dim, maxval=1 / sqrt_dim
-        )
+/tensorflow_addons/losses/contrastive.py @windqaq
+/tensorflow_addons/losses/tests/contrastive_test.py @windqaq
+/tensorflow_addons/losses/focal_loss.py @aakashkumarnain @ssaishruthi
+/tensorflow_addons/losses/tests/focal_loss_test.py @aakashkumarnain @ssaishruthi
+/tensorflow_addons/losses/giou_loss.py @fsx950223
+/tensorflow_addons/losses/tests/giou_loss_test.py @fsx950223
+/tensorflow_addons/losses/lifted.py @rahulunair
+/tensorflow_addons/losses/tests/lifted_test.py @rahulunair
+/tensorflow_addons/losses/metric_learning.py
+/tensorflow_addons/losses/npairs.py @windqaq
+/tensorflow_addons/losses/tests/npairs_test.py @windqaq
+/tensorflow_addons/losses/quantiles.py @romainbrault
+/tensorflow_addons/losses/tests/quantiles_test.py @romainbrault
+/tensorflow_addons/losses/sparsemax_loss.py @andreasmadsen
+/tensorflow_addons/losses/tests/sparsemax_loss_test.py @andreasmadsen
+/tensorflow_addons/losses/triplet.py @lc0
+/tensorflow_addons/losses/tests/triplet_test.py @lc0
+/tensorflow_addons/losses/kappa_loss.py @wenmin-wu
+/tensorflow_addons/losses/tests/kappa_loss_test.py @wenmin-wu
 
-        # Learnable parameters
-        # Agent will learn to decay σ as it improves creating a sort of learned epsilon decay
-        self.σ_kernel = self.add_weight(
-            "σ_kernel",
-            shape=[self.last_dim, self.units],
-            initializer=self.σ_init,
-            regularizer=self.kernel_regularizer,
-            constraint=self.kernel_constraint,
-            dtype=self.dtype,
-            trainable=True,
-        )
+/tensorflow_addons/metrics/cohens_kappa.py @aakashkumarnain
+/tensorflow_addons/metrics/tests/cohens_kappa_test.py @aakashkumarnain
+/tensorflow_addons/metrics/f_scores.py @ssaishruthi @marload
+/tensorflow_addons/metrics/tests/f_scores_test.py @ssaishruthi @marload
+/tensorflow_addons/metrics/hamming.py @ssaishruthi
+/tensorflow_addons/metrics/tests/hamming_test.py @ssaishruthi
+/tensorflow_addons/metrics/matthews_correlation_coefficient.py @autoih @marload
+/tensorflow_addons/metrics/tests/matthews_correlation_coefficient_test.py @autoih @marload
+/tensorflow_addons/metrics/multilabel_confusion_matrix.py @ssaishruthi
+/tensorflow_addons/metrics/tests/multilabel_confusion_matrix_test.py @ssaishruthi
+/tensorflow_addons/metrics/r_square.py @ssaishruthi @marload
+/tensorflow_addons/metrics/tests/r_square_test.py @ssaishruthi @marload
+/tensorflow_addons/metrics/geometric_mean.py @marload
+/tensorflow_addons/metrics/tests/geometric_mean_test.py @marload
 
-        self.µ_kernel = self.add_weight(
-            "µ_kernel",
-            shape=[self.last_dim, self.units],
-            initializer=self.µ_init,
-            regularizer=self.kernel_regularizer,
-            constraint=self.kernel_constraint,
-            dtype=self.dtype,
-            trainable=True,
-        )
+/tensorflow_addons/optimizers/average_wrapper.py @squadrick
+/tensorflow_addons/optimizers/conditional_gradient.py @pkan2 @lokhande-vishnu
+/tensorflow_addons/optimizers/tests/conditional_gradient_test.py @pkan2 @lokhande-vishnu
+/tensorflow_addons/optimizers/cyclical_learning_rate.py @raphaelmeudec
+/tensorflow_addons/optimizers/tests/cyclical_learning_rate_test.py @raphaelmeudec
+/tensorflow_addons/optimizers/lamb.py @junjiek
+/tensorflow_addons/optimizers/tests/lamb_test.py @junjiek
+/tensorflow_addons/optimizers/lazy_adam.py @ssaishruthi
+/tensorflow_addons/optimizers/tests/lazy_adam_test.py @ssaishruthi
+/tensorflow_addons/optimizers/lookahead.py @cyberzhg
+/tensorflow_addons/optimizers/tests/lookahead_test.py @cyberzhg
+/tensorflow_addons/optimizers/moving_average.py @squadrick
+/tensorflow_addons/optimizers/tests/moving_average_test.py @squadrick
+/tensorflow_addons/optimizers/novograd.py @shreyashpatodia
+/tensorflow_addons/optimizers/tests/novograd_test.py @shreyashpatodia
+/tensorflow_addons/optimizers/proximal_adagrad.py @WindQAQ
+/tensorflow_addons/optimizers/tests/proximal_adagrad_test.py @WindQAQ
+/tensorflow_addons/optimizers/rectified_adam.py @cyberzhg
+/tensorflow_addons/optimizers/tests/rectified_adam_test.py @cyberzhg
+/tensorflow_addons/optimizers/stochastic_weight_averaging.py @shreyashpatodia
+/tensorflow_addons/optimizers/tests/stochastic_weight_averaging_test.py @shreyashpatodia
+/tensorflow_addons/optimizers/weight_decay_optimizers.py @philjd
+/tensorflow_addons/optimizers/tests/weight_decay_optimizers_test.py @philjd
+/tensorflow_addons/optimizers/yogi.py @manzilz
+/tensorflow_addons/optimizers/tests/yogi_test.py @manzilz
 
-        if self.use_bias:
-            self.σ_bias = self.add_weight(
-                "σ_bias",
-                shape=[self.units,],
-                initializer=self.σ_init,
-                regularizer=self.bias_regularizer,
-                constraint=self.bias_constraint,
-                dtype=self.dtype,
-                trainable=True,
-            )
+/tensorflow_addons/rnn/esn_cell.py @pedrolarben
+/tensorflow_addons/rnn/tests/esn_cell_test.py @pedrolarben
+/tensorflow_addons/rnn/layer_norm_lstm_cell.py @qlzh727
+/tensorflow_addons/rnn/tests/layer_norm_lstm_cell_test.py @qlzh727
+/tensorflow_addons/rnn/layer_norm_simple_rnn_cell.py @qlzh727
+/tensorflow_addons/rnn/tests/layer_norm_simple_rnn_cell_test.py @qlzh727
+/tensorflow_addons/rnn/nas_cell.py @qlzh727
+/tensorflow_addons/rnn/tests/nas_cell_test.py @qlzh727
+/tensorflow_addons/rnn/peephole_lstm_cell.py @qlzh727
+/tensorflow_addons/rnn/tests/peephole_lstm_cell_test.py @qlzh727
 
-            self.µ_bias = self.add_weight(
-                "µ_bias",
-                shape=[self.units,],
-                initializer=self.µ_init,
-                regularizer=self.bias_regularizer,
-                constraint=self.bias_constraint,
-                dtype=self.dtype,
-                trainable=True,
-            )
+/tensorflow_addons/seq2seq/ @qlzh727 @guillaumekln
 
-        self.built = True
-
-    @staticmethod
-    def _scale_noise(x):
-        return tf.sign(x) * tf.sqrt(tf.abs(x))
-
-    def call(self, inputs):
-        dtype = self._compute_dtype_object
-        if inputs.dtype.base_dtype != dtype.base_dtype:
-            inputs = tf.cast(inputs, dtype=dtype)
-
-        # Fixed parameters added as the noise
-        ε_i = tf.random.normal([self.last_dim, self.units], dtype=dtype)
-        ε_j = tf.random.normal([self.units,], dtype=dtype)
-
-        # Creates the factorised Gaussian noise
-        f = NoisyDense._scale_noise
-        ε_kernel = f(ε_i) * f(ε_j)
-        ε_bias = f(ε_j)
-
-        # Performs: y = (µw + σw · εw)x + µb + σb · εb
-        # to calculate the output
-        kernel = self.µ_kernel + (self.σ_kernel * ε_kernel)
-
-        if inputs.dtype.base_dtype != dtype.base_dtype:
-            inputs = tf.cast(inputs, dtype=dtype)
-
-        rank = inputs.shape.rank
-        if rank == 2 or rank is None:
-            if isinstance(inputs, tf.sparse.SparseTensor):
-                outputs = tf.sparse.sparse_dense_matmul(inputs, kernel)
-            else:
-                outputs = tf.linalg.matmul(inputs, kernel)
-        # Broadcast kernel to inputs.
-        else:
-            outputs = tf.tensordot(inputs, kernel, [[rank - 1], [0]])
-            # Reshape the output back to the original ndim of the input.
-            if not tf.executing_eagerly():
-                shape = inputs.shape.as_list()
-                output_shape = shape[:-1] + [kernel.shape[-1]]
-                outputs.set_shape(output_shape)
-
-        if self.use_bias:
-            noisy_bias = self.µ_bias + (self.σ_bias * ε_bias)
-            outputs = tf.nn.bias_add(outputs, noisy_bias)
-
-        if self.activation is not None:
-            outputs = self.activation(outputs)
-
-        return outputs
-
-    def compute_output_shape(self, input_shape):
-        input_shape = tf.TensorShape(input_shape)
-        input_shape = input_shape.with_rank_at_least(2)
-        if tf.compat.dimension_value(input_shape[-1]) is None:
-            raise ValueError(
-                "The innermost dimension of input_shape must be defined, but saw: %s"
-                % input_shape
-            )
-        return input_shape[:-1].concatenate(self.units)
-
-    def get_config(self):
-        config = super(NoisyDense, self).get_config()
-        config.update(
-            {
-                "units": self.units,
-                "activation": activations.serialize(self.activation),
-                "use_bias": self.use_bias,
-                "kernel_regularizer": regularizers.serialize(self.kernel_regularizer),
-                "bias_regularizer": regularizers.serialize(self.bias_regularizer),
-                "activity_regularizer": regularizers.serialize(
-                    self.activity_regularizer
-                ),
-                "kernel_constraint": constraints.serialize(self.kernel_constraint),
-                "bias_constraint": constraints.serialize(self.bias_constraint),
-            }
-        )
-        return config
+/tensorflow_addons/text/crf.py @squadrick
+/tensorflow_addons/text/tests/crf_test.py @squadrick
+/tensorflow_addons/text/parse_time_op.py @helinwang
+/tensorflow_addons/text/tests/parse_time_op_test.py @helinwang
+/tensorflow_addons/text/skip_gram_ops.py @rahulunair
+/tensorflow_addons/text/tests/skip_gram_ops_test.py @rahulunair

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -106,7 +106,7 @@
 /tensorflow_addons/layers/snake.py @failure-to-thrive
 /tensorflow_addons/layers/tests/snake_test.py @failure-to-thrive
 /tensorflow_addons/layers/noisy_dense.py @leonshams
-/tensorflow_addons/layers/tests/noisy_dense_test.py @leonshams
+/tensorflow_addons/layers/noisy_dense_test.py @leonshams
 
 /tensorflow_addons/losses/contrastive.py @windqaq
 /tensorflow_addons/losses/tests/contrastive_test.py @windqaq

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -106,7 +106,7 @@
 /tensorflow_addons/layers/snake.py @failure-to-thrive
 /tensorflow_addons/layers/tests/snake_test.py @failure-to-thrive
 /tensorflow_addons/layers/noisy_dense.py @leonshams
-/tensorflow_addons/layers/noisy_dense_test.py @leonshams
+/tensorflow_addons/layers/tests/noisy_dense_test.py @leonshams
 
 /tensorflow_addons/losses/contrastive.py @windqaq
 /tensorflow_addons/losses/tests/contrastive_test.py @windqaq

--- a/tensorflow_addons/layers/__init__.py
+++ b/tensorflow_addons/layers/__init__.py
@@ -38,3 +38,4 @@ from tensorflow_addons.layers.spatial_pyramid_pooling import SpatialPyramidPooli
 from tensorflow_addons.layers.tlu import TLU
 from tensorflow_addons.layers.wrappers import WeightNormalization
 from tensorflow_addons.layers.esn import ESN
+from tensorflow_addons.layers.noisy_dense import NoisyDense

--- a/tensorflow_addons/layers/noisy_dense.py
+++ b/tensorflow_addons/layers/noisy_dense.py
@@ -1,4 +1,4 @@
-# Copyright 2019 The TensorFlow Authors. All Rights Reserved.
+# Copyright 2020 The TensorFlow Authors. All Rights Reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -11,9 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-
-# Orginal implementation from keras_contrib/layer/normalization
-# =============================================================================
+# ==============================================================================
 
 import tensorflow as tf
 from tensorflow.keras import (
@@ -28,8 +26,8 @@ from tensorflow.keras.layers import InputSpec
 
 @tf.keras.utils.register_keras_serializable(package="Addons")
 class NoisyDense(tf.keras.layers.Layer):
-    """Like normal dense layer but random noisy is added to the weights matrix. But
-  as the network improves the random noise is decayed until it is insignificant.
+    """Like normal dense layer (https://github.com/tensorflow/tensorflow/blob/v2.3.0/tensorflow/python/keras/layers/core.py#L1067-L1233)
+  but random noisy is added to the weights matrix. But as the network improves the random noise is decayed until it is insignificant.
 
   A `NoisyDense` layer implements the operation:
   `output = activation(dot(input, µ_kernel + (σ_kernel * ε_kernel)) + bias)`

--- a/tensorflow_addons/layers/noisy_dense.py
+++ b/tensorflow_addons/layers/noisy_dense.py
@@ -21,7 +21,7 @@ from tensorflow.python.ops import math_ops, nn_ops, sparse_ops, gen_math_ops, st
 from tensorflow.python.keras.engine.input_spec import InputSpec
 from tensorflow.python.framework import dtypes, tensor_shape, sparse_tensor
 
-@tf.utils.register_keras_serializable(package="Addons")
+@tf.keras.utils.register_keras_serializable(package="Addons")
 class NoisyDense(tf.keras.layers.Layer):
   """Like normal dense layer but random noisy is added to the weights matrix. But
   as the network improves the random noise is decayed until it is insignificant. 

--- a/tensorflow_addons/layers/noisy_dense.py
+++ b/tensorflow_addons/layers/noisy_dense.py
@@ -26,31 +26,32 @@ from tensorflow.keras.layers import InputSpec
 
 @tf.keras.utils.register_keras_serializable(package="Addons")
 class NoisyDense(tf.keras.layers.Layer):
-    """Like normal dense layer (https://github.com/tensorflow/tensorflow/blob/v2.3.0/tensorflow/python/keras/layers/core.py#L1067-L1233)
-  but random noisy is added to the weights matrix. But as the network improves the random noise is decayed until it is insignificant.
+    """
+    Like normal dense layer (https://github.com/tensorflow/tensorflow/blob/v2.3.0/tensorflow/python/keras/layers/core.py#L1067-L1233)
+    but random noisy is added to the weights matrix. But as the network improves the random noise is decayed until it is insignificant.
 
-  A `NoisyDense` layer implements the operation:
-  `output = activation(dot(input, µ_kernel + (σ_kernel * ε_kernel)) + bias)`
-  where `activation` is the element-wise activation function
-  passed as the `activation` argument, `µ_kernel` is your average weights matrix
-  created by the layer, σ_kernel is a weights matrix that controls the importance of
-  the ε_kernel which is just random noise, and `bias` is a bias vector created by the layer
-  (only applicable if `use_bias` is `True`).
+    A `NoisyDense` layer implements the operation:
+    `output = activation(dot(input, µ_kernel + (σ_kernel * ε_kernel)) + bias)`
+    where `activation` is the element-wise activation function
+    passed as the `activation` argument, `µ_kernel` is your average weights matrix
+    created by the layer, σ_kernel is a weights matrix that controls the importance of
+    the ε_kernel which is just random noise, and `bias` is a bias vector created by the layer
+    (only applicable if `use_bias` is `True`).
 
-  Example:
-  >>> # Create a `Sequential` model and add a Dense layer as the first layer.
-  >>> model = tf.keras.models.Sequential()
-  >>> model.add(tf.keras.Input(shape=(16,)))
-  >>> model.add(NoisyDense(32, activation='relu'))
-  >>> # Now the model will take as input arrays of shape (None, 16)
-  >>> # and output arrays of shape (None, 32).
-  >>> # Note that after the first layer, you don't need to specify
-  >>> # the size of the input anymore:
-  >>> model.add(NoisyDense(32))
-  >>> model.output_shape
-  (None, 32)
+    Example:
+    >>> # Create a `Sequential` model and add a Dense layer as the first layer.
+    >>> model = tf.keras.models.Sequential()
+    >>> model.add(tf.keras.Input(shape=(16,)))
+    >>> model.add(NoisyDense(32, activation='relu'))
+    >>> # Now the model will take as input arrays of shape (None, 16)
+    >>> # and output arrays of shape (None, 32).
+    >>> # Note that after the first layer, you don't need to specify
+    >>> # the size of the input anymore:
+    >>> model.add(NoisyDense(32))
+    >>> model.output_shape
+    (None, 32)
 
-  Arguments:
+    Arguments:
     units: Positive integer, dimensionality of the output space.
     activation: Activation function to use.
       If you don't specify anything, no activation is applied
@@ -65,16 +66,16 @@ class NoisyDense(tf.keras.layers.Layer):
       the `kernel` weights matrix.
     bias_constraint: Constraint function applied to the bias vector.
 
-  Input shape:
+    Input shape:
     N-D tensor with shape: `(batch_size, ..., input_dim)`.
     The most common situation would be
     a 2D input with shape `(batch_size, input_dim)`.
 
-  Output shape:
+    Output shape:
     N-D tensor with shape: `(batch_size, ..., units)`.
     For instance, for a 2D input with shape `(batch_size, input_dim)`,
     the output would have shape `(batch_size, units)`.
-  """
+    """
 
     def __init__(
         self,

--- a/tensorflow_addons/layers/noisy_dense.py
+++ b/tensorflow_addons/layers/noisy_dense.py
@@ -16,21 +16,35 @@
 # =============================================================================
 
 import tensorflow as tf
-from tensorflow.keras import layers, activations, initializers, regularizers, constraints
-from tensorflow.python.ops import math_ops, nn_ops, sparse_ops, gen_math_ops, standard_ops
+from tensorflow.keras import (
+    activations,
+    initializers,
+    regularizers,
+    constraints,
+)
+from tensorflow.python.ops import (
+    math_ops,
+    nn_ops,
+    sparse_ops,
+    gen_math_ops,
+    standard_ops,
+)
+from tensorflow.python.keras import backend as K
 from tensorflow.python.keras.engine.input_spec import InputSpec
 from tensorflow.python.framework import dtypes, tensor_shape, sparse_tensor
+from tensorflow.python.eager import context
+
 
 @tf.keras.utils.register_keras_serializable(package="Addons")
 class NoisyDense(tf.keras.layers.Layer):
-  """Like normal dense layer but random noisy is added to the weights matrix. But
-  as the network improves the random noise is decayed until it is insignificant. 
-  
+    """Like normal dense layer but random noisy is added to the weights matrix. But
+  as the network improves the random noise is decayed until it is insignificant.
+
   A `NoisyDense` layer implements the operation:
   `output = activation(dot(input, µ_kernel + (σ_kernel * ε_kernel)) + bias)`
   where `activation` is the element-wise activation function
   passed as the `activation` argument, `µ_kernel` is your average weights matrix
-  created by the layer, σ_kernel is a weights matrix that controls the importance of 
+  created by the layer, σ_kernel is a weights matrix that controls the importance of
   the ε_kernel which is just random noise, and `bias` is a bias vector created by the layer
   (only applicable if `use_bias` is `True`).
 
@@ -46,7 +60,7 @@ class NoisyDense(tf.keras.layers.Layer):
   >>> model.add(NoisyDense(32))
   >>> model.output_shape
   (None, 32)
-  
+
   Arguments:
     units: Positive integer, dimensionality of the output space.
     activation: Activation function to use.
@@ -61,174 +75,182 @@ class NoisyDense(tf.keras.layers.Layer):
     kernel_constraint: Constraint function applied to
       the `kernel` weights matrix.
     bias_constraint: Constraint function applied to the bias vector.
-    
+
   Input shape:
     N-D tensor with shape: `(batch_size, ..., input_dim)`.
     The most common situation would be
     a 2D input with shape `(batch_size, input_dim)`.
-    
+
   Output shape:
     N-D tensor with shape: `(batch_size, ..., units)`.
     For instance, for a 2D input with shape `(batch_size, input_dim)`,
     the output would have shape `(batch_size, units)`.
   """
 
-  def __init__(self,
-               units,
-               activation=None,
-               use_bias=True,
-               kernel_regularizer=None,
-               bias_regularizer=None,
-               activity_regularizer=None,
-               kernel_constraint=None,
-               bias_constraint=None,
-               **kwargs):
-    super(NoisyDense, self).__init__(activity_regularizer=activity_regularizer, **kwargs)
+    def __init__(
+        self,
+        units,
+        activation=None,
+        use_bias=True,
+        kernel_regularizer=None,
+        bias_regularizer=None,
+        activity_regularizer=None,
+        kernel_constraint=None,
+        bias_constraint=None,
+        **kwargs
+    ):
+        super(NoisyDense, self).__init__(
+            activity_regularizer=activity_regularizer, **kwargs
+        )
 
-    self.units = int(units) if not isinstance(units, int) else units
-    self.activation = activations.get(activation)
-    self.use_bias = use_bias
-    self.kernel_regularizer = regularizers.get(kernel_regularizer)
-    self.bias_regularizer = regularizers.get(bias_regularizer)
-    self.kernel_constraint = constraints.get(kernel_constraint)
-    self.bias_constraint = constraints.get(bias_constraint)
+        self.units = int(units) if not isinstance(units, int) else units
+        self.activation = activations.get(activation)
+        self.use_bias = use_bias
+        self.kernel_regularizer = regularizers.get(kernel_regularizer)
+        self.bias_regularizer = regularizers.get(bias_regularizer)
+        self.kernel_constraint = constraints.get(kernel_constraint)
+        self.bias_constraint = constraints.get(bias_constraint)
 
-    self.input_spec = InputSpec(min_ndim=2)
-    self.supports_masking = True
+        self.input_spec = InputSpec(min_ndim=2)
+        self.supports_masking = True
 
-  def build(self, input_shape):
-    # Make sure dtype is correct
-    dtype = dtypes.as_dtype(self.dtype or K.floatx())
-    if not (dtype.is_floating or dtype.is_complex):
-      raise TypeError('Unable to build `Dense` layer with non-floating point '
-                      'dtype %s' % (dtype,))
+    def build(self, input_shape):
+        # Make sure dtype is correct
+        dtype = dtypes.as_dtype(self.dtype or K.floatx())
+        if not (dtype.is_floating or dtype.is_complex):
+            raise TypeError(
+                "Unable to build `Dense` layer with non-floating point "
+                "dtype %s" % (dtype,)
+            )
 
-    input_shape = tensor_shape.TensorShape(input_shape)
-    self.last_dim = tensor_shape.dimension_value(input_shape[-1])
-    sqrt_dim = self.last_dim ** (1/2)
-    if self.last_dim is None:
-      raise ValueError('The last dimension of the inputs to `Dense` '
-                       'should be defined. Found `None`.')
-    self.input_spec = InputSpec(min_ndim=2, axes={-1: self.last_dim})
+        input_shape = tensor_shape.TensorShape(input_shape)
+        self.last_dim = tensor_shape.dimension_value(input_shape[-1])
+        sqrt_dim = self.last_dim ** (1 / 2)
+        if self.last_dim is None:
+            raise ValueError(
+                "The last dimension of the inputs to `Dense` "
+                "should be defined. Found `None`."
+            )
+        self.input_spec = InputSpec(min_ndim=2, axes={-1: self.last_dim})
 
-    self.σ_init = initializers.Constant(value=0.5/sqrt_dim)
-    self.µ_init = initializers.RandomUniform(minval=-1/sqrt_dim, maxval=1/sqrt_dim)
+        self.σ_init = initializers.Constant(value=0.5 / sqrt_dim)
+        self.µ_init = initializers.RandomUniform(
+            minval=-1 / sqrt_dim, maxval=1 / sqrt_dim
+        )
 
-    # Learnable parameters
-    # Agent will learn to decay σ as it improves creating a sort of learned epsilon decay
-    self.σ_kernel = self.add_weight(
-        "σ_kernel",
-        shape=[self.last_dim, self.units], 
-        initializer=self.σ_init,
-        regularizer=self.kernel_regularizer,
-        constraint=self.kernel_constraint, 
-        dtype=self.dtype,
-        trainable=True)
+        # Learnable parameters
+        # Agent will learn to decay σ as it improves creating a sort of learned epsilon decay
+        self.σ_kernel = self.add_weight(
+            "σ_kernel",
+            shape=[self.last_dim, self.units],
+            initializer=self.σ_init,
+            regularizer=self.kernel_regularizer,
+            constraint=self.kernel_constraint,
+            dtype=self.dtype,
+            trainable=True,
+        )
 
-    self.µ_kernel = self.add_weight(
-        "µ_kernel",
-        shape=[self.last_dim, self.units], 
-        initializer=self.µ_init,
-        regularizer=self.kernel_regularizer,
-        constraint=self.kernel_constraint, 
-        dtype=self.dtype,
-        trainable=True)
+        self.µ_kernel = self.add_weight(
+            "µ_kernel",
+            shape=[self.last_dim, self.units],
+            initializer=self.µ_init,
+            regularizer=self.kernel_regularizer,
+            constraint=self.kernel_constraint,
+            dtype=self.dtype,
+            trainable=True,
+        )
 
-    if self.use_bias:
-      self.σ_bias = self.add_weight(
-          "σ_bias",
-          shape=[self.units,],
-          initializer=self.σ_init,
-          regularizer=self.bias_regularizer,
-          constraint=self.bias_constraint,
-          dtype=self.dtype,
-          trainable=True)
+        if self.use_bias:
+            self.σ_bias = self.add_weight(
+                "σ_bias",
+                shape=[self.units,],
+                initializer=self.σ_init,
+                regularizer=self.bias_regularizer,
+                constraint=self.bias_constraint,
+                dtype=self.dtype,
+                trainable=True,
+            )
 
-      self.µ_bias = self.add_weight(
-          "µ_bias",
-          shape=[self.units,],
-          initializer=self.µ_init,
-          regularizer=self.bias_regularizer,
-          constraint=self.bias_constraint,
-          dtype=self.dtype,
-          trainable=True)
+            self.µ_bias = self.add_weight(
+                "µ_bias",
+                shape=[self.units,],
+                initializer=self.µ_init,
+                regularizer=self.bias_regularizer,
+                constraint=self.bias_constraint,
+                dtype=self.dtype,
+                trainable=True,
+            )
 
-    self.built = True
+        self.built = True
 
-  @staticmethod
-  def _scale_noise(x):
-    return tf.sign(x)*tf.sqrt(tf.abs(x))
+    @staticmethod
+    def _scale_noise(x):
+        return tf.sign(x) * tf.sqrt(tf.abs(x))
 
-  def call(self, inputs):
-    dtype = self._compute_dtype_object
-    if inputs.dtype.base_dtype != dtype.base_dtype:
-      inputs = math_ops.cast(inputs, dtype=dtype)
+    def call(self, inputs):
+        dtype = self._compute_dtype_object
+        if inputs.dtype.base_dtype != dtype.base_dtype:
+            inputs = math_ops.cast(inputs, dtype=dtype)
 
-    # Fixed parameters added as the noise
-    ε_i = tf.random.normal([self.last_dim, self.units])
-    ε_j = tf.random.normal([self.units,])
+        # Fixed parameters added as the noise
+        ε_i = tf.random.normal([self.last_dim, self.units], dtype=dtype)
+        ε_j = tf.random.normal([self.units,], dtype=dtype)
 
-    # Creates the factorised Gaussian noise
-    f = NoisyDense._scale_noise
-    ε_kernel = f(ε_i) * f(ε_j)
-    ε_bias = f(ε_j)
+        # Creates the factorised Gaussian noise
+        f = NoisyDense._scale_noise
+        ε_kernel = f(ε_i) * f(ε_j)
+        ε_bias = f(ε_j)
 
-    # Performs: y = (µw + σw · εw)x + µb + σb · εb
-    # to calculate the output
-    rank = inputs.shape.rank
-    if rank == 2 or rank is None:
-      if isinstance(inputs, sparse_tensor.SparseTensor):
-        outputs = sparse_ops.sparse_tensor_dense_matmul(inputs, self.µ_kernel + (self.σ_kernel * ε_kernel))
-      else:
-        outputs = gen_math_ops.mat_mul(inputs, self.µ_kernel + (self.σ_kernel * ε_kernel))
-    # Broadcast kernel to inputs.
-    else:
-      outputs = standard_ops.tensordot(inputs, self.µ_kernel + (self.σ_kernel * ε_kernel), [[rank - 1], [0]])
-      # Reshape the output back to the original ndim of the input.
-      if not context.executing_eagerly():
-        shape = inputs.shape.as_list()
-        output_shape = shape[:-1] + [kernel.shape[-1]]
-        outputs.set_shape(output_shape)
+        # Performs: y = (µw + σw · εw)x + µb + σb · εb
+        # to calculate the output
+        kernel = self.µ_kernel + (self.σ_kernel * ε_kernel)
+        rank = inputs.shape.rank
+        if rank == 2 or rank is None:
+            if isinstance(inputs, sparse_tensor.SparseTensor):
+                outputs = sparse_ops.sparse_tensor_dense_matmul(inputs, kernel)
+            else:
+                outputs = gen_math_ops.mat_mul(inputs, kernel)
+        # Broadcast kernel to inputs.
+        else:
+            outputs = standard_ops.tensordot(inputs, kernel, [[rank - 1], [0]])
+            # Reshape the output back to the original ndim of the input.
+            if not context.executing_eagerly():
+                shape = inputs.shape.as_list()
+                output_shape = shape[:-1] + [kernel.shape[-1]]
+                outputs.set_shape(output_shape)
 
-    if self.use_bias:
-      noisy_bias = self.µ_bias + (self.σ_bias * ε_bias)
-      outputs = nn_ops.bias_add(outputs, noisy_bias)
+        if self.use_bias:
+            noisy_bias = self.µ_bias + (self.σ_bias * ε_bias)
+            outputs = nn_ops.bias_add(outputs, noisy_bias)
 
-    if self.activation is not None:
-      outputs = self.activation(outputs)
+        if self.activation is not None:
+            outputs = self.activation(outputs)
 
-    return outputs
+        return outputs
 
+    def compute_output_shape(self, input_shape):
+        input_shape = tensor_shape.TensorShape(input_shape)
+        input_shape = input_shape.with_rank_at_least(2)
+        if tensor_shape.dimension_value(input_shape[-1]) is None:
+            raise ValueError(
+                "The innermost dimension of input_shape must be defined, but saw: %s"
+                % input_shape
+            )
+        return input_shape[:-1].concatenate(self.units)
 
-  def compute_output_shape(self, input_shape):
-    input_shape = tensor_shape.TensorShape(input_shape)
-    input_shape = input_shape.with_rank_at_least(2)
-    if tensor_shape.dimension_value(input_shape[-1]) is None:
-      raise ValueError(
-          'The innermost dimension of input_shape must be defined, but saw: %s'
-          % input_shape)
-    return input_shape[:-1].concatenate(self.units)
-
-  def get_config(self):
-    config = super(NoisyDense, self).get_config()
-    config.update({
-        'units':
-            self.units,
-        'activation':
-            activations.serialize(self.activation),
-        'σ_initializer':
-            initializers.serialize(self.σ_init),
-        'µ_initializer':
-            initializers.serialize(self.µ_init),
-        'kernel_regularizer':
-            regularizers.serialize(self.kernel_regularizer),
-        'bias_regularizer':
-            regularizers.serialize(self.bias_regularizer),
-        'activity_regularizer':
-            regularizers.serialize(self.activity_regularizer),
-        'kernel_constraint':
-            constraints.serialize(self.kernel_constraint),
-        'bias_constraint':
-            constraints.serialize(self.bias_constraint)
-    })
-    return config
+    def get_config(self):
+        config = super(NoisyDense, self).get_config()
+        config.update(
+            {
+                "units": self.units,
+                "activation": activations.serialize(self.activation),
+                "kernel_regularizer": regularizers.serialize(self.kernel_regularizer),
+                "bias_regularizer": regularizers.serialize(self.bias_regularizer),
+                "activity_regularizer": regularizers.serialize(
+                    self.activity_regularizer
+                ),
+                "kernel_constraint": constraints.serialize(self.kernel_constraint),
+                "bias_constraint": constraints.serialize(self.bias_constraint),
+            }
+        )
+        return config

--- a/tensorflow_addons/layers/noisy_dense.py
+++ b/tensorflow_addons/layers/noisy_dense.py
@@ -20,10 +20,9 @@ from tensorflow.keras import layers, activations, initializers, regularizers, co
 from tensorflow.python.ops import math_ops, nn_ops, sparse_ops, gen_math_ops, standard_ops
 from tensorflow.python.keras.engine.input_spec import InputSpec
 from tensorflow.python.framework import dtypes, tensor_shape, sparse_tensor
-from tensorflow.python.keras.engine.base_layer import Layer
 
 @tf.utils.register_keras_serializable(package="Addons")
-class NoisyDense(Layer):
+class NoisyDense(tf.keras.layers.Layer):
   """Like normal dense layer but random noisy is added to the weights matrix. But
   as the network improves the random noise is decayed until it is insignificant. 
   

--- a/tensorflow_addons/layers/noisy_dense.py
+++ b/tensorflow_addons/layers/noisy_dense.py
@@ -28,6 +28,7 @@ from tensorflow.keras.layers import InputSpec
 class NoisyDense(tf.keras.layers.Layer):
     """Like normal dense layer (https://github.com/tensorflow/tensorflow/blob/v2.3.0/tensorflow/python/keras/layers/core.py#L1067-L1233)
   but random noisy is added to the weights matrix. But as the network improves the random noise is decayed until it is insignificant.
+
   A `NoisyDense` layer implements the operation:
   `output = activation(dot(input, µ_kernel + (σ_kernel * ε_kernel)) + bias)`
   where `activation` is the element-wise activation function
@@ -35,6 +36,7 @@ class NoisyDense(tf.keras.layers.Layer):
   created by the layer, σ_kernel is a weights matrix that controls the importance of
   the ε_kernel which is just random noise, and `bias` is a bias vector created by the layer
   (only applicable if `use_bias` is `True`).
+
   Example:
   >>> # Create a `Sequential` model and add a Dense layer as the first layer.
   >>> model = tf.keras.models.Sequential()
@@ -47,6 +49,7 @@ class NoisyDense(tf.keras.layers.Layer):
   >>> model.add(NoisyDense(32))
   >>> model.output_shape
   (None, 32)
+
   Arguments:
     units: Positive integer, dimensionality of the output space.
     activation: Activation function to use.
@@ -61,10 +64,12 @@ class NoisyDense(tf.keras.layers.Layer):
     kernel_constraint: Constraint function applied to
       the `kernel` weights matrix.
     bias_constraint: Constraint function applied to the bias vector.
+
   Input shape:
     N-D tensor with shape: `(batch_size, ..., input_dim)`.
     The most common situation would be
     a 2D input with shape `(batch_size, input_dim)`.
+
   Output shape:
     N-D tensor with shape: `(batch_size, ..., units)`.
     For instance, for a 2D input with shape `(batch_size, input_dim)`,

--- a/tensorflow_addons/layers/noisy_dense.py
+++ b/tensorflow_addons/layers/noisy_dense.py
@@ -39,12 +39,12 @@ class NoisyDense(Layer):
   >>> # Create a `Sequential` model and add a Dense layer as the first layer.
   >>> model = tf.keras.models.Sequential()
   >>> model.add(tf.keras.Input(shape=(16,)))
-  >>> model.add(tf.keras.layers.NoisyDense(32, activation='relu'))
+  >>> model.add(NoisyDense(32, activation='relu'))
   >>> # Now the model will take as input arrays of shape (None, 16)
   >>> # and output arrays of shape (None, 32).
   >>> # Note that after the first layer, you don't need to specify
   >>> # the size of the input anymore:
-  >>> model.add(tf.keras.layers.NoisyDense(32))
+  >>> model.add(NoisyDense(32))
   >>> model.output_shape
   (None, 32)
   Arguments:

--- a/tensorflow_addons/layers/noisy_dense.py
+++ b/tensorflow_addons/layers/noisy_dense.py
@@ -200,6 +200,11 @@ class NoisyDense(tf.keras.layers.Layer):
         self.ε_kernel = NoisyDense._scale_noise(ε_i) * NoisyDense._scale_noise(ε_j)
         self.ε_bias = NoisyDense._scale_noise(ε_j)
 
+    def remove_noise(self):
+        dtype = self._compute_dtype_object
+        self.ε_kernel = tf.zeros([self.last_dim, self.units], dtype=dtype)
+        self.ε_bias = tf.zeros([self.last_dim, self.units], dtype=dtype)
+
     def call(self, inputs, reset_noise=True):
         dtype = self._compute_dtype_object
         if inputs.dtype.base_dtype != dtype.base_dtype:

--- a/tensorflow_addons/layers/noisy_dense.py
+++ b/tensorflow_addons/layers/noisy_dense.py
@@ -232,6 +232,7 @@ class NoisyDense(tf.keras.layers.Dense):
         return super().call(inputs)
 
     def get_config(self):
+        # TODO(WindQAQ): Get rid of this hacky way.
         config = super(tf.keras.layers.Dense, self).get_config()
         config.update(
             {

--- a/tensorflow_addons/layers/noisy_dense.py
+++ b/tensorflow_addons/layers/noisy_dense.py
@@ -1,4 +1,4 @@
-# Copyright 2020 The TensorFlow Authors. All Rights Reserved.
+# Copyright 2019 The TensorFlow Authors. All Rights Reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -11,7 +11,9 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-# ==============================================================================
+
+# Orginal implementation from keras_contrib/layer/normalization
+# =============================================================================
 
 import tensorflow as tf
 from tensorflow.keras import (
@@ -26,8 +28,8 @@ from tensorflow.keras.layers import InputSpec
 
 @tf.keras.utils.register_keras_serializable(package="Addons")
 class NoisyDense(tf.keras.layers.Layer):
-    """Like normal dense layer (https://github.com/tensorflow/tensorflow/blob/v2.3.0/tensorflow/python/keras/layers/core.py#L1067-L1233)
-  but random noisy is added to the weights matrix. But as the network improves the random noise is decayed until it is insignificant.
+    """Like normal dense layer but random noisy is added to the weights matrix. But
+  as the network improves the random noise is decayed until it is insignificant.
 
   A `NoisyDense` layer implements the operation:
   `output = activation(dot(input, µ_kernel + (σ_kernel * ε_kernel)) + bias)`
@@ -237,6 +239,7 @@ class NoisyDense(tf.keras.layers.Layer):
             {
                 "units": self.units,
                 "activation": activations.serialize(self.activation),
+                "use_bias": self.use_bias,
                 "kernel_regularizer": regularizers.serialize(self.kernel_regularizer),
                 "bias_regularizer": regularizers.serialize(self.bias_regularizer),
                 "activity_regularizer": regularizers.serialize(

--- a/tensorflow_addons/layers/noisy_dense.py
+++ b/tensorflow_addons/layers/noisy_dense.py
@@ -48,6 +48,7 @@ class NoisyDense(tf.keras.layers.Dense):
     where $\mu$ is the standard weights layer, $\epsilon$ is the factorised
     Gaussian noise, and $\sigma$ is a second weights layer which controls
     $\epsilon$.
+
     Note: bias only added if `use_bias` is `True`.
 
     Example:

--- a/tensorflow_addons/layers/noisy_dense.py
+++ b/tensorflow_addons/layers/noisy_dense.py
@@ -174,7 +174,9 @@ class NoisyDense(tf.keras.layers.Layer):
                 dtype=self.dtype,
                 trainable=True,
             )
-
+        else:
+            self.σ_bias = None
+            self.µ_bias = None
         self.built = True
 
     @staticmethod

--- a/tensorflow_addons/layers/noisy_dense.py
+++ b/tensorflow_addons/layers/noisy_dense.py
@@ -231,8 +231,8 @@ class NoisyDense(tf.keras.layers.Layer):
         config.update(
             {
                 "units": self.units,
-                "use_bias": self.use_bias,
                 "activation": activations.serialize(self.activation),
+                "use_bias": self.use_bias,
                 "kernel_regularizer": regularizers.serialize(self.kernel_regularizer),
                 "bias_regularizer": regularizers.serialize(self.bias_regularizer),
                 "activity_regularizer": regularizers.serialize(

--- a/tensorflow_addons/layers/noisy_dense.py
+++ b/tensorflow_addons/layers/noisy_dense.py
@@ -1,4 +1,4 @@
-# Copyright 2019 The TensorFlow Authors. All Rights Reserved.
+# Copyright 2020 The TensorFlow Authors. All Rights Reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -11,9 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-
-# Orginal implementation from keras_contrib/layer/normalization
-# =============================================================================
+# ==============================================================================
 
 import tensorflow as tf
 from tensorflow.keras import (
@@ -28,9 +26,8 @@ from tensorflow.keras.layers import InputSpec
 
 @tf.keras.utils.register_keras_serializable(package="Addons")
 class NoisyDense(tf.keras.layers.Layer):
-    """Like normal dense layer but random noisy is added to the weights matrix. But
-  as the network improves the random noise is decayed until it is insignificant.
-
+    """Like normal dense layer (https://github.com/tensorflow/tensorflow/blob/v2.3.0/tensorflow/python/keras/layers/core.py#L1067-L1233)
+  but random noisy is added to the weights matrix. But as the network improves the random noise is decayed until it is insignificant.
   A `NoisyDense` layer implements the operation:
   `output = activation(dot(input, µ_kernel + (σ_kernel * ε_kernel)) + bias)`
   where `activation` is the element-wise activation function
@@ -38,7 +35,6 @@ class NoisyDense(tf.keras.layers.Layer):
   created by the layer, σ_kernel is a weights matrix that controls the importance of
   the ε_kernel which is just random noise, and `bias` is a bias vector created by the layer
   (only applicable if `use_bias` is `True`).
-
   Example:
   >>> # Create a `Sequential` model and add a Dense layer as the first layer.
   >>> model = tf.keras.models.Sequential()
@@ -51,7 +47,6 @@ class NoisyDense(tf.keras.layers.Layer):
   >>> model.add(NoisyDense(32))
   >>> model.output_shape
   (None, 32)
-
   Arguments:
     units: Positive integer, dimensionality of the output space.
     activation: Activation function to use.
@@ -66,12 +61,10 @@ class NoisyDense(tf.keras.layers.Layer):
     kernel_constraint: Constraint function applied to
       the `kernel` weights matrix.
     bias_constraint: Constraint function applied to the bias vector.
-
   Input shape:
     N-D tensor with shape: `(batch_size, ..., input_dim)`.
     The most common situation would be
     a 2D input with shape `(batch_size, input_dim)`.
-
   Output shape:
     N-D tensor with shape: `(batch_size, ..., units)`.
     For instance, for a 2D input with shape `(batch_size, input_dim)`,

--- a/tensorflow_addons/layers/noisy_dense.py
+++ b/tensorflow_addons/layers/noisy_dense.py
@@ -22,7 +22,7 @@ from tensorflow.python.keras.engine.input_spec import InputSpec
 from tensorflow.python.framework import dtypes, tensor_shape, sparse_tensor
 from tensorflow.python.keras.engine.base_layer import Layer
 
-@tf..utils.register_keras_serializable(package="Addons")
+@tf.utils.register_keras_serializable(package="Addons")
 class NoisyDense(Layer):
   """Like normal dense layer but random noisy is added to the weights matrix. But
   as the network improves the random noise is decayed until it is insignificant. 

--- a/tensorflow_addons/layers/noisy_dense.py
+++ b/tensorflow_addons/layers/noisy_dense.py
@@ -213,13 +213,15 @@ class NoisyDense(tf.keras.layers.Layer):
         self.eps_kernel = tf.zeros([self.last_dim, self.units], dtype=dtype)
         self.eps_bias = tf.zeros([self.last_dim, self.units], dtype=dtype)
 
-    def call(self, inputs, reset_noise=True):
+    def call(self, inputs, reset_noise=True, remove_noise=False):
         dtype = self._compute_dtype_object
         if inputs.dtype.base_dtype != dtype.base_dtype:
             inputs = tf.cast(inputs, dtype=dtype)
 
         # Generate fixed parameters added as the noise
-        if reset_noise:
+        if remove_noise:
+            self.remove_noise()
+        elif reset_noise:
             self.reset_noise()
 
         r"""

--- a/tensorflow_addons/layers/noisy_dense.py
+++ b/tensorflow_addons/layers/noisy_dense.py
@@ -1,0 +1,232 @@
+# Copyright 2019 The TensorFlow Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Orginal implementation from keras_contrib/layer/normalization
+# =============================================================================
+
+import tensorflow as tf
+from tensorflow.keras import layers, activations, initializers, regularizers, constraints
+from tensorflow.python.ops import math_ops, nn_ops, sparse_ops, gen_math_ops, standard_ops
+from tensorflow.python.keras.engine.input_spec import InputSpec
+from tensorflow.python.framework import dtypes, tensor_shape, sparse_tensor
+from tensorflow.python.keras.engine.base_layer import Layer
+
+@tf..utils.register_keras_serializable(package="Addons")
+class NoisyDense(Layer):
+  """Like normal dense layer but random noisy is added to the weights matrix. But
+  as the network improves the random noise is decayed until it is insignificant. 
+  A `NoisyDense` layer implements the operation:
+  `output = activation(dot(input, µ_kernel + (σ_kernel * ε_kernel)) + bias)`
+  where `activation` is the element-wise activation function
+  passed as the `activation` argument, `µ_kernel` is your average weights matrix
+  created by the layer, σ_kernel is a weights matrix that controls the importance of 
+  the ε_kernel which is just random noise, and `bias` is a bias vector created by the layer
+  (only applicable if `use_bias` is `True`).
+  Besides, layer attributes cannot be modified after the layer has been called
+  once (except the `trainable` attribute).
+  Example:
+  >>> # Create a `Sequential` model and add a Dense layer as the first layer.
+  >>> model = tf.keras.models.Sequential()
+  >>> model.add(tf.keras.Input(shape=(16,)))
+  >>> model.add(tf.keras.layers.NoisyDense(32, activation='relu'))
+  >>> # Now the model will take as input arrays of shape (None, 16)
+  >>> # and output arrays of shape (None, 32).
+  >>> # Note that after the first layer, you don't need to specify
+  >>> # the size of the input anymore:
+  >>> model.add(tf.keras.layers.NoisyDense(32))
+  >>> model.output_shape
+  (None, 32)
+  Arguments:
+    units: Positive integer, dimensionality of the output space.
+    activation: Activation function to use.
+      If you don't specify anything, no activation is applied
+      (ie. "linear" activation: `a(x) = x`).
+    use_bias: Boolean, whether the layer uses a bias vector.
+    kernel_regularizer: Regularizer function applied to
+      the `kernel` weights matrix.
+    bias_regularizer: Regularizer function applied to the bias vector.
+    activity_regularizer: Regularizer function applied to
+      the output of the layer (its "activation").
+    kernel_constraint: Constraint function applied to
+      the `kernel` weights matrix.
+    bias_constraint: Constraint function applied to the bias vector.
+  Input shape:
+    N-D tensor with shape: `(batch_size, ..., input_dim)`.
+    The most common situation would be
+    a 2D input with shape `(batch_size, input_dim)`.
+  Output shape:
+    N-D tensor with shape: `(batch_size, ..., units)`.
+    For instance, for a 2D input with shape `(batch_size, input_dim)`,
+    the output would have shape `(batch_size, units)`.
+  """
+
+  def __init__(self,
+               units,
+               activation=None,
+               use_bias=True,
+               kernel_regularizer=None,
+               bias_regularizer=None,
+               activity_regularizer=None,
+               kernel_constraint=None,
+               bias_constraint=None,
+               **kwargs):
+    super(NoisyDense, self).__init__(activity_regularizer=activity_regularizer, **kwargs)
+
+    self.units = int(units) if not isinstance(units, int) else units
+    self.activation = activations.get(activation)
+    self.use_bias = use_bias
+    self.kernel_regularizer = regularizers.get(kernel_regularizer)
+    self.bias_regularizer = regularizers.get(bias_regularizer)
+    self.kernel_constraint = constraints.get(kernel_constraint)
+    self.bias_constraint = constraints.get(bias_constraint)
+
+    self.input_spec = InputSpec(min_ndim=2)
+    self.supports_masking = True
+
+  def build(self, input_shape):
+    # Make sure dtype is correct
+    dtype = dtypes.as_dtype(self.dtype or K.floatx())
+    if not (dtype.is_floating or dtype.is_complex):
+      raise TypeError('Unable to build `Dense` layer with non-floating point '
+                      'dtype %s' % (dtype,))
+
+    input_shape = tensor_shape.TensorShape(input_shape)
+    self.last_dim = tensor_shape.dimension_value(input_shape[-1])
+    sqrt_dim = self.last_dim ** (1/2)
+    if self.last_dim is None:
+      raise ValueError('The last dimension of the inputs to `Dense` '
+                       'should be defined. Found `None`.')
+    self.input_spec = InputSpec(min_ndim=2, axes={-1: self.last_dim})
+
+    self.σ_init = initializers.Constant(value=0.5/sqrt_dim)
+    self.µ_init = initializers.RandomUniform(minval=-1/sqrt_dim, maxval=1/sqrt_dim)
+
+    # Learnable parameters
+    # Agent will learn to decay σ as it improves creating a sort of learned epsilon decay
+    self.σ_kernel = self.add_weight(
+        "σ_kernel",
+        shape=[self.last_dim, self.units], 
+        initializer=self.σ_init,
+        regularizer=self.kernel_regularizer,
+        constraint=self.kernel_constraint, 
+        dtype=self.dtype,
+        trainable=True)
+
+    self.µ_kernel = self.add_weight(
+        "µ_kernel",
+        shape=[self.last_dim, self.units], 
+        initializer=self.µ_init,
+        regularizer=self.kernel_regularizer,
+        constraint=self.kernel_constraint, 
+        dtype=self.dtype,
+        trainable=True)
+
+    if self.use_bias:
+      self.σ_bias = self.add_weight(
+          "σ_bias",
+          shape=[self.units,],
+          initializer=self.σ_init,
+          regularizer=self.bias_regularizer,
+          constraint=self.bias_constraint,
+          dtype=self.dtype,
+          trainable=True)
+
+      self.µ_bias = self.add_weight(
+          "µ_bias",
+          shape=[self.units,],
+          initializer=self.µ_init,
+          regularizer=self.bias_regularizer,
+          constraint=self.bias_constraint,
+          dtype=self.dtype,
+          trainable=True)
+
+    self.built = True
+
+  @staticmethod
+  def _scale_noise(x):
+    return tf.sign(x)*tf.sqrt(tf.abs(x))
+
+  def call(self, inputs):
+    dtype = self._compute_dtype_object
+    if inputs.dtype.base_dtype != dtype.base_dtype:
+      inputs = math_ops.cast(inputs, dtype=dtype)
+
+    # Fixed parameters added as the noise
+    ε_i = tf.random.normal([self.last_dim, self.units])
+    ε_j = tf.random.normal([self.units,])
+
+    # Creates the factorised Gaussian noise
+    f = NoisyDense._scale_noise
+    ε_kernel = f(ε_i) * f(ε_j)
+    ε_bias = f(ε_j)
+
+    # Performs: y = (µw + σw · εw)x + µb + σb · εb
+    # to calculate the output
+    rank = inputs.shape.rank
+    if rank == 2 or rank is None:
+      if isinstance(inputs, sparse_tensor.SparseTensor):
+        outputs = sparse_ops.sparse_tensor_dense_matmul(inputs, self.µ_kernel + (self.σ_kernel * ε_kernel))
+      else:
+        outputs = gen_math_ops.mat_mul(inputs, self.µ_kernel + (self.σ_kernel * ε_kernel))
+    # Broadcast kernel to inputs.
+    else:
+      outputs = standard_ops.tensordot(inputs, self.µ_kernel + (self.σ_kernel * ε_kernel), [[rank - 1], [0]])
+      # Reshape the output back to the original ndim of the input.
+      if not context.executing_eagerly():
+        shape = inputs.shape.as_list()
+        output_shape = shape[:-1] + [kernel.shape[-1]]
+        outputs.set_shape(output_shape)
+
+    if self.use_bias:
+      noisy_bias = self.µ_bias + (self.σ_bias * ε_bias)
+      outputs = nn_ops.bias_add(outputs, noisy_bias)
+
+    if self.activation is not None:
+      outputs = self.activation(outputs)
+
+    return outputs
+
+
+  def compute_output_shape(self, input_shape):
+    input_shape = tensor_shape.TensorShape(input_shape)
+    input_shape = input_shape.with_rank_at_least(2)
+    if tensor_shape.dimension_value(input_shape[-1]) is None:
+      raise ValueError(
+          'The innermost dimension of input_shape must be defined, but saw: %s'
+          % input_shape)
+    return input_shape[:-1].concatenate(self.units)
+
+  def get_config(self):
+    config = super(NoisyDense, self).get_config()
+    config.update({
+        'units':
+            self.units,
+        'activation':
+            activations.serialize(self.activation),
+        'σ_initializer':
+            initializers.serialize(self.σ_init),
+        'µ_initializer':
+            initializers.serialize(self.µ_init),
+        'kernel_regularizer':
+            regularizers.serialize(self.kernel_regularizer),
+        'bias_regularizer':
+            regularizers.serialize(self.bias_regularizer),
+        'activity_regularizer':
+            regularizers.serialize(self.activity_regularizer),
+        'kernel_constraint':
+            constraints.serialize(self.kernel_constraint),
+        'bias_constraint':
+            constraints.serialize(self.bias_constraint)
+    })
+    return config

--- a/tensorflow_addons/layers/noisy_dense.py
+++ b/tensorflow_addons/layers/noisy_dense.py
@@ -231,8 +231,8 @@ class NoisyDense(tf.keras.layers.Layer):
         config.update(
             {
                 "units": self.units,
-                "activation": activations.serialize(self.activation),
                 "use_bias": self.use_bias,
+                "activation": activations.serialize(self.activation),
                 "kernel_regularizer": regularizers.serialize(self.kernel_regularizer),
                 "bias_regularizer": regularizers.serialize(self.bias_regularizer),
                 "activity_regularizer": regularizers.serialize(

--- a/tensorflow_addons/layers/noisy_dense.py
+++ b/tensorflow_addons/layers/noisy_dense.py
@@ -153,7 +153,9 @@ class NoisyDense(tf.keras.layers.Layer):
         if self.use_bias:
             self.σ_bias = self.add_weight(
                 "σ_bias",
-                shape=[self.units,],
+                shape=[
+                    self.units,
+                ],
                 initializer=self.σ_init,
                 regularizer=self.bias_regularizer,
                 constraint=self.bias_constraint,
@@ -163,7 +165,9 @@ class NoisyDense(tf.keras.layers.Layer):
 
             self.µ_bias = self.add_weight(
                 "µ_bias",
-                shape=[self.units,],
+                shape=[
+                    self.units,
+                ],
                 initializer=self.µ_init,
                 regularizer=self.bias_regularizer,
                 constraint=self.bias_constraint,
@@ -184,7 +188,12 @@ class NoisyDense(tf.keras.layers.Layer):
 
         # Fixed parameters added as the noise
         ε_i = tf.random.normal([self.last_dim, self.units], dtype=dtype)
-        ε_j = tf.random.normal([self.units,], dtype=dtype)
+        ε_j = tf.random.normal(
+            [
+                self.units,
+            ],
+            dtype=dtype,
+        )
 
         # Creates the factorised Gaussian noise
         f = NoisyDense._scale_noise

--- a/tensorflow_addons/layers/noisy_dense.py
+++ b/tensorflow_addons/layers/noisy_dense.py
@@ -51,6 +51,7 @@ class NoisyDense(tf.keras.layers.Dense):
     Note: bias only added if `use_bias` is `True`.
 
     Example:
+
     >>> # Create a `Sequential` model and add a NoisyDense
     >>> # layer as the first layer.
     >>> model = tf.keras.models.Sequential()
@@ -143,16 +144,14 @@ class NoisyDense(tf.keras.layers.Dense):
             )
         self.input_spec = InputSpec(min_ndim=2, axes={-1: self.last_dim})
 
-        self.sigma_init = initializers.Constant(value=self.sigma / sqrt_dim)
-        self.mu_init = initializers.RandomUniform(
-            minval=-1 / sqrt_dim, maxval=1 / sqrt_dim
-        )
+        sigma_init = initializers.Constant(value=self.sigma / sqrt_dim)
+        mu_init = initializers.RandomUniform(minval=-1 / sqrt_dim, maxval=1 / sqrt_dim)
 
         # Learnable parameters
         self.sigma_kernel = self.add_weight(
             "sigma_kernel",
             shape=[self.last_dim, self.units],
-            initializer=self.sigma_init,
+            initializer=sigma_init,
             regularizer=self.kernel_regularizer,
             constraint=self.kernel_constraint,
             dtype=self.dtype,
@@ -162,7 +161,7 @@ class NoisyDense(tf.keras.layers.Dense):
         self.mu_kernel = self.add_weight(
             "mu_kernel",
             shape=[self.last_dim, self.units],
-            initializer=self.mu_init,
+            initializer=mu_init,
             regularizer=self.kernel_regularizer,
             constraint=self.kernel_constraint,
             dtype=self.dtype,
@@ -175,7 +174,7 @@ class NoisyDense(tf.keras.layers.Dense):
                 shape=[
                     self.units,
                 ],
-                initializer=self.sigma_init,
+                initializer=sigma_init,
                 regularizer=self.bias_regularizer,
                 constraint=self.bias_constraint,
                 dtype=self.dtype,
@@ -187,7 +186,7 @@ class NoisyDense(tf.keras.layers.Dense):
                 shape=[
                     self.units,
                 ],
-                initializer=self.mu_init,
+                initializer=mu_init,
                 regularizer=self.bias_regularizer,
                 constraint=self.bias_constraint,
                 dtype=self.dtype,

--- a/tensorflow_addons/layers/noisy_dense.py
+++ b/tensorflow_addons/layers/noisy_dense.py
@@ -26,6 +26,7 @@ from tensorflow.python.keras.engine.base_layer import Layer
 class NoisyDense(Layer):
   """Like normal dense layer but random noisy is added to the weights matrix. But
   as the network improves the random noise is decayed until it is insignificant. 
+  
   A `NoisyDense` layer implements the operation:
   `output = activation(dot(input, µ_kernel + (σ_kernel * ε_kernel)) + bias)`
   where `activation` is the element-wise activation function
@@ -33,8 +34,7 @@ class NoisyDense(Layer):
   created by the layer, σ_kernel is a weights matrix that controls the importance of 
   the ε_kernel which is just random noise, and `bias` is a bias vector created by the layer
   (only applicable if `use_bias` is `True`).
-  Besides, layer attributes cannot be modified after the layer has been called
-  once (except the `trainable` attribute).
+
   Example:
   >>> # Create a `Sequential` model and add a Dense layer as the first layer.
   >>> model = tf.keras.models.Sequential()
@@ -47,6 +47,7 @@ class NoisyDense(Layer):
   >>> model.add(NoisyDense(32))
   >>> model.output_shape
   (None, 32)
+  
   Arguments:
     units: Positive integer, dimensionality of the output space.
     activation: Activation function to use.
@@ -61,10 +62,12 @@ class NoisyDense(Layer):
     kernel_constraint: Constraint function applied to
       the `kernel` weights matrix.
     bias_constraint: Constraint function applied to the bias vector.
+    
   Input shape:
     N-D tensor with shape: `(batch_size, ..., input_dim)`.
     The most common situation would be
     a 2D input with shape `(batch_size, input_dim)`.
+    
   Output shape:
     N-D tensor with shape: `(batch_size, ..., units)`.
     For instance, for a 2D input with shape `(batch_size, input_dim)`,

--- a/tensorflow_addons/layers/tests/noisy_dense_test.py
+++ b/tensorflow_addons/layers/tests/noisy_dense_test.py
@@ -1,4 +1,4 @@
-# Copyright 2019 The TensorFlow Authors. All Rights Reserved.
+# Copyright 2020 The TensorFlow Authors. All Rights Reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/tensorflow_addons/layers/tests/noisy_dense_test.py
+++ b/tensorflow_addons/layers/tests/noisy_dense_test.py
@@ -57,8 +57,8 @@ def test_noisy_dense_with_policy():
     np.testing.assert_array_equal(output_signature.dtype, tf.dtypes.float16)
     np.testing.assert_array_equal(output_signature.shape, (2, 5))
     np.testing.assert_array_equal(outputs.dtype, "float16")
-    np.testing.assert_array_equal(layer.µ_kernel.dtype, "float32")
-    np.testing.assert_array_equal(layer.σ_kernel.dtype, "float32")
+    np.testing.assert_array_equal(layer.mu_kernel.dtype, "float32")
+    np.testing.assert_array_equal(layer.sigma_kernel.dtype, "float32")
 
 
 @pytest.mark.usefixtures("maybe_run_functions_eagerly")
@@ -85,10 +85,10 @@ def test_noisy_dense_constraints():
         name="noisy_dense_constriants",
     )
     layer(keras.backend.variable(np.ones((2, 4))))
-    np.testing.assert_array_equal(layer.µ_kernel.constraint, k_constraint)
-    np.testing.assert_array_equal(layer.σ_kernel.constraint, k_constraint)
-    np.testing.assert_array_equal(layer.µ_bias.constraint, b_constraint)
-    np.testing.assert_array_equal(layer.σ_bias.constraint, b_constraint)
+    np.testing.assert_array_equal(layer.mu_kernel.constraint, k_constraint)
+    np.testing.assert_array_equal(layer.sigma_kernel.constraint, k_constraint)
+    np.testing.assert_array_equal(layer.mu_bias.constraint, b_constraint)
+    np.testing.assert_array_equal(layer.sigma_bias.constraint, b_constraint)
 
 
 @pytest.mark.usefixtures("maybe_run_functions_eagerly")
@@ -96,16 +96,22 @@ def test_noisy_dense_automatic_reset_noise():
     inputs = tf.convert_to_tensor(np.random.randint(low=0, high=7, size=(2, 2)))
     layer = NoisyDense(5, name="noise_dense_auto_reset_noise")
     layer(inputs)
-    initial_ε_kernel = layer.ε_kernel
-    initial_ε_bias = layer.ε_bias
+    initial_eps_kernel = layer.eps_kernel
+    initial_eps_bias = layer.eps_bias
     layer(inputs)
-    new_ε_kernel = layer.ε_kernel
-    new_ε_bias = layer.ε_bias
+    new_eps_kernel = layer.eps_kernel
+    new_eps_bias = layer.eps_bias
     np.testing.assert_raises(
-        AssertionError, np.testing.assert_array_equal, initial_ε_kernel, new_ε_kernel
+        AssertionError,
+        np.testing.assert_array_equal,
+        initial_eps_kernel,
+        new_eps_kernel,
     )
     np.testing.assert_raises(
-        AssertionError, np.testing.assert_array_equal, initial_ε_bias, new_ε_bias
+        AssertionError,
+        np.testing.assert_array_equal,
+        initial_eps_bias,
+        new_eps_bias,
     )
 
 
@@ -114,16 +120,22 @@ def test_noisy_dense_manual_reset_noise():
     inputs = tf.convert_to_tensor(np.random.randint(low=0, high=7, size=(2, 2)))
     layer = NoisyDense(5, name="noise_dense_manual_reset_noise")
     layer(inputs)
-    initial_ε_kernel = layer.ε_kernel
-    initial_ε_bias = layer.ε_bias
+    initial_eps_kernel = layer.eps_kernel
+    initial_eps_bias = layer.eps_bias
     layer.reset_noise()
-    new_ε_kernel = layer.ε_kernel
-    new_ε_bias = layer.ε_bias
+    new_eps_kernel = layer.eps_kernel
+    new_eps_bias = layer.eps_bias
     np.testing.assert_raises(
-        AssertionError, np.testing.assert_array_equal, initial_ε_kernel, new_ε_kernel
+        AssertionError,
+        np.testing.assert_array_equal,
+        initial_eps_kernel,
+        new_eps_kernel,
     )
     np.testing.assert_raises(
-        AssertionError, np.testing.assert_array_equal, initial_ε_bias, new_ε_bias
+        AssertionError,
+        np.testing.assert_array_equal,
+        initial_eps_bias,
+        new_eps_bias,
     )
 
 
@@ -132,17 +144,23 @@ def test_noisy_dense_remove_noise():
     inputs = tf.convert_to_tensor(np.random.randint(low=0, high=7, size=(2, 2)))
     layer = NoisyDense(5, name="noise_dense_manual_reset_noise")
     layer(inputs)
-    initial_ε_kernel = layer.ε_kernel
-    initial_ε_bias = layer.ε_bias
+    initial_eps_kernel = layer.eps_kernel
+    initial_eps_bias = layer.eps_bias
     layer.remove_noise()
-    new_ε_kernel = layer.ε_kernel
-    new_ε_bias = layer.ε_bias
-    zeros = tf.zeros(initial_ε_kernel.shape, dtype=initial_ε_kernel.dtype)
+    new_eps_kernel = layer.eps_kernel
+    new_eps_bias = layer.eps_bias
+    zeros = tf.zeros(initial_eps_kernel.shape, dtype=initial_eps_kernel.dtype)
     np.testing.assert_raises(
-        AssertionError, np.testing.assert_array_equal, initial_ε_kernel, new_ε_kernel
+        AssertionError,
+        np.testing.assert_array_equal,
+        initial_eps_kernel,
+        new_eps_kernel,
     )
     np.testing.assert_raises(
-        AssertionError, np.testing.assert_array_equal, initial_ε_bias, new_ε_bias
+        AssertionError,
+        np.testing.assert_array_equal,
+        initial_eps_bias,
+        new_eps_bias,
     )
-    np.testing.assert_array_equal(zeros, new_ε_kernel)
-    np.testing.assert_array_equal(zeros, new_ε_bias)
+    np.testing.assert_array_equal(zeros, new_eps_kernel)
+    np.testing.assert_array_equal(zeros, new_eps_bias)

--- a/tensorflow_addons/layers/tests/noisy_dense_test.py
+++ b/tensorflow_addons/layers/tests/noisy_dense_test.py
@@ -125,3 +125,24 @@ def test_noisy_dense_manual_reset_noise():
     np.testing.assert_raises(
         AssertionError, np.testing.assert_array_equal, initial_ε_bias, new_ε_bias
     )
+
+
+@pytest.mark.usefixtures("maybe_run_functions_eagerly")
+def test_noisy_dense_remove_noise():
+    inputs = tf.convert_to_tensor(np.random.randint(low=0, high=7, size=(2, 2)))
+    layer = NoisyDense(5, name="noise_dense_manual_reset_noise")
+    layer(inputs)
+    initial_ε_kernel = layer.ε_kernel
+    initial_ε_bias = layer.ε_bias
+    layer.remove_noise()
+    new_ε_kernel = layer.ε_kernel
+    new_ε_bias = layer.ε_bias
+    zeros = tf.zeros(initial_ε_kernel.shape, dtype=initial_ε_kernel.dtype)
+    np.testing.assert_raises(
+        AssertionError, np.testing.assert_array_equal, initial_ε_kernel, new_ε_kernel
+    )
+    np.testing.assert_raises(
+        AssertionError, np.testing.assert_array_equal, initial_ε_bias, new_ε_bias
+    )
+    np.testing.assert_array_equal(zeros, new_ε_kernel)
+    np.testing.assert_array_equal(zeros, new_ε_bias)

--- a/tensorflow_addons/layers/tests/noisy_dense_test.py
+++ b/tensorflow_addons/layers/tests/noisy_dense_test.py
@@ -16,63 +16,61 @@
 
 
 import numpy as np
+import pytest
 from tensorflow.python import keras
-from tensorflow.python.keras import testing_utils
+from tensorflow_addons.utils import test_utils
 from tensorflow_addons.layers.noisy_dense import NoisyDense
 from tensorflow.python.framework import ops
 from tensorflow.python.keras import keras_parameterized
 from tensorflow.python.framework import tensor_spec
+from tensorflow.debugging import assert_equal
+from tensorflow.python.keras.mixed_precision.experimental import policy
 
+@pytest.mark.usefixtures("maybe_run_functions_eagerly")
+@pytest.mark.parametrize("dtype", [np.float16, np.float32, np.float64])
+def test_noisy_dense(dtype):
+  test_utils.layer_test(
+      NoisyDense, kwargs={'units': 3, "dtype": dtype}, input_shape=(3, 2))
 
-@keras_parameterized.run_all_keras_modes
-class NoisyDenseTest(keras_parameterized.TestCase):
-  def test_noisy_dense(self):
-    testing_utils.layer_test(
-        NoisyDense, kwargs={'units': 3}, input_shape=(3, 2))
+  test_utils.layer_test(
+      NoisyDense, kwargs={'units': 3, "dtype": dtype}, input_shape=(3, 4, 2))
 
-    testing_utils.layer_test(
-        NoisyDense, kwargs={'units': 3}, input_shape=(3, 4, 2))
+  test_utils.layer_test(
+      NoisyDense, kwargs={'units': 3, "dtype": dtype}, input_shape=(None, None, 2))
 
-    testing_utils.layer_test(
-        NoisyDense, kwargs={'units': 3}, input_shape=(None, None, 2))
+  test_utils.layer_test(
+      NoisyDense, kwargs={'units': 3, "dtype": dtype}, input_shape=(3, 4, 5, 2))
 
-    testing_utils.layer_test(
-        NoisyDense, kwargs={'units': 3}, input_shape=(3, 4, 5, 2))
+@pytest.mark.usefixtures("maybe_run_functions_eagerly")
+def test_noisy_dense_with_policy():
+  inputs = ops.convert_to_tensor_v2(
+      np.random.randint(low=0, high=7, size=(2, 2)))
+  layer = NoisyDense(5, dtype=policy.Policy('mixed_float16'))
+  outputs = layer(inputs)
+  output_signature = layer.compute_output_signature(
+      tensor_spec.TensorSpec(dtype='float16', shape=(2, 2)))
+  assert_equal(output_signature.dtype, dtypes.float16)
+  assert_equal(output_signature.shape, (2, 5))
+  sassert_equal(outputs.dtype, 'float16')
+  assert_equal(layer.kernel.dtype, 'float32')
 
-  def test_noisy_dense_dtype(self):
-    inputs = ops.convert_to_tensor_v2(
-        np.random.randint(low=0, high=7, size=(2, 2)))
-    layer = NoisyDense(5, dtype='float32')
-    outputs = layer(inputs)
-    self.assertEqual(outputs.dtype, 'float32')
+@pytest.mark.usefixtures("maybe_run_functions_eagerly")
+def test_noisy_dense_regularization(self):
+  layer = NoisyDense(
+      3,
+      kernel_regularizer=keras.regularizers.l1(0.01),
+      bias_regularizer='l1',
+      activity_regularizer='l2',
+      name='noisy_dense_reg')
+  layer(keras.backend.variable(np.ones((2, 4))))
+  assert_equal(3, len(layer.losses))
 
-  def test_noisy_dense_with_policy(self):
-    inputs = ops.convert_to_tensor_v2(
-        np.random.randint(low=0, high=7, size=(2, 2)))
-    layer = NoisyDense(5, dtype=policy.Policy('mixed_float16'))
-    outputs = layer(inputs)
-    output_signature = layer.compute_output_signature(
-        tensor_spec.TensorSpec(dtype='float16', shape=(2, 2)))
-    self.assertEqual(output_signature.dtype, dtypes.float16)
-    self.assertEqual(output_signature.shape, (2, 5))
-    self.assertEqual(outputs.dtype, 'float16')
-    self.assertEqual(layer.kernel.dtype, 'float32')
-
-  def test_noisy_dense_regularization(self):
-    layer = NoisyDense(
-        3,
-        kernel_regularizer=keras.regularizers.l1(0.01),
-        bias_regularizer='l1',
-        activity_regularizer='l2',
-        name='noisy_dense_reg')
-    layer(keras.backend.variable(np.ones((2, 4))))
-    self.assertEqual(3, len(layer.losses))
-
-  def test_noisy_dense_constraints(self):
-    k_constraint = keras.constraints.max_norm(0.01)
-    b_constraint = keras.constraints.max_norm(0.01)
-    layer = NoisyDense(
-        3, kernel_constraint=k_constraint, bias_constraint=b_constraint)
-    layer(keras.backend.variable(np.ones((2, 4))))
-    self.assertEqual(layer.kernel.constraint, k_constraint)
-    self.assertEqual(layer.bias.constraint, b_constraint)
+@pytest.mark.usefixtures("maybe_run_functions_eagerly")
+def test_noisy_dense_constraints(self):
+  k_constraint = keras.constraints.max_norm(0.01)
+  b_constraint = keras.constraints.max_norm(0.01)
+  layer = NoisyDense(
+      3, kernel_constraint=k_constraint, bias_constraint=b_constraint)
+  layer(keras.backend.variable(np.ones((2, 4))))
+  assert_equal(layer.kernel.constraint, k_constraint)
+  assert_equal(layer.bias.constraint, b_constraint)

--- a/tensorflow_addons/layers/tests/noisy_dense_test.py
+++ b/tensorflow_addons/layers/tests/noisy_dense_test.py
@@ -1,0 +1,78 @@
+# Copyright 2019 The TensorFlow Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ==============================================================================
+"""Tests NoisyDense layer."""
+
+
+import numpy as np
+from tensorflow.python import keras
+from tensorflow.python.keras import testing_utils
+from tensorflow_addons.layers.noisy_dense import NoisyDense
+from tensorflow.python.framework import ops
+from tensorflow.python.keras import keras_parameterized
+from tensorflow.python.framework import tensor_spec
+
+
+@keras_parameterized.run_all_keras_modes
+class NoisyDenseTest(keras_parameterized.TestCase):
+  def test_noisy_dense(self):
+    testing_utils.layer_test(
+        NoisyDense, kwargs={'units': 3}, input_shape=(3, 2))
+
+    testing_utils.layer_test(
+        NoisyDense, kwargs={'units': 3}, input_shape=(3, 4, 2))
+
+    testing_utils.layer_test(
+        NoisyDense, kwargs={'units': 3}, input_shape=(None, None, 2))
+
+    testing_utils.layer_test(
+        NoisyDense, kwargs={'units': 3}, input_shape=(3, 4, 5, 2))
+
+  def test_noisy_dense_dtype(self):
+    inputs = ops.convert_to_tensor_v2(
+        np.random.randint(low=0, high=7, size=(2, 2)))
+    layer = NoisyDense(5, dtype='float32')
+    outputs = layer(inputs)
+    self.assertEqual(outputs.dtype, 'float32')
+
+  def test_noisy_dense_with_policy(self):
+    inputs = ops.convert_to_tensor_v2(
+        np.random.randint(low=0, high=7, size=(2, 2)))
+    layer = NoisyDense(5, dtype=policy.Policy('mixed_float16'))
+    outputs = layer(inputs)
+    output_signature = layer.compute_output_signature(
+        tensor_spec.TensorSpec(dtype='float16', shape=(2, 2)))
+    self.assertEqual(output_signature.dtype, dtypes.float16)
+    self.assertEqual(output_signature.shape, (2, 5))
+    self.assertEqual(outputs.dtype, 'float16')
+    self.assertEqual(layer.kernel.dtype, 'float32')
+
+  def test_noisy_dense_regularization(self):
+    layer = NoisyDense(
+        3,
+        kernel_regularizer=keras.regularizers.l1(0.01),
+        bias_regularizer='l1',
+        activity_regularizer='l2',
+        name='noisy_dense_reg')
+    layer(keras.backend.variable(np.ones((2, 4))))
+    self.assertEqual(3, len(layer.losses))
+
+  def test_noisy_dense_constraints(self):
+    k_constraint = keras.constraints.max_norm(0.01)
+    b_constraint = keras.constraints.max_norm(0.01)
+    layer = NoisyDense(
+        3, kernel_constraint=k_constraint, bias_constraint=b_constraint)
+    layer(keras.backend.variable(np.ones((2, 4))))
+    self.assertEqual(layer.kernel.constraint, k_constraint)
+    self.assertEqual(layer.bias.constraint, b_constraint)

--- a/tensorflow_addons/layers/tests/noisy_dense_test.py
+++ b/tensorflow_addons/layers/tests/noisy_dense_test.py
@@ -116,40 +116,17 @@ def test_noisy_dense_automatic_reset_noise():
 
 
 @pytest.mark.usefixtures("maybe_run_functions_eagerly")
-def test_noisy_dense_manual_reset_noise():
-    inputs = tf.convert_to_tensor(np.random.randint(low=0, high=7, size=(2, 2)))
-    layer = NoisyDense(5, name="noise_dense_manual_reset_noise")
-    layer(inputs)
-    initial_eps_kernel = layer.eps_kernel
-    initial_eps_bias = layer.eps_bias
-    layer.reset_noise()
-    new_eps_kernel = layer.eps_kernel
-    new_eps_bias = layer.eps_bias
-    np.testing.assert_raises(
-        AssertionError,
-        np.testing.assert_array_equal,
-        initial_eps_kernel,
-        new_eps_kernel,
-    )
-    np.testing.assert_raises(
-        AssertionError,
-        np.testing.assert_array_equal,
-        initial_eps_bias,
-        new_eps_bias,
-    )
-
-
-@pytest.mark.usefixtures("maybe_run_functions_eagerly")
 def test_noisy_dense_remove_noise():
     inputs = tf.convert_to_tensor(np.random.randint(low=0, high=7, size=(2, 2)))
     layer = NoisyDense(5, name="noise_dense_manual_reset_noise")
     layer(inputs)
     initial_eps_kernel = layer.eps_kernel
     initial_eps_bias = layer.eps_bias
-    layer.remove_noise()
+    layer(inputs, reset_noise=False, remove_noise=True)
     new_eps_kernel = layer.eps_kernel
     new_eps_bias = layer.eps_bias
-    zeros = tf.zeros(initial_eps_kernel.shape, dtype=initial_eps_kernel.dtype)
+    kernel_zeros = tf.zeros(initial_eps_kernel.shape, dtype=initial_eps_kernel.dtype)
+    bias_zeros = tf.zeros(initial_eps_bias.shape, dtype=initial_eps_kernel.dtype)
     np.testing.assert_raises(
         AssertionError,
         np.testing.assert_array_equal,
@@ -162,5 +139,5 @@ def test_noisy_dense_remove_noise():
         initial_eps_bias,
         new_eps_bias,
     )
-    np.testing.assert_array_equal(zeros, new_eps_kernel)
-    np.testing.assert_array_equal(zeros, new_eps_bias)
+    np.testing.assert_array_equal(kernel_zeros, new_eps_kernel)
+    np.testing.assert_array_equal(bias_zeros, new_eps_bias)

--- a/tensorflow_addons/layers/tests/noisy_dense_test.py
+++ b/tensorflow_addons/layers/tests/noisy_dense_test.py
@@ -20,19 +20,17 @@ import numpy as np
 
 import tensorflow as tf
 from tensorflow import keras
-from tensorflow_addons.utils import test_utils
-from tensorflow_addons.layers.noisy_dense import NoisyDense
 from tensorflow.keras.mixed_precision.experimental import Policy
 
+from tensorflow_addons.utils import test_utils
+from tensorflow_addons.layers.noisy_dense import NoisyDense
 
-def test_noisy_dense():
-    test_utils.layer_test(NoisyDense, kwargs={"units": 3}, input_shape=(3, 2))
 
-    test_utils.layer_test(NoisyDense, kwargs={"units": 3}, input_shape=(3, 4, 2))
-
-    test_utils.layer_test(NoisyDense, kwargs={"units": 3}, input_shape=(None, None, 2))
-
-    test_utils.layer_test(NoisyDense, kwargs={"units": 3}, input_shape=(3, 4, 5, 2))
+@pytest.mark.parametrize(
+    "input_shape", [(3, 2), (3, 4, 2), (None, None, 2), (3, 4, 5, 2)]
+)
+def test_noisy_dense(input_shape):
+    test_utils.layer_test(NoisyDense, kwargs={"units": 3}, input_shape=input_shape)
 
 
 @pytest.mark.usefixtures("maybe_run_functions_eagerly")

--- a/tensorflow_addons/layers/tests/noisy_dense_test.py
+++ b/tensorflow_addons/layers/tests/noisy_dense_test.py
@@ -15,15 +15,14 @@
 """Tests NoisyDense layer."""
 
 
-import numpy as np
 import pytest
-from tensorflow.python import keras
+import numpy as np
+
+import tensorflow as tf
+from tensorflow import keras
 from tensorflow_addons.utils import test_utils
 from tensorflow_addons.layers.noisy_dense import NoisyDense
-from tensorflow.python.framework import ops
-from tensorflow.python.framework import tensor_spec
-from tensorflow.python.keras.mixed_precision.experimental import policy
-from tensorflow.python.framework import dtypes
+from tensorflow.keras.mixed_precision.experimental import Policy
 
 
 def test_noisy_dense():
@@ -39,7 +38,7 @@ def test_noisy_dense():
 @pytest.mark.usefixtures("maybe_run_functions_eagerly")
 @pytest.mark.parametrize("dtype", ["float16", "float32", "float64"])
 def test_noisy_dense_dtype(dtype):
-    inputs = ops.convert_to_tensor_v2(
+    inputs = tf.convert_to_tensor(
         np.random.randint(low=0, high=7, size=(2, 2)), dtype=dtype
     )
     layer = NoisyDense(5, dtype=dtype)
@@ -49,13 +48,13 @@ def test_noisy_dense_dtype(dtype):
 
 @pytest.mark.usefixtures("maybe_run_functions_eagerly")
 def test_noisy_dense_with_policy():
-    inputs = ops.convert_to_tensor_v2(np.random.randint(low=0, high=7, size=(2, 2)))
-    layer = NoisyDense(5, dtype=policy.Policy("mixed_float16"))
+    inputs = tf.convert_to_tensor(np.random.randint(low=0, high=7, size=(2, 2)))
+    layer = NoisyDense(5, dtype=Policy("mixed_float16"))
     outputs = layer(inputs)
     output_signature = layer.compute_output_signature(
-        tensor_spec.TensorSpec(dtype="float16", shape=(2, 2))
+        tf.TensorSpec(dtype="float16", shape=(2, 2))
     )
-    np.testing.assert_array_equal(output_signature.dtype, dtypes.float16)
+    np.testing.assert_array_equal(output_signature.dtype, tf.dtypes.float16)
     np.testing.assert_array_equal(output_signature.shape, (2, 5))
     np.testing.assert_array_equal(outputs.dtype, "float16")
     np.testing.assert_array_equal(layer.µ_kernel.dtype, "float32")

--- a/tensorflow_addons/layers/tests/noisy_dense_test.py
+++ b/tensorflow_addons/layers/tests/noisy_dense_test.py
@@ -21,56 +21,67 @@ from tensorflow.python import keras
 from tensorflow_addons.utils import test_utils
 from tensorflow_addons.layers.noisy_dense import NoisyDense
 from tensorflow.python.framework import ops
-from tensorflow.python.keras import keras_parameterized
 from tensorflow.python.framework import tensor_spec
-from tensorflow.debugging import assert_equal
 from tensorflow.python.keras.mixed_precision.experimental import policy
+from tensorflow.python.framework import dtypes
+
+
+def test_noisy_dense():
+    test_utils.layer_test(NoisyDense, kwargs={"units": 3}, input_shape=(3, 2))
+
+    test_utils.layer_test(NoisyDense, kwargs={"units": 3}, input_shape=(3, 4, 2))
+
+    test_utils.layer_test(NoisyDense, kwargs={"units": 3}, input_shape=(None, None, 2))
+
+    test_utils.layer_test(NoisyDense, kwargs={"units": 3}, input_shape=(3, 4, 5, 2))
+
 
 @pytest.mark.usefixtures("maybe_run_functions_eagerly")
-@pytest.mark.parametrize("dtype", [np.float16, np.float32, np.float64])
-def test_noisy_dense(dtype):
-  test_utils.layer_test(
-      NoisyDense, kwargs={'units': 3, "dtype": dtype}, input_shape=(3, 2))
+@pytest.mark.parametrize("dtype", ["float16", "float32", "float64"])
+def test_noisy_dense_dtype(dtype):
+    inputs = ops.convert_to_tensor_v2(
+        np.random.randint(low=0, high=7, size=(2, 2)), dtype=dtype
+    )
+    layer = NoisyDense(5, dtype=dtype)
+    outputs = layer(inputs)
+    np.testing.assert_array_equal(outputs.dtype, dtype)
 
-  test_utils.layer_test(
-      NoisyDense, kwargs={'units': 3, "dtype": dtype}, input_shape=(3, 4, 2))
-
-  test_utils.layer_test(
-      NoisyDense, kwargs={'units': 3, "dtype": dtype}, input_shape=(None, None, 2))
-
-  test_utils.layer_test(
-      NoisyDense, kwargs={'units': 3, "dtype": dtype}, input_shape=(3, 4, 5, 2))
 
 @pytest.mark.usefixtures("maybe_run_functions_eagerly")
 def test_noisy_dense_with_policy():
-  inputs = ops.convert_to_tensor_v2(
-      np.random.randint(low=0, high=7, size=(2, 2)))
-  layer = NoisyDense(5, dtype=policy.Policy('mixed_float16'))
-  outputs = layer(inputs)
-  output_signature = layer.compute_output_signature(
-      tensor_spec.TensorSpec(dtype='float16', shape=(2, 2)))
-  assert_equal(output_signature.dtype, dtypes.float16)
-  assert_equal(output_signature.shape, (2, 5))
-  sassert_equal(outputs.dtype, 'float16')
-  assert_equal(layer.kernel.dtype, 'float32')
+    inputs = ops.convert_to_tensor_v2(np.random.randint(low=0, high=7, size=(2, 2)))
+    layer = NoisyDense(5, dtype=policy.Policy("mixed_float16"))
+    outputs = layer(inputs)
+    output_signature = layer.compute_output_signature(
+        tensor_spec.TensorSpec(dtype="float16", shape=(2, 2))
+    )
+    np.testing.assert_array_equal(output_signature.dtype, dtypes.float16)
+    np.testing.assert_array_equal(output_signature.shape, (2, 5))
+    np.testing.assert_array_equal(outputs.dtype, "float16")
+    np.testing.assert_array_equal(layer.µ_kernel.dtype, "float32")
+    np.testing.assert_array_equal(layer.σ_kernel.dtype, "float32")
+
 
 @pytest.mark.usefixtures("maybe_run_functions_eagerly")
-def test_noisy_dense_regularization(self):
-  layer = NoisyDense(
-      3,
-      kernel_regularizer=keras.regularizers.l1(0.01),
-      bias_regularizer='l1',
-      activity_regularizer='l2',
-      name='noisy_dense_reg')
-  layer(keras.backend.variable(np.ones((2, 4))))
-  assert_equal(3, len(layer.losses))
+def test_noisy_dense_regularization():
+    layer = NoisyDense(
+        3,
+        kernel_regularizer=keras.regularizers.l1(0.01),
+        bias_regularizer="l1",
+        activity_regularizer="l2",
+        name="noisy_dense_reg",
+    )
+    layer(keras.backend.variable(np.ones((2, 4))))
+    np.testing.assert_array_equal(5, len(layer.losses))
+
 
 @pytest.mark.usefixtures("maybe_run_functions_eagerly")
-def test_noisy_dense_constraints(self):
-  k_constraint = keras.constraints.max_norm(0.01)
-  b_constraint = keras.constraints.max_norm(0.01)
-  layer = NoisyDense(
-      3, kernel_constraint=k_constraint, bias_constraint=b_constraint)
-  layer(keras.backend.variable(np.ones((2, 4))))
-  assert_equal(layer.kernel.constraint, k_constraint)
-  assert_equal(layer.bias.constraint, b_constraint)
+def test_noisy_dense_constraints():
+    k_constraint = keras.constraints.max_norm(0.01)
+    b_constraint = keras.constraints.max_norm(0.01)
+    layer = NoisyDense(3, kernel_constraint=k_constraint, bias_constraint=b_constraint)
+    layer(keras.backend.variable(np.ones((2, 4))))
+    np.testing.assert_array_equal(layer.µ_kernel.constraint, k_constraint)
+    np.testing.assert_array_equal(layer.σ_kernel.constraint, k_constraint)
+    np.testing.assert_array_equal(layer.µ_bias.constraint, b_constraint)
+    np.testing.assert_array_equal(layer.σ_bias.constraint, b_constraint)


### PR DESCRIPTION
# Description

This PR adds support for noisy dense layers. Noisy dense layers are like dense layers but random noise is injected to help agents explore in reinforcement learning environments. This is very commonly used in Deep Q Learning and was first introduced by DeepMind in their [Noisy Networks for Exploration](https://arxiv.org/pdf/1706.10295.pdf) paper in 2017.
Fixes: [#2127](https://github.com/tensorflow/addons/issues/2127)

## Type of change

- [ ] Bug fix
- [ ] New Tutorial
- [ ] Updated or additional documentation
- [ ] Additional Testing
- [ ] New Activation and the changes conform to the [activation contribution guidelines](https://github.com/tensorflow/addons/blob/master/tensorflow_addons/activations/README.md#contribution-guidelines)
- [ ] New Callback and the changes conform to the [callback contribution guidelines](https://github.com/tensorflow/addons/blob/master/tensorflow_addons/callbacks/README.md#contribution-guidelines)
- [ ] New Image addition and the changes conform to the [image op contribution guidelines](https://github.com/tensorflow/addons/blob/master/tensorflow_addons/image/README.md#contribution-guidelines)
- [x] New Layer and the changes conform to the [layer contribution guidelines](https://github.com/tensorflow/addons/blob/master/tensorflow_addons/layers/README.md#contribution-guidelines)
- [ ] New Loss and the changes conform to the [loss contribution guidelines](https://github.com/tensorflow/addons/blob/master/tensorflow_addons/losses/README.md#contribution-guidelines)
- [ ] New Metric and the changes conform to the [metric contribution guidelines](https://github.com/tensorflow/addons/blob/master/tensorflow_addons/metrics/README.md#contribution-guidelines)
- [ ] New Optimizer and the changes conform to the [optimizer contribution guidelines](https://github.com/tensorflow/addons/blob/master/tensorflow_addons/optimizers/README.md#contribution-guidelines)
- [ ] New RNN Cell and the changes conform to the [rnn contribution guidelines](https://github.com/tensorflow/addons/blob/master/tensorflow_addons/rnn/README.md#contribution-guidelines)
- [ ] New Seq2seq addition and the changes conform to the [seq2seq contribution guidelines](https://github.com/tensorflow/addons/blob/master/tensorflow_addons/seq2seq/README.md#contribution-guidelines)
- [ ] New Text addition and the changes conform to the [text op contribution guidelines](https://github.com/tensorflow/addons/blob/master/tensorflow_addons/text/README.md#contribution-guidelines)

# Checklist:

- [x] I've properly [formatted my code according to the guidelines](https://github.com/tensorflow/addons/blob/master/CONTRIBUTING.md#coding-style)
    - [x] By running Black + Flake8
    - [ ] By running pre-commit hooks
- [x] This PR addresses an already submitted issue for TensorFlow Addons
- [ ] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] This PR contains modifications to C++ custom-ops

# How Has This Been Tested?

I used PyTest to test the code and trained it on some reinforcement learning environments from the [gym](https://github.com/openai/gym) toolkit and compared my results to the results on the [Noisy Networks for Exploration](https://arxiv.org/pdf/1706.10295.pdf) paper.