### PR TITLE
fix LayerNormalization use on the right axis

### DIFF
--- a/docs/tutorials/layers_normalizations.ipynb
+++ b/docs/tutorials/layers_normalizations.ipynb
@@ -299,7 +299,7 @@
         "  tf.keras.layers.Reshape((28,28,1), input_shape=(28,28)),\n",
         "  tf.keras.layers.Conv2D(filters=10, kernel_size=(3,3),data_format=\"channels_last\"),\n",
         "  # LayerNorm Layer\n",
-        "  tf.keras.layers.LayerNormalization(axis=1 , center=True , scale=True),\n",
+        "  tf.keras.layers.LayerNormalization(axis=3 , center=True , scale=True),\n",
         "  tf.keras.layers.Flatten(),\n",
         "  tf.keras.layers.Dense(128, activation='relu'),\n",
         "  tf.keras.layers.Dropout(0.2),\n",


### PR DESCRIPTION
# Description

I assume this was wrong, right? You probably meant to apply it to the channel axis, which is the last here.

## Type of change

- [x] Bug fix
