### PR TITLE
Added extra requirements for tensorflow, tensorflow-gpu, and tensorflow-cpu

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,6 +68,15 @@ we can only guarantee compatibility with the TensorFlow versions which it was te
 Warnings will be emitted when importing `tensorflow_addons` if your TensorFlow version does not match 
 what it was tested against.
 
+To ensure you install a compatible version of `tensorflow_addons` for your existing version of
+TensorFlow, you can install with the `tensorflow` extra requirement:
+
+```
+pip install tensorflow-addons[tensorflow]
+```
+
+Similar extras exist for `tensorflow-gpu` and `tensorflow-cpu`.
+
 #### Python Op Compatibility Matrix
 | TensorFlow Addons | TensorFlow | Python  |
 |:----------------------- |:---|:---------- |

--- a/README.md
+++ b/README.md
@@ -52,6 +52,15 @@ run the following:
 ```
 pip install tensorflow-addons
 ```
+
+To ensure you have a version of TensorFlow that is compatible with TensorFlow Addons, 
+you can specify the `tensorflow` extra requirement during install:
+
+```
+pip install tensorflow-addons[tensorflow]
+```
+
+Similar extras exist for the `tensorflow-gpu` and `tensorflow-cpu` packages.
  
 
 To use TensorFlow Addons:
@@ -67,15 +76,6 @@ However, there are still a few private API uses within the repository so at the 
 we can only guarantee compatibility with the TensorFlow versions which it was tested against. 
 Warnings will be emitted when importing `tensorflow_addons` if your TensorFlow version does not match 
 what it was tested against.
-
-To ensure you install a compatible version of `tensorflow_addons` for your existing version of
-TensorFlow, you can install with the `tensorflow` extra requirement:
-
-```
-pip install tensorflow-addons[tensorflow]
-```
-
-Similar extras exist for `tensorflow-gpu` and `tensorflow-cpu`.
 
 #### Python Op Compatibility Matrix
 | TensorFlow Addons | TensorFlow | Python  |

--- a/setup.py
+++ b/setup.py
@@ -76,6 +76,8 @@ class BinaryDistribution(Distribution):
 
 
 project_name, version = get_project_name_version()
+min_tf_version = version["MIN_TF_VERSION"]
+max_tf_version = version["MAX_TF_VERSION"]
 setup(
     name=project_name,
     version=version["__version__"],
@@ -86,6 +88,11 @@ setup(
     packages=find_packages(),
     ext_modules=get_ext_modules(),
     install_requires=Path("requirements.txt").read_text().splitlines(),
+    extras_require={
+        "tensorflow": [f"tensorflow>={min_tf_version},<{max_tf_version}"],
+        "tensorflow-gpu": [f"tensorflow-gpu>={min_tf_version},<{max_tf_version}"],
+        "tensorflow-cpu": [f"tensorflow-cpu>={min_tf_version},<{max_tf_version}"],
+    },
     include_package_data=True,
     zip_safe=False,
     distclass=BinaryDistribution,

--- a/setup.py
+++ b/setup.py
@@ -89,9 +89,13 @@ setup(
     ext_modules=get_ext_modules(),
     install_requires=Path("requirements.txt").read_text().splitlines(),
     extras_require={
-        "tensorflow": [f"tensorflow>={min_tf_version},<{max_tf_version}"],
-        "tensorflow-gpu": [f"tensorflow-gpu>={min_tf_version},<{max_tf_version}"],
-        "tensorflow-cpu": [f"tensorflow-cpu>={min_tf_version},<{max_tf_version}"],
+        "tensorflow": ["tensorflow>={},<{}".format(min_tf_version, max_tf_version)],
+        "tensorflow-gpu": [
+            "tensorflow-gpu>={},<{}".format(min_tf_version, max_tf_version)
+        ],
+        "tensorflow-cpu": [
+            "tensorflow-cpu>={},<{}".format(min_tf_version, max_tf_version)
+        ],
     },
     include_package_data=True,
     zip_safe=False,

--- a/tensorflow_addons/utils/ensure_tf_install.py
+++ b/tensorflow_addons/utils/ensure_tf_install.py
@@ -23,8 +23,7 @@ import warnings
 
 import tensorflow as tf
 
-MIN_TF_VERSION = "2.2.0"
-MAX_TF_VERSION = "2.4.0"
+from tensorflow_addons.version import MIN_TF_VERSION, MAX_TF_VERSION
 
 
 def _check_tf_version():

--- a/tensorflow_addons/version.py
+++ b/tensorflow_addons/version.py
@@ -14,6 +14,10 @@
 # ============================================================================
 """Define TensorFlow Addons version information."""
 
+# Required TensorFlow version [min, max)
+MIN_TF_VERSION = "2.2.0"
+MAX_TF_VERSION = "2.4.0"
+
 # We follow Semantic Versioning (https://semver.org/)
 _MAJOR_VERSION = "0"
 _MINOR_VERSION = "12"


### PR DESCRIPTION
# Description

Brief Description of the PR:

This restores the functionality removed by #974 but makes it optional, so users can get the behavior when installing:

```
pip install tensorflow_addons[tensorflow]
```

Fixes #2111

## Type of change

Install script enhancement.

# Checklist:

- [X] I've properly [formatted my code according to the guidelines](https://github.com/tensorflow/addons/blob/master/CONTRIBUTING.md#coding-style)
    - [X] By running Black + Flake8
    - [X] By running pre-commit hooks
- [X] This PR addresses an already submitted issue for TensorFlow Addons
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] This PR contains modifications to C++ custom-ops

# How Has This Been Tested?

```
pip install '.[tensorflow]'
```