### PR TITLE
Speedup gaussian kernel generation

### DIFF
--- a/tensorflow_addons/image/filters.py
+++ b/tensorflow_addons/image/filters.py
@@ -211,8 +211,7 @@ def _get_gaussian_kernel(sigma, filter_shape):
     sigma = tf.convert_to_tensor(sigma)
     x = tf.range(-filter_shape // 2 + 1, filter_shape // 2 + 1)
     x = tf.cast(x ** 2, sigma.dtype)
-    x = tf.exp(-x / (2.0 * (sigma ** 2)))
-    x = x / tf.math.reduce_sum(x)
+    x = tf.nn.softmax(-x / (2.0 * (sigma ** 2)))
     return x
 
 
@@ -299,10 +298,8 @@ def gaussian_filter2d(
         gaussian_kernel_2d = _get_gaussian_kernel_2d(
             gaussian_kernel_y, gaussian_kernel_x
         )
-        gaussian_kernel_2d = tf.repeat(gaussian_kernel_2d, channels)
-        gaussian_kernel_2d = tf.reshape(
-            gaussian_kernel_2d, [filter_shape[0], filter_shape[1], channels, 1]
-        )
+        gaussian_kernel_2d = gaussian_kernel_2d[:, :, tf.newaxis, tf.newaxis]
+        gaussian_kernel_2d = tf.tile(gaussian_kernel_2d, [1, 1, channels, 1])
 
         image = _pad(image, filter_shape, mode=padding, constant_values=constant_values)
 

--- a/tensorflow_addons/image/filters.py
+++ b/tensorflow_addons/image/filters.py
@@ -290,10 +290,10 @@ def gaussian_filter2d(
 
         sigma = tf.cast(sigma, image.dtype)
         gaussian_kernel_x = _get_gaussian_kernel(sigma[1], filter_shape[1])
-        gaussian_kernel_x = tf.reshape(gaussian_kernel_x, [1, filter_shape[1]])
+        gaussian_kernel_x = gaussian_kernel_x[tf.newaxis, :]
 
         gaussian_kernel_y = _get_gaussian_kernel(sigma[0], filter_shape[0])
-        gaussian_kernel_y = tf.reshape(gaussian_kernel_y, [filter_shape[0], 1])
+        gaussian_kernel_y = gaussian_kernel_y[:, tf.newaxis]
 
         gaussian_kernel_2d = _get_gaussian_kernel_2d(
             gaussian_kernel_y, gaussian_kernel_x


### PR DESCRIPTION
# Description

Speedup Gaussian kernel generation. It doesn't really matter (cause `depthwise_conv2d` dominate the computation time), but might be helpful for anyone who is looking for standalone gaussian kernel function. Also switch to `softmax` offers numeric stability.

https://colab.research.google.com/drive/1UTA00ZD6Iq4RSgPpWgNBauyNbgTTk8Xj?usp=sharing

## Type of change

- [ ] Bug fix
- [ ] New Tutorial
- [ ] Updated or additional documentation
- [ ] Additional Testing
- [ ] New Activation and the changes conform to the [activation contribution guidelines](https://github.com/tensorflow/addons/blob/master/tensorflow_addons/activations/README.md#contribution-guidelines)
- [ ] New Callback and the changes conform to the [callback contribution guidelines](https://github.com/tensorflow/addons/blob/master/tensorflow_addons/callbacks/README.md#contribution-guidelines)
- [ ] New Image addition and the changes conform to the [image op contribution guidelines](https://github.com/tensorflow/addons/blob/master/tensorflow_addons/image/README.md#contribution-guidelines)
- [ ] New Layer and the changes conform to the [layer contribution guidelines](https://github.com/tensorflow/addons/blob/master/tensorflow_addons/layers/README.md#contribution-guidelines)
- [ ] New Loss and the changes conform to the [loss contribution guidelines](https://github.com/tensorflow/addons/blob/master/tensorflow_addons/losses/README.md#contribution-guidelines)
- [ ] New Metric and the changes conform to the [metric contribution guidelines](https://github.com/tensorflow/addons/blob/master/tensorflow_addons/metrics/README.md#contribution-guidelines)
- [ ] New Optimizer and the changes conform to the [optimizer contribution guidelines](https://github.com/tensorflow/addons/blob/master/tensorflow_addons/optimizers/README.md#contribution-guidelines)
- [ ] New RNN Cell and the changes conform to the [rnn contribution guidelines](https://github.com/tensorflow/addons/blob/master/tensorflow_addons/rnn/README.md#contribution-guidelines)
- [ ] New Seq2seq addition and the changes conform to the [seq2seq contribution guidelines](https://github.com/tensorflow/addons/blob/master/tensorflow_addons/seq2seq/README.md#contribution-guidelines)
- [ ] New Text addition and the changes conform to the [text op contribution guidelines](https://github.com/tensorflow/addons/blob/master/tensorflow_addons/text/README.md#contribution-guidelines)

# Checklist:

- [x] I've properly [formatted my code according to the guidelines](https://github.com/tensorflow/addons/blob/master/CONTRIBUTING.md#coding-style)
    - [ ] By running Black + Flake8
    - [ ] By running pre-commit hooks
- [ ] This PR addresses an already submitted issue for TensorFlow Addons
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] This PR contains modifications to C++ custom-ops

# How Has This Been Tested?

Underlying implementation changes.