### PR TITLE
nbfmt tutorial notebooks

### DIFF
--- a/docs/tutorials/_template.ipynb
+++ b/docs/tutorials/_template.ipynb
@@ -3,7 +3,6 @@
     {
       "cell_type": "markdown",
       "metadata": {
-        "colab_type": "text",
         "id": "Tce3stUlHN0L"
       },
       "source": [
@@ -15,8 +14,6 @@
       "execution_count": null,
       "metadata": {
         "cellView": "form",
-        "colab": {},
-        "colab_type": "code",
         "id": "tuOe1ymfHZPu"
       },
       "outputs": [],
@@ -37,7 +34,6 @@
     {
       "cell_type": "markdown",
       "metadata": {
-        "colab_type": "text",
         "id": "qFdPvlXBOdUN"
       },
       "source": [
@@ -47,7 +43,6 @@
     {
       "cell_type": "markdown",
       "metadata": {
-        "colab_type": "text",
         "id": "MfBg1C5NB3X0"
       },
       "source": [
@@ -70,7 +65,6 @@
     {
       "cell_type": "markdown",
       "metadata": {
-        "colab_type": "text",
         "id": "r6P32iYYV27b"
       },
       "source": [
@@ -80,7 +74,6 @@
     {
       "cell_type": "markdown",
       "metadata": {
-        "colab_type": "text",
         "id": "xHxb-dlhMIzW"
       },
       "source": [
@@ -92,7 +85,6 @@
     {
       "cell_type": "markdown",
       "metadata": {
-        "colab_type": "text",
         "id": "MUXex9ctTuDB"
       },
       "source": [
@@ -102,7 +94,6 @@
     {
       "cell_type": "markdown",
       "metadata": {
-        "colab_type": "text",
         "id": "1Eh-iCRVBm0p"
       },
       "source": [
@@ -112,7 +103,9 @@
     {
       "cell_type": "code",
       "execution_count": null,
-      "metadata": {},
+      "metadata": {
+        "id": "rEk-ibQkDNtF"
+      },
       "outputs": [],
       "source": [
         "!pip install -U tensorflow-addons"
@@ -122,8 +115,6 @@
       "cell_type": "code",
       "execution_count": null,
       "metadata": {
-        "colab": {},
-        "colab_type": "code",
         "id": "IqR2PQG4ZaZ0"
       },
       "outputs": [],
@@ -135,7 +126,6 @@
     {
       "cell_type": "markdown",
       "metadata": {
-        "colab_type": "text",
         "id": "UhNtHfuxCGVy"
       },
       "source": [
@@ -149,7 +139,6 @@
     {
       "cell_type": "markdown",
       "metadata": {
-        "colab_type": "text",
         "id": "2V22fKegUtF9"
       },
       "source": [
@@ -169,7 +158,6 @@
     {
       "cell_type": "markdown",
       "metadata": {
-        "colab_type": "text",
         "id": "QKp40qS-DGEZ"
       },
       "source": [
@@ -184,8 +172,6 @@
       "cell_type": "code",
       "execution_count": null,
       "metadata": {
-        "colab": {},
-        "colab_type": "code",
         "id": "KtylpxOmceaC"
       },
       "outputs": [],
@@ -200,7 +186,6 @@
     {
       "cell_type": "markdown",
       "metadata": {
-        "colab_type": "text",
         "id": "pwdM2pl3RSPb"
       },
       "source": [
@@ -211,8 +196,6 @@
       "cell_type": "code",
       "execution_count": null,
       "metadata": {
-        "colab": {},
-        "colab_type": "code",
         "id": "mMOeXVmbdilM"
       },
       "outputs": [],
@@ -230,7 +213,6 @@
     {
       "cell_type": "markdown",
       "metadata": {
-        "colab_type": "text",
         "id": "uabQmjMtRtzs"
       },
       "source": [
@@ -241,8 +223,6 @@
       "cell_type": "code",
       "execution_count": null,
       "metadata": {
-        "colab": {},
-        "colab_type": "code",
         "id": "U82B_tH2d294"
       },
       "outputs": [],
@@ -254,7 +234,6 @@
     {
       "cell_type": "markdown",
       "metadata": {
-        "colab_type": "text",
         "id": "TJdqBNBbS78n"
       },
       "source": [
@@ -271,7 +250,6 @@
     {
       "cell_type": "markdown",
       "metadata": {
-        "colab_type": "text",
         "id": "78HBT9cQXJko"
       },
       "source": [
@@ -286,7 +264,6 @@
     {
       "cell_type": "markdown",
       "metadata": {
-        "colab_type": "text",
         "id": "YrsKXcPRUvK9"
       },
       "source": [
@@ -307,8 +284,6 @@
         "Tce3stUlHN0L"
       ],
       "name": "_template.ipynb",
-      "private_outputs": true,
-      "provenance": [],
       "toc_visible": true
     },
     "kernelspec": {

--- a/docs/tutorials/average_optimizers_callback.ipynb
+++ b/docs/tutorials/average_optimizers_callback.ipynb
@@ -3,7 +3,6 @@
     {
       "cell_type": "markdown",
       "metadata": {
-        "colab_type": "text",
         "id": "Tce3stUlHN0L"
       },
       "source": [
@@ -15,8 +14,6 @@
       "execution_count": null,
       "metadata": {
         "cellView": "form",
-        "colab": {},
-        "colab_type": "code",
         "id": "tuOe1ymfHZPu"
       },
       "outputs": [],
@@ -37,7 +34,6 @@
     {
       "cell_type": "markdown",
       "metadata": {
-        "colab_type": "text",
         "id": "MfBg1C5NB3X0"
       },
       "source": [
@@ -62,7 +58,6 @@
     {
       "cell_type": "markdown",
       "metadata": {
-        "colab_type": "text",
         "id": "xHxb-dlhMIzW"
       },
       "source": [
@@ -74,7 +69,6 @@
     {
       "cell_type": "markdown",
       "metadata": {
-        "colab_type": "text",
         "id": "o2UNySlpXkbl"
       },
       "source": [
@@ -96,7 +90,6 @@
     {
       "cell_type": "markdown",
       "metadata": {
-        "colab_type": "text",
         "id": "MUXex9ctTuDB"
       },
       "source": [
@@ -107,7 +100,7 @@
       "cell_type": "code",
       "execution_count": null,
       "metadata": {
-        "scrolled": true
+        "id": "sXEOqj5cIgyW"
       },
       "outputs": [],
       "source": [
@@ -118,13 +111,7 @@
       "cell_type": "code",
       "execution_count": null,
       "metadata": {
-        "colab": {
-          "base_uri": "https://localhost:8080/",
-          "height": 35
-        },
-        "colab_type": "code",
-        "id": "IqR2PQG4ZaZ0",
-        "outputId": "49c5f5be-4b1a-4298-e218-5c6c0126b4ff"
+        "id": "IqR2PQG4ZaZ0"
       },
       "outputs": [],
       "source": [
@@ -136,8 +123,6 @@
       "cell_type": "code",
       "execution_count": null,
       "metadata": {
-        "colab": {},
-        "colab_type": "code",
         "id": "4hnJ2rDpI38-"
       },
       "outputs": [],
@@ -149,7 +134,6 @@
     {
       "cell_type": "markdown",
       "metadata": {
-        "colab_type": "text",
         "id": "Iox_HZNNYLEB"
       },
       "source": [
@@ -160,8 +144,6 @@
       "cell_type": "code",
       "execution_count": null,
       "metadata": {
-        "colab": {},
-        "colab_type": "code",
         "id": "KtylpxOmceaC"
       },
       "outputs": [],
@@ -184,7 +166,6 @@
     {
       "cell_type": "markdown",
       "metadata": {
-        "colab_type": "text",
         "id": "pwdM2pl3RSPb"
       },
       "source": [
@@ -195,8 +176,6 @@
       "cell_type": "code",
       "execution_count": null,
       "metadata": {
-        "colab": {},
-        "colab_type": "code",
         "id": "mMOeXVmbdilM"
       },
       "outputs": [],
@@ -217,7 +196,6 @@
     {
       "cell_type": "markdown",
       "metadata": {
-        "colab_type": "text",
         "id": "iEbhI_eajpJe"
       },
       "source": [
@@ -234,8 +212,6 @@
       "cell_type": "code",
       "execution_count": null,
       "metadata": {
-        "colab": {},
-        "colab_type": "code",
         "id": "_Q76K1fNk7Va"
       },
       "outputs": [],
@@ -249,7 +225,6 @@
     {
       "cell_type": "markdown",
       "metadata": {
-        "colab_type": "text",
         "id": "nXlMX4p9qHwg"
       },
       "source": [
@@ -260,8 +235,6 @@
       "cell_type": "code",
       "execution_count": null,
       "metadata": {
-        "colab": {},
-        "colab_type": "code",
         "id": "SnvZjt34qEHY"
       },
       "outputs": [],
@@ -280,7 +253,6 @@
     {
       "cell_type": "markdown",
       "metadata": {
-        "colab_type": "text",
         "id": "uabQmjMtRtzs"
       },
       "source": [
@@ -290,7 +262,6 @@
     {
       "cell_type": "markdown",
       "metadata": {
-        "colab_type": "text",
         "id": "SPmifETHmPix"
       },
       "source": [
@@ -301,13 +272,7 @@
       "cell_type": "code",
       "execution_count": null,
       "metadata": {
-        "colab": {
-          "base_uri": "https://localhost:8080/",
-          "height": 421
-        },
-        "colab_type": "code",
-        "id": "Xy8W4LYppadJ",
-        "outputId": "97bfbf95-d9e7-4c69-99e2-d233e8f54d5a"
+        "id": "Xy8W4LYppadJ"
       },
       "outputs": [],
       "source": [
@@ -322,13 +287,7 @@
       "cell_type": "code",
       "execution_count": null,
       "metadata": {
-        "colab": {
-          "base_uri": "https://localhost:8080/",
-          "height": 72
-        },
-        "colab_type": "code",
-        "id": "uU2iQ6HAZ6-E",
-        "outputId": "ec4ae0ad-dd99-4966-d448-270fae1fd0d3"
+        "id": "uU2iQ6HAZ6-E"
       },
       "outputs": [],
       "source": [
@@ -342,7 +301,6 @@
     {
       "cell_type": "markdown",
       "metadata": {
-        "colab_type": "text",
         "id": "lAvhD4unmc6W"
       },
       "source": [
@@ -353,13 +311,7 @@
       "cell_type": "code",
       "execution_count": null,
       "metadata": {
-        "colab": {
-          "base_uri": "https://localhost:8080/",
-          "height": 404
-        },
-        "colab_type": "code",
-        "id": "--NIjBp-mhVb",
-        "outputId": "51510f00-c0cc-4443-cef3-0b1c263e1600"
+        "id": "--NIjBp-mhVb"
       },
       "outputs": [],
       "source": [
@@ -374,13 +326,7 @@
       "cell_type": "code",
       "execution_count": null,
       "metadata": {
-        "colab": {
-          "base_uri": "https://localhost:8080/",
-          "height": 72
-        },
-        "colab_type": "code",
-        "id": "zRAym9EBmnW9",
-        "outputId": "ac7dc6d6-c5c6-456f-af8e-a11a211ef357"
+        "id": "zRAym9EBmnW9"
       },
       "outputs": [],
       "source": [
@@ -394,7 +340,6 @@
     {
       "cell_type": "markdown",
       "metadata": {
-        "colab_type": "text",
         "id": "K98lbU07m_Bk"
       },
       "source": [
@@ -405,13 +350,7 @@
       "cell_type": "code",
       "execution_count": null,
       "metadata": {
-        "colab": {
-          "base_uri": "https://localhost:8080/",
-          "height": 329
-        },
-        "colab_type": "code",
-        "id": "Ia7ALKefnXWQ",
-        "outputId": "ecf67a66-baf3-43df-ff9c-da14bc6148fa"
+        "id": "Ia7ALKefnXWQ"
       },
       "outputs": [],
       "source": [
@@ -426,13 +365,7 @@
       "cell_type": "code",
       "execution_count": null,
       "metadata": {
-        "colab": {
-          "base_uri": "https://localhost:8080/",
-          "height": 72
-        },
-        "colab_type": "code",
-        "id": "EOT2E9NBoeHI",
-        "outputId": "4117451c-1886-4980-b40e-68591912559e"
+        "id": "EOT2E9NBoeHI"
       },
       "outputs": [],
       "source": [
@@ -450,13 +383,10 @@
         "Tce3stUlHN0L"
       ],
       "name": "average_optimizers_callback.ipynb",
-      "private_outputs": true,
-      "provenance": [],
       "toc_visible": true
     },
     "kernelspec": {
       "display_name": "Python 3",
-      "language": "python",
       "name": "python3"
     }
   },

--- a/docs/tutorials/image_ops.ipynb
+++ b/docs/tutorials/image_ops.ipynb
@@ -3,7 +3,6 @@
     {
       "cell_type": "markdown",
       "metadata": {
-        "colab_type": "text",
         "id": "GWEKvPCCxJke"
       },
       "source": [
@@ -15,8 +14,6 @@
       "execution_count": null,
       "metadata": {
         "cellView": "form",
-        "colab": {},
-        "colab_type": "code",
         "id": "l-m8KQ-nxK5l"
       },
       "outputs": [],
@@ -37,7 +34,6 @@
     {
       "cell_type": "markdown",
       "metadata": {
-        "colab_type": "text",
         "id": "O8FuVCLYxi_l"
       },
       "source": [
@@ -62,7 +58,6 @@
     {
       "cell_type": "markdown",
       "metadata": {
-        "colab_type": "text",
         "id": "2a5ksOt-xsOl"
       },
       "source": [
@@ -89,7 +84,6 @@
     {
       "cell_type": "markdown",
       "metadata": {
-        "colab_type": "text",
         "id": "DMbjxr4PyMPF"
       },
       "source": [
@@ -99,7 +93,9 @@
     {
       "cell_type": "code",
       "execution_count": null,
-      "metadata": {},
+      "metadata": {
+        "id": "o_QTX_vHGbj7"
+      },
       "outputs": [],
       "source": [
         "!pip install -U tensorflow-addons"
@@ -109,13 +105,7 @@
       "cell_type": "code",
       "execution_count": null,
       "metadata": {
-        "colab": {
-          "base_uri": "https://localhost:8080/",
-          "height": 34
-        },
-        "colab_type": "code",
-        "id": "5hVIKCrhWh4a",
-        "outputId": "365ae823-365c-4141-9d84-e4ccfb0c85c7"
+        "id": "5hVIKCrhWh4a"
       },
       "outputs": [],
       "source": [
@@ -128,7 +118,6 @@
     {
       "cell_type": "markdown",
       "metadata": {
-        "colab_type": "text",
         "id": "Q6Z2rsP8yp2v"
       },
       "source": [
@@ -138,7 +127,6 @@
     {
       "cell_type": "markdown",
       "metadata": {
-        "colab_type": "text",
         "id": "9gbgJP10z9WO"
       },
       "source": [
@@ -149,13 +137,7 @@
       "cell_type": "code",
       "execution_count": null,
       "metadata": {
-        "colab": {
-          "base_uri": "https://localhost:8080/",
-          "height": 52
-        },
-        "colab_type": "code",
-        "id": "IgUsVhBQ6dSg",
-        "outputId": "20ecbebf-6ed9-4e59-f958-c94b2921ba74"
+        "id": "IgUsVhBQ6dSg"
       },
       "outputs": [],
       "source": [
@@ -165,7 +147,6 @@
     {
       "cell_type": "markdown",
       "metadata": {
-        "colab_type": "text",
         "id": "uheQOL-y0Fj3"
       },
       "source": [
@@ -175,7 +156,6 @@
     {
       "cell_type": "markdown",
       "metadata": {
-        "colab_type": "text",
         "id": "MFGirRRZ0Y9k"
       },
       "source": [
@@ -186,13 +166,7 @@
       "cell_type": "code",
       "execution_count": null,
       "metadata": {
-        "colab": {
-          "base_uri": "https://localhost:8080/",
-          "height": 281
-        },
-        "colab_type": "code",
-        "id": "NRlvNQdm1YI8",
-        "outputId": "1922ef25-a9f8-4fb4-8f60-65402a6fd969"
+        "id": "NRlvNQdm1YI8"
       },
       "outputs": [],
       "source": [
@@ -208,7 +182,6 @@
     {
       "cell_type": "markdown",
       "metadata": {
-        "colab_type": "text",
         "id": "clXQrFVa2nN7"
       },
       "source": [
@@ -219,13 +192,7 @@
       "cell_type": "code",
       "execution_count": null,
       "metadata": {
-        "colab": {
-          "base_uri": "https://localhost:8080/",
-          "height": 281
-        },
-        "colab_type": "code",
-        "id": "tbaIkUCS2eNv",
-        "outputId": "7e2796dd-26d9-4856-fa6e-7b5a084583c5"
+        "id": "tbaIkUCS2eNv"
       },
       "outputs": [],
       "source": [
@@ -238,7 +205,6 @@
     {
       "cell_type": "markdown",
       "metadata": {
-        "colab_type": "text",
         "id": "UwqfpOm--vV2"
       },
       "source": [
@@ -248,7 +214,6 @@
     {
       "cell_type": "markdown",
       "metadata": {
-        "colab_type": "text",
         "id": "jIa5HnomPds3"
       },
       "source": [
@@ -260,13 +225,7 @@
       "cell_type": "code",
       "execution_count": null,
       "metadata": {
-        "colab": {
-          "base_uri": "https://localhost:8080/",
-          "height": 269
-        },
-        "colab_type": "code",
-        "id": "SutWnbRoHl6i",
-        "outputId": "52333d9d-788d-4c46-df94-f24456abb67f"
+        "id": "SutWnbRoHl6i"
       },
       "outputs": [],
       "source": [
@@ -277,7 +236,6 @@
     {
       "cell_type": "markdown",
       "metadata": {
-        "colab_type": "text",
         "id": "Mp6cU7I0-r2h"
       },
       "source": [
@@ -289,13 +247,7 @@
       "cell_type": "code",
       "execution_count": null,
       "metadata": {
-        "colab": {
-          "base_uri": "https://localhost:8080/",
-          "height": 269
-        },
-        "colab_type": "code",
-        "id": "9kxUES9sM8Jl",
-        "outputId": "1340b774-5fbd-4c94-ae26-a35fa3c50546"
+        "id": "9kxUES9sM8Jl"
       },
       "outputs": [],
       "source": [
@@ -306,7 +258,6 @@
     {
       "cell_type": "markdown",
       "metadata": {
-        "colab_type": "text",
         "id": "WjMdSDKlBcPh"
       },
       "source": [
@@ -318,13 +269,7 @@
       "cell_type": "code",
       "execution_count": null,
       "metadata": {
-        "colab": {
-          "base_uri": "https://localhost:8080/",
-          "height": 269
-        },
-        "colab_type": "code",
-        "id": "HTh1Qpps8Rg5",
-        "outputId": "00dd3893-ffbe-4bdd-de3c-9f037651b36b"
+        "id": "HTh1Qpps8Rg5"
       },
       "outputs": [],
       "source": [
@@ -335,7 +280,6 @@
     {
       "cell_type": "markdown",
       "metadata": {
-        "colab_type": "text",
         "id": "O79BrK-bC8oh"
       },
       "source": [
@@ -347,13 +291,7 @@
       "cell_type": "code",
       "execution_count": null,
       "metadata": {
-        "colab": {
-          "base_uri": "https://localhost:8080/",
-          "height": 269
-        },
-        "colab_type": "code",
-        "id": "zZBI-9XvBSuh",
-        "outputId": "452460e3-13ee-4eb7-ef4e-dd8a86c897eb"
+        "id": "zZBI-9XvBSuh"
       },
       "outputs": [],
       "source": [
@@ -369,7 +307,6 @@
     {
       "cell_type": "markdown",
       "metadata": {
-        "colab_type": "text",
         "id": "ruyvVnmCDBgj"
       },
       "source": [
@@ -381,13 +318,7 @@
       "cell_type": "code",
       "execution_count": null,
       "metadata": {
-        "colab": {
-          "base_uri": "https://localhost:8080/",
-          "height": 269
-        },
-        "colab_type": "code",
-        "id": "vbCdwGtYChnQ",
-        "outputId": "430b5cf5-8a0a-497b-fa77-af6792bd5bf7"
+        "id": "vbCdwGtYChnQ"
       },
       "outputs": [],
       "source": [
@@ -401,7 +332,6 @@
     {
       "cell_type": "markdown",
       "metadata": {
-        "colab_type": "text",
         "id": "fdbCDYJkG8Gv"
       },
       "source": [
@@ -413,13 +343,7 @@
       "cell_type": "code",
       "execution_count": null,
       "metadata": {
-        "colab": {
-          "base_uri": "https://localhost:8080/",
-          "height": 269
-        },
-        "colab_type": "code",
-        "id": "dG557eQDDtSK",
-        "outputId": "641b79fd-e23a-4bb5-d162-eb670b2b88d0"
+        "id": "dG557eQDDtSK"
       },
       "outputs": [],
       "source": [
@@ -435,7 +359,6 @@
     {
       "cell_type": "markdown",
       "metadata": {
-        "colab_type": "text",
         "id": "FcLMnSKYPcjA"
       },
       "source": [
@@ -448,13 +371,7 @@
       "cell_type": "code",
       "execution_count": null,
       "metadata": {
-        "colab": {
-          "base_uri": "https://localhost:8080/",
-          "height": 269
-        },
-        "colab_type": "code",
-        "id": "-OMh6oeRQaYQ",
-        "outputId": "4f7e9aca-ed78-4e4d-8c06-6833ec899797"
+        "id": "-OMh6oeRQaYQ"
       },
       "outputs": [],
       "source": [
@@ -472,8 +389,6 @@
     "colab": {
       "collapsed_sections": [],
       "name": "image_ops.ipynb",
-      "private_outputs": true,
-      "provenance": [],
       "toc_visible": true
     },
     "kernelspec": {

--- a/docs/tutorials/layers_normalizations.ipynb
+++ b/docs/tutorials/layers_normalizations.ipynb
@@ -3,7 +3,6 @@
     {
       "cell_type": "markdown",
       "metadata": {
-        "colab_type": "text",
         "id": "wFPyjGqMQ82Q"
       },
       "source": [
@@ -15,8 +14,6 @@
       "execution_count": null,
       "metadata": {
         "cellView": "form",
-        "colab": {},
-        "colab_type": "code",
         "id": "aNZ7aEDyQIYU"
       },
       "outputs": [],
@@ -37,7 +34,6 @@
     {
       "cell_type": "markdown",
       "metadata": {
-        "colab_type": "text",
         "id": "uMOmzhPEQh7b"
       },
       "source": [
@@ -62,7 +58,6 @@
     {
       "cell_type": "markdown",
       "metadata": {
-        "colab_type": "text",
         "id": "cthm5dovQMJl"
       },
       "source": [
@@ -105,7 +100,6 @@
     {
       "cell_type": "markdown",
       "metadata": {
-        "colab_type": "text",
         "id": "I2XlcXf5WBHb"
       },
       "source": [
@@ -115,7 +109,6 @@
     {
       "cell_type": "markdown",
       "metadata": {
-        "colab_type": "text",
         "id": "kTlbneoEUKrD"
       },
       "source": [
@@ -125,7 +118,9 @@
     {
       "cell_type": "code",
       "execution_count": null,
-      "metadata": {},
+      "metadata": {
+        "id": "_ZQGY_ALnirQ"
+      },
       "outputs": [],
       "source": [
         "!pip install -U tensorflow-addons"
@@ -135,8 +130,6 @@
       "cell_type": "code",
       "execution_count": null,
       "metadata": {
-        "colab": {},
-        "colab_type": "code",
         "id": "7aGgPZG_WBHg"
       },
       "outputs": [],
@@ -148,7 +141,6 @@
     {
       "cell_type": "markdown",
       "metadata": {
-        "colab_type": "text",
         "id": "u82Gz_gOUPDZ"
       },
       "source": [
@@ -159,8 +151,6 @@
       "cell_type": "code",
       "execution_count": null,
       "metadata": {
-        "colab": {},
-        "colab_type": "code",
         "id": "3wso9oidUZZQ"
       },
       "outputs": [],
@@ -174,7 +164,6 @@
     {
       "cell_type": "markdown",
       "metadata": {
-        "colab_type": "text",
         "id": "UTQH56j89POZ"
       },
       "source": [
@@ -193,8 +182,6 @@
       "cell_type": "code",
       "execution_count": null,
       "metadata": {
-        "colab": {},
-        "colab_type": "code",
         "id": "aIGjLwYWAm0v"
       },
       "outputs": [],
@@ -220,7 +207,6 @@
     {
       "cell_type": "markdown",
       "metadata": {
-        "colab_type": "text",
         "id": "QMwUfJUib3ka"
       },
       "source": [
@@ -238,8 +224,6 @@
       "cell_type": "code",
       "execution_count": null,
       "metadata": {
-        "colab": {},
-        "colab_type": "code",
         "id": "6sLVv-C8f6Kf"
       },
       "outputs": [],
@@ -269,7 +253,6 @@
     {
       "cell_type": "markdown",
       "metadata": {
-        "colab_type": "text",
         "id": "qYdnEocRUCll"
       },
       "source": [
@@ -288,8 +271,6 @@
       "cell_type": "code",
       "execution_count": null,
       "metadata": {
-        "colab": {},
-        "colab_type": "code",
         "id": "Fh-Pp_e5UB54"
       },
       "outputs": [],
@@ -315,7 +296,6 @@
     {
       "cell_type": "markdown",
       "metadata": {
-        "colab_type": "text",
         "id": "shvGfnB0WpQQ"
       },
       "source": [
@@ -334,8 +314,6 @@
     "colab": {
       "collapsed_sections": [],
       "name": "layers_normalizations.ipynb",
-      "private_outputs": true,
-      "provenance": [],
       "toc_visible": true
     },
     "kernelspec": {

--- a/docs/tutorials/layers_weightnormalization.ipynb
+++ b/docs/tutorials/layers_weightnormalization.ipynb
@@ -3,7 +3,6 @@
     {
       "cell_type": "markdown",
       "metadata": {
-        "colab_type": "text",
         "id": "Tce3stUlHN0L"
       },
       "source": [
@@ -15,8 +14,6 @@
       "execution_count": null,
       "metadata": {
         "cellView": "form",
-        "colab": {},
-        "colab_type": "code",
         "id": "tuOe1ymfHZPu"
       },
       "outputs": [],
@@ -37,7 +34,6 @@
     {
       "cell_type": "markdown",
       "metadata": {
-        "colab_type": "text",
         "id": "MfBg1C5NB3X0"
       },
       "source": [
@@ -62,7 +58,6 @@
     {
       "cell_type": "markdown",
       "metadata": {
-        "colab_type": "text",
         "id": "xHxb-dlhMIzW"
       },
       "source": [
@@ -74,7 +69,6 @@
     {
       "cell_type": "markdown",
       "metadata": {
-        "colab_type": "text",
         "id": "KR01t9v_fxbT"
       },
       "source": [
@@ -94,7 +88,6 @@
     {
       "cell_type": "markdown",
       "metadata": {
-        "colab_type": "text",
         "id": "MUXex9ctTuDB"
       },
       "source": [
@@ -104,7 +97,9 @@
     {
       "cell_type": "code",
       "execution_count": null,
-      "metadata": {},
+      "metadata": {
+        "id": "CyWHXw9mQ6mp"
+      },
       "outputs": [],
       "source": [
         "!pip install -U tensorflow-addons"
@@ -114,8 +109,6 @@
       "cell_type": "code",
       "execution_count": null,
       "metadata": {
-        "colab": {},
-        "colab_type": "code",
         "id": "OywLbs7EXiE_"
       },
       "outputs": [],
@@ -128,8 +121,6 @@
       "cell_type": "code",
       "execution_count": null,
       "metadata": {
-        "colab": {},
-        "colab_type": "code",
         "id": "KQMhhq1qXiFF"
       },
       "outputs": [],
@@ -142,8 +133,6 @@
       "cell_type": "code",
       "execution_count": null,
       "metadata": {
-        "colab": {},
-        "colab_type": "code",
         "id": "ULWHqMAnTVZD"
       },
       "outputs": [],
@@ -157,7 +146,6 @@
     {
       "cell_type": "markdown",
       "metadata": {
-        "colab_type": "text",
         "id": "fhM0ieDpSnKh"
       },
       "source": [
@@ -168,8 +156,6 @@
       "cell_type": "code",
       "execution_count": null,
       "metadata": {
-        "colab": {},
-        "colab_type": "code",
         "id": "7XZXnBYgRPSk"
       },
       "outputs": [],
@@ -191,8 +177,6 @@
       "cell_type": "code",
       "execution_count": null,
       "metadata": {
-        "colab": {},
-        "colab_type": "code",
         "id": "UZd6V90eR4Gm"
       },
       "outputs": [],
@@ -213,7 +197,6 @@
     {
       "cell_type": "markdown",
       "metadata": {
-        "colab_type": "text",
         "id": "AA5dti8AS2Y7"
       },
       "source": [
@@ -224,8 +207,6 @@
       "cell_type": "code",
       "execution_count": null,
       "metadata": {
-        "colab": {},
-        "colab_type": "code",
         "id": "L8Isjc7W8MEn"
       },
       "outputs": [],
@@ -245,7 +226,6 @@
     {
       "cell_type": "markdown",
       "metadata": {
-        "colab_type": "text",
         "id": "cH1CG9E7S34C"
       },
       "source": [
@@ -256,8 +236,6 @@
       "cell_type": "code",
       "execution_count": null,
       "metadata": {
-        "colab": {},
-        "colab_type": "code",
         "id": "EvNKxfaI7vSm"
       },
       "outputs": [],
@@ -277,8 +255,6 @@
       "cell_type": "code",
       "execution_count": null,
       "metadata": {
-        "colab": {},
-        "colab_type": "code",
         "id": "esmMh-5g7wmp"
       },
       "outputs": [],
@@ -298,8 +274,6 @@
       "cell_type": "code",
       "execution_count": null,
       "metadata": {
-        "colab": {},
-        "colab_type": "code",
         "id": "yujf2YRbwX55"
       },
       "outputs": [],
@@ -325,8 +299,6 @@
     "colab": {
       "collapsed_sections": [],
       "name": "layers_weightnormalization.ipynb",
-      "private_outputs": true,
-      "provenance": [],
       "toc_visible": true
     },
     "kernelspec": {

--- a/docs/tutorials/losses_triplet.ipynb
+++ b/docs/tutorials/losses_triplet.ipynb
@@ -3,7 +3,6 @@
     {
       "cell_type": "markdown",
       "metadata": {
-        "colab_type": "text",
         "id": "Tce3stUlHN0L"
       },
       "source": [
@@ -15,8 +14,6 @@
       "execution_count": null,
       "metadata": {
         "cellView": "form",
-        "colab": {},
-        "colab_type": "code",
         "id": "tuOe1ymfHZPu"
       },
       "outputs": [],
@@ -37,7 +34,6 @@
     {
       "cell_type": "markdown",
       "metadata": {
-        "colab_type": "text",
         "id": "MfBg1C5NB3X0"
       },
       "source": [
@@ -62,7 +58,6 @@
     {
       "cell_type": "markdown",
       "metadata": {
-        "colab_type": "text",
         "id": "xHxb-dlhMIzW"
       },
       "source": [
@@ -77,7 +72,6 @@
     {
       "cell_type": "markdown",
       "metadata": {
-        "colab_type": "text",
         "id": "bQwBbFVAyHJ_"
       },
       "source": [
@@ -96,7 +90,6 @@
     {
       "cell_type": "markdown",
       "metadata": {
-        "colab_type": "text",
         "id": "wPJ5521HZHeL"
       },
       "source": [
@@ -107,7 +100,6 @@
     {
       "cell_type": "markdown",
       "metadata": {
-        "colab_type": "text",
         "id": "MUXex9ctTuDB"
       },
       "source": [
@@ -117,7 +109,9 @@
     {
       "cell_type": "code",
       "execution_count": null,
-      "metadata": {},
+      "metadata": {
+        "id": "6Vyo25M2ba1P"
+      },
       "outputs": [],
       "source": [
         "!pip install -U tensorflow-addons"
@@ -127,8 +121,6 @@
       "cell_type": "code",
       "execution_count": null,
       "metadata": {
-        "colab": {},
-        "colab_type": "code",
         "id": "IqR2PQG4ZaZ0"
       },
       "outputs": [],
@@ -141,8 +133,6 @@
       "cell_type": "code",
       "execution_count": null,
       "metadata": {
-        "colab": {},
-        "colab_type": "code",
         "id": "WH_7-ZYZYblV"
       },
       "outputs": [],
@@ -155,7 +145,6 @@
     {
       "cell_type": "markdown",
       "metadata": {
-        "colab_type": "text",
         "id": "0_D7CZqkv_Hj"
       },
       "source": [
@@ -166,8 +155,6 @@
       "cell_type": "code",
       "execution_count": null,
       "metadata": {
-        "colab": {},
-        "colab_type": "code",
         "id": "iXvByj6wcT7d"
       },
       "outputs": [],
@@ -189,7 +176,6 @@
     {
       "cell_type": "markdown",
       "metadata": {
-        "colab_type": "text",
         "id": "KR01t9v_fxbT"
       },
       "source": [
@@ -199,7 +185,6 @@
     {
       "cell_type": "markdown",
       "metadata": {
-        "colab_type": "text",
         "id": "wvOPPuIKhLJi"
       },
       "source": [
@@ -210,8 +195,6 @@
       "cell_type": "code",
       "execution_count": null,
       "metadata": {
-        "colab": {},
-        "colab_type": "code",
         "id": "djpoAvfWNyL5"
       },
       "outputs": [],
@@ -233,7 +216,6 @@
     {
       "cell_type": "markdown",
       "metadata": {
-        "colab_type": "text",
         "id": "HYE-BxhOzFQp"
       },
       "source": [
@@ -244,8 +226,6 @@
       "cell_type": "code",
       "execution_count": null,
       "metadata": {
-        "colab": {},
-        "colab_type": "code",
         "id": "NxfYhtiSzHf-"
       },
       "outputs": [],
@@ -260,8 +240,6 @@
       "cell_type": "code",
       "execution_count": null,
       "metadata": {
-        "colab": {},
-        "colab_type": "code",
         "id": "TGBYNGxgVDrj"
       },
       "outputs": [],
@@ -276,8 +254,6 @@
       "cell_type": "code",
       "execution_count": null,
       "metadata": {
-        "colab": {},
-        "colab_type": "code",
         "id": "1Y--0tK69SXf"
       },
       "outputs": [],
@@ -290,8 +266,6 @@
       "cell_type": "code",
       "execution_count": null,
       "metadata": {
-        "colab": {},
-        "colab_type": "code",
         "id": "dqSuLdVZGNrZ"
       },
       "outputs": [],
@@ -316,7 +290,6 @@
     {
       "cell_type": "markdown",
       "metadata": {
-        "colab_type": "text",
         "id": "VAtj_m6Z_Uwe"
       },
       "source": [
@@ -326,7 +299,6 @@
     {
       "cell_type": "markdown",
       "metadata": {
-        "colab_type": "text",
         "id": "Y4rjlG9rlbVA"
       },
       "source": [
@@ -342,8 +314,6 @@
     "colab": {
       "collapsed_sections": [],
       "name": "losses_triplet.ipynb",
-      "private_outputs": true,
-      "provenance": [],
       "toc_visible": true
     },
     "kernelspec": {

--- a/docs/tutorials/networks_seq2seq_nmt.ipynb
+++ b/docs/tutorials/networks_seq2seq_nmt.ipynb
@@ -4,8 +4,6 @@
       "cell_type": "code",
       "execution_count": null,
       "metadata": {
-        "colab": {},
-        "colab_type": "code",
         "id": "f9ySOjrcc0Yp"
       },
       "outputs": [],
@@ -18,8 +16,6 @@
       "execution_count": null,
       "metadata": {
         "cellView": "form",
-        "colab": {},
-        "colab_type": "code",
         "id": "bl9GdT7h0Hxk"
       },
       "outputs": [],
@@ -40,7 +36,6 @@
     {
       "cell_type": "markdown",
       "metadata": {
-        "colab_type": "text",
         "id": "WhwgQAn50EZp"
       },
       "source": [
@@ -65,7 +60,6 @@
     {
       "cell_type": "markdown",
       "metadata": {
-        "colab_type": "text",
         "id": "ip0n8178Fuwm"
       },
       "source": [
@@ -85,7 +79,6 @@
     {
       "cell_type": "markdown",
       "metadata": {
-        "colab_type": "text",
         "id": "YNiadLKNLleD"
       },
       "source": [
@@ -95,7 +88,6 @@
     {
       "cell_type": "markdown",
       "metadata": {
-        "colab_type": "text",
         "id": "82GcQTsGf414"
       },
       "source": [
@@ -113,7 +105,9 @@
     {
       "cell_type": "code",
       "execution_count": null,
-      "metadata": {},
+      "metadata": {
+        "id": "vKBON2miJ_g1"
+      },
       "outputs": [],
       "source": [
         "!pip install -U tensorflow-addons\n",
@@ -124,8 +118,6 @@
       "cell_type": "code",
       "execution_count": null,
       "metadata": {
-        "colab": {},
-        "colab_type": "code",
         "id": "5OIlpST_6ga-"
       },
       "outputs": [],
@@ -140,13 +132,7 @@
       "cell_type": "code",
       "execution_count": null,
       "metadata": {
-        "colab": {
-          "base_uri": "https://localhost:8080/",
-          "height": 34
-        },
-        "colab_type": "code",
-        "id": "co6-YpBwL-4d",
-        "outputId": "6571961c-8f50-4333-9b1d-5eb1a157f4f8"
+        "id": "co6-YpBwL-4d"
       },
       "outputs": [],
       "source": [
@@ -177,7 +163,6 @@
     {
       "cell_type": "markdown",
       "metadata": {
-        "colab_type": "text",
         "id": "q7gjUT_9XSoj"
       },
       "source": [
@@ -190,8 +175,6 @@
       "cell_type": "code",
       "execution_count": null,
       "metadata": {
-        "colab": {},
-        "colab_type": "code",
         "id": "6ZIu-TNqKFsd"
       },
       "outputs": [],
@@ -315,7 +298,6 @@
     {
       "cell_type": "markdown",
       "metadata": {
-        "colab_type": "text",
         "id": "5nDIELt9RH-w"
       },
       "source": [
@@ -330,13 +312,7 @@
       "cell_type": "code",
       "execution_count": null,
       "metadata": {
-        "colab": {
-          "base_uri": "https://localhost:8080/",
-          "height": 119
-        },
-        "colab_type": "code",
-        "id": "GMxdlVU1X8yI",
-        "outputId": "f4977f48-dbe9-4323-ec2a-a9b0cf8b1895"
+        "id": "GMxdlVU1X8yI"
       },
       "outputs": [],
       "source": [
@@ -358,7 +334,6 @@
     {
       "cell_type": "markdown",
       "metadata": {
-        "colab_type": "text",
         "id": "Cfb66QxWYr6A"
       },
       "source": [
@@ -369,8 +344,6 @@
       "cell_type": "code",
       "execution_count": null,
       "metadata": {
-        "colab": {},
-        "colab_type": "code",
         "id": "3oq60MBPSanQ"
       },
       "outputs": [],
@@ -392,8 +365,6 @@
       "cell_type": "code",
       "execution_count": null,
       "metadata": {
-        "colab": {},
-        "colab_type": "code",
         "id": "XH5oSRNeSc1s"
       },
       "outputs": [],
@@ -406,7 +377,6 @@
     {
       "cell_type": "markdown",
       "metadata": {
-        "colab_type": "text",
         "id": "KdM37lNBGXAj"
       },
       "source": [
@@ -417,8 +387,6 @@
       "cell_type": "code",
       "execution_count": null,
       "metadata": {
-        "colab": {},
-        "colab_type": "code",
         "id": "EfiBUJM2Et6C"
       },
       "outputs": [],
@@ -436,7 +404,6 @@
     {
       "cell_type": "markdown",
       "metadata": {
-        "colab_type": "text",
         "id": "Ff_jQHLhGqJU"
       },
       "source": [
@@ -447,13 +414,7 @@
       "cell_type": "code",
       "execution_count": null,
       "metadata": {
-        "colab": {
-          "base_uri": "https://localhost:8080/",
-          "height": 51
-        },
-        "colab_type": "code",
-        "id": "b__1hPHVFALO",
-        "outputId": "88d35286-184c-44e7-a16b-5559f22e2eb1"
+        "id": "b__1hPHVFALO"
       },
       "outputs": [],
       "source": [
@@ -471,7 +432,6 @@
     {
       "cell_type": "markdown",
       "metadata": {
-        "colab_type": "text",
         "id": "UQRgJcYgapqE"
       },
       "source": [
@@ -482,8 +442,6 @@
       "cell_type": "code",
       "execution_count": null,
       "metadata": {
-        "colab": {},
-        "colab_type": "code",
         "id": "sGdakRtjaokF"
       },
       "outputs": [],
@@ -538,7 +496,6 @@
     {
       "cell_type": "markdown",
       "metadata": {
-        "colab_type": "text",
         "id": "NPwcfddTa0oB"
       },
       "source": [
@@ -549,8 +506,6 @@
       "cell_type": "code",
       "execution_count": null,
       "metadata": {
-        "colab": {},
-        "colab_type": "code",
         "id": "x1BEqVyra2jW"
       },
       "outputs": [],
@@ -618,8 +573,6 @@
       "cell_type": "code",
       "execution_count": null,
       "metadata": {
-        "colab": {},
-        "colab_type": "code",
         "id": "71Lkdx6GFb3A"
       },
       "outputs": [],
@@ -632,7 +585,6 @@
     {
       "cell_type": "markdown",
       "metadata": {
-        "colab_type": "text",
         "id": "v5uzLcu2bNX3"
       },
       "source": [
@@ -643,13 +595,7 @@
       "cell_type": "code",
       "execution_count": null,
       "metadata": {
-        "colab": {
-          "base_uri": "https://localhost:8080/",
-          "height": 1000
-        },
-        "colab_type": "code",
-        "id": "PvfD2SknWrt6",
-        "outputId": "0a427bb7-8184-4076-97ca-f638116ca52b"
+        "id": "PvfD2SknWrt6"
       },
       "outputs": [],
       "source": [
@@ -669,7 +615,6 @@
     {
       "cell_type": "markdown",
       "metadata": {
-        "colab_type": "text",
         "id": "nDyK-EGqbN5r"
       },
       "source": [
@@ -680,13 +625,7 @@
       "cell_type": "code",
       "execution_count": null,
       "metadata": {
-        "colab": {
-          "base_uri": "https://localhost:8080/",
-          "height": 326
-        },
-        "colab_type": "code",
-        "id": "y98sfom7SuGy",
-        "outputId": "00d94338-e841-4bd6-f9e3-509ef1f1a08b"
+        "id": "y98sfom7SuGy"
       },
       "outputs": [],
       "source": [
@@ -767,7 +706,6 @@
     {
       "cell_type": "markdown",
       "metadata": {
-        "colab_type": "text",
         "id": "iodjSItQds1t"
       },
       "source": [
@@ -778,13 +716,7 @@
       "cell_type": "code",
       "execution_count": null,
       "metadata": {
-        "colab": {
-          "base_uri": "https://localhost:8080/",
-          "height": 102
-        },
-        "colab_type": "code",
-        "id": "K6aWFB5IWlH2",
-        "outputId": "2179c9a3-cb27-447a-ac94-0e5ab2920aff"
+        "id": "K6aWFB5IWlH2"
       },
       "outputs": [],
       "source": [
@@ -801,7 +733,6 @@
     {
       "cell_type": "markdown",
       "metadata": {
-        "colab_type": "text",
         "id": "g6Av-oPWvRc4"
       },
       "source": [
@@ -816,13 +747,10 @@
     "colab": {
       "collapsed_sections": [],
       "name": "networks_seq2seq_nmt.ipynb",
-      "private_outputs": true,
-      "provenance": [],
       "toc_visible": true
     },
     "kernelspec": {
       "display_name": "Python 3",
-      "language": "python",
       "name": "python3"
     }
   },

--- a/docs/tutorials/optimizers_conditionalgradient.ipynb
+++ b/docs/tutorials/optimizers_conditionalgradient.ipynb
@@ -3,7 +3,6 @@
     {
       "cell_type": "markdown",
       "metadata": {
-        "colab_type": "text",
         "id": "pGUYKbJNWNgj"
       },
       "source": [
@@ -15,8 +14,6 @@
       "execution_count": null,
       "metadata": {
         "cellView": "form",
-        "colab": {},
-        "colab_type": "code",
         "id": "1PzPJglSWgnW"
       },
       "outputs": [],
@@ -37,7 +34,6 @@
     {
       "cell_type": "markdown",
       "metadata": {
-        "colab_type": "text",
         "id": "b5P4BEg1XYd5"
       },
       "source": [
@@ -63,7 +59,6 @@
     {
       "cell_type": "markdown",
       "metadata": {
-        "colab_type": "text",
         "id": "Faj8luWnYNSG"
       },
       "source": [
@@ -74,7 +69,6 @@
     {
       "cell_type": "markdown",
       "metadata": {
-        "colab_type": "text",
         "id": "MrDjqjY6YRYM"
       },
       "source": [
@@ -87,7 +81,6 @@
     {
       "cell_type": "markdown",
       "metadata": {
-        "colab_type": "text",
         "id": "dooBaYGLYYnn"
       },
       "source": [
@@ -97,7 +90,9 @@
     {
       "cell_type": "code",
       "execution_count": null,
-      "metadata": {},
+      "metadata": {
+        "id": "2sCyoNXlgGbk"
+      },
       "outputs": [],
       "source": [
         "!pip install -U tensorflow-addons"
@@ -107,13 +102,7 @@
       "cell_type": "code",
       "execution_count": null,
       "metadata": {
-        "colab": {
-          "base_uri": "https://localhost:8080/",
-          "height": 34
-        },
-        "colab_type": "code",
-        "id": "qYo0FkL4O7io",
-        "outputId": "7c40f5df-075a-4d9f-910e-7dff84c46b1f"
+        "id": "qYo0FkL4O7io"
       },
       "outputs": [],
       "source": [
@@ -126,8 +115,6 @@
       "cell_type": "code",
       "execution_count": null,
       "metadata": {
-        "colab": {},
-        "colab_type": "code",
         "id": "kR0PnjrIirpJ"
       },
       "outputs": [],
@@ -140,7 +127,6 @@
     {
       "cell_type": "markdown",
       "metadata": {
-        "colab_type": "text",
         "id": "-x0WBp-IYz7x"
       },
       "source": [
@@ -151,8 +137,6 @@
       "cell_type": "code",
       "execution_count": null,
       "metadata": {
-        "colab": {},
-        "colab_type": "code",
         "id": "4KzMDUT0i1QE"
       },
       "outputs": [],
@@ -167,7 +151,6 @@
     {
       "cell_type": "markdown",
       "metadata": {
-        "colab_type": "text",
         "id": "XGADNG3-Y7aa"
       },
       "source": [
@@ -178,13 +161,7 @@
       "cell_type": "code",
       "execution_count": null,
       "metadata": {
-        "colab": {
-          "base_uri": "https://localhost:8080/",
-          "height": 52
-        },
-        "colab_type": "code",
-        "id": "d6a-kbM_i1b2",
-        "outputId": "248bd642-2d06-4da5-acbe-b1bf59d335b0"
+        "id": "d6a-kbM_i1b2"
       },
       "outputs": [],
       "source": [
@@ -201,7 +178,6 @@
     {
       "cell_type": "markdown",
       "metadata": {
-        "colab_type": "text",
         "id": "sOlB-WqjZp1Y"
       },
       "source": [
@@ -212,8 +188,6 @@
       "cell_type": "code",
       "execution_count": null,
       "metadata": {
-        "colab": {},
-        "colab_type": "code",
         "id": "8LCmRXUgZqyV"
       },
       "outputs": [],
@@ -236,8 +210,6 @@
       "cell_type": "code",
       "execution_count": null,
       "metadata": {
-        "colab": {},
-        "colab_type": "code",
         "id": "udSvzKm4Z5Zr"
       },
       "outputs": [],
@@ -251,7 +223,6 @@
     {
       "cell_type": "markdown",
       "metadata": {
-        "colab_type": "text",
         "id": "qfhE1DfwZC1i"
       },
       "source": [
@@ -264,13 +235,7 @@
       "cell_type": "code",
       "execution_count": null,
       "metadata": {
-        "colab": {
-          "base_uri": "https://localhost:8080/",
-          "height": 382
-        },
-        "colab_type": "code",
-        "id": "6-AMaOYEi1kK",
-        "outputId": "28534147-5ccd-48cf-f8b5-a6afdcf7612a"
+        "id": "6-AMaOYEi1kK"
       },
       "outputs": [],
       "source": [
@@ -293,7 +258,6 @@
     {
       "cell_type": "markdown",
       "metadata": {
-        "colab_type": "text",
         "id": "8OJp4So9bYYR"
       },
       "source": [
@@ -304,8 +268,6 @@
       "cell_type": "code",
       "execution_count": null,
       "metadata": {
-        "colab": {},
-        "colab_type": "code",
         "id": "SuizUueqn449"
       },
       "outputs": [],
@@ -321,8 +283,6 @@
       "cell_type": "code",
       "execution_count": null,
       "metadata": {
-        "colab": {},
-        "colab_type": "code",
         "id": "V8QC3xCwbfNl"
       },
       "outputs": [],
@@ -337,13 +297,7 @@
       "cell_type": "code",
       "execution_count": null,
       "metadata": {
-        "colab": {
-          "base_uri": "https://localhost:8080/",
-          "height": 382
-        },
-        "colab_type": "code",
-        "id": "9BNi4yXGcDlg",
-        "outputId": "be21bdc7-c693-4663-fa5a-f036fc4b6140"
+        "id": "9BNi4yXGcDlg"
       },
       "outputs": [],
       "source": [
@@ -365,7 +319,6 @@
     {
       "cell_type": "markdown",
       "metadata": {
-        "colab_type": "text",
         "id": "1Myw0FVcd_Z9"
       },
       "source": [
@@ -375,7 +328,6 @@
     {
       "cell_type": "markdown",
       "metadata": {
-        "colab_type": "text",
         "id": "0tJYQBRt-ZUl"
       },
       "source": [
@@ -386,13 +338,7 @@
       "cell_type": "code",
       "execution_count": null,
       "metadata": {
-        "colab": {
-          "base_uri": "https://localhost:8080/",
-          "height": 296
-        },
-        "colab_type": "code",
-        "id": "Ewf17MW1cJVI",
-        "outputId": "481d5d00-5642-458d-aa86-225d7faf07ff"
+        "id": "Ewf17MW1cJVI"
       },
       "outputs": [],
       "source": [
@@ -412,7 +358,6 @@
     {
       "cell_type": "markdown",
       "metadata": {
-        "colab_type": "text",
         "id": "JGtutiXuoZyx"
       },
       "source": [
@@ -423,13 +368,7 @@
       "cell_type": "code",
       "execution_count": null,
       "metadata": {
-        "colab": {
-          "base_uri": "https://localhost:8080/",
-          "height": 296
-        },
-        "colab_type": "code",
-        "id": "s-SNIr10o2va",
-        "outputId": "1226fcbd-b71a-442b-811c-7155edbe623d"
+        "id": "s-SNIr10o2va"
       },
       "outputs": [],
       "source": [
@@ -448,8 +387,6 @@
     "colab": {
       "collapsed_sections": [],
       "name": "optimizers_conditionalgradient.ipynb",
-      "private_outputs": true,
-      "provenance": [],
       "toc_visible": true
     },
     "kernelspec": {

--- a/docs/tutorials/optimizers_lazyadam.ipynb
+++ b/docs/tutorials/optimizers_lazyadam.ipynb
@@ -3,7 +3,6 @@
     {
       "cell_type": "markdown",
       "metadata": {
-        "colab_type": "text",
         "id": "Tce3stUlHN0L"
       },
       "source": [
@@ -15,8 +14,6 @@
       "execution_count": null,
       "metadata": {
         "cellView": "form",
-        "colab": {},
-        "colab_type": "code",
         "id": "tuOe1ymfHZPu"
       },
       "outputs": [],
@@ -37,7 +34,6 @@
     {
       "cell_type": "markdown",
       "metadata": {
-        "colab_type": "text",
         "id": "MfBg1C5NB3X0"
       },
       "source": [
@@ -62,7 +58,6 @@
     {
       "cell_type": "markdown",
       "metadata": {
-        "colab_type": "text",
         "id": "xHxb-dlhMIzW"
       },
       "source": [
@@ -74,7 +69,6 @@
     {
       "cell_type": "markdown",
       "metadata": {
-        "colab_type": "text",
         "id": "bQwBbFVAyHJ_"
       },
       "source": [
@@ -95,7 +89,6 @@
     {
       "cell_type": "markdown",
       "metadata": {
-        "colab_type": "text",
         "id": "MUXex9ctTuDB"
       },
       "source": [
@@ -105,7 +98,9 @@
     {
       "cell_type": "code",
       "execution_count": null,
-      "metadata": {},
+      "metadata": {
+        "id": "cHAOyeOVx-k3"
+      },
       "outputs": [],
       "source": [
         "!pip install -U tensorflow-addons"
@@ -115,8 +110,6 @@
       "cell_type": "code",
       "execution_count": null,
       "metadata": {
-        "colab": {},
-        "colab_type": "code",
         "id": "42ztALK4ZdyZ"
       },
       "outputs": [],
@@ -129,8 +122,6 @@
       "cell_type": "code",
       "execution_count": null,
       "metadata": {
-        "colab": {},
-        "colab_type": "code",
         "id": "ys65MwOLKnXq"
       },
       "outputs": [],
@@ -143,7 +134,6 @@
     {
       "cell_type": "markdown",
       "metadata": {
-        "colab_type": "text",
         "id": "KR01t9v_fxbT"
       },
       "source": [
@@ -154,8 +144,6 @@
       "cell_type": "code",
       "execution_count": null,
       "metadata": {
-        "colab": {},
-        "colab_type": "code",
         "id": "djpoAvfWNyL5"
       },
       "outputs": [],
@@ -170,7 +158,6 @@
     {
       "cell_type": "markdown",
       "metadata": {
-        "colab_type": "text",
         "id": "0_D7CZqkv_Hj"
       },
       "source": [
@@ -181,8 +168,6 @@
       "cell_type": "code",
       "execution_count": null,
       "metadata": {
-        "colab": {},
-        "colab_type": "code",
         "id": "U0bS3SyowBoB"
       },
       "outputs": [],
@@ -200,7 +185,6 @@
     {
       "cell_type": "markdown",
       "metadata": {
-        "colab_type": "text",
         "id": "HYE-BxhOzFQp"
       },
       "source": [
@@ -213,8 +197,6 @@
       "cell_type": "code",
       "execution_count": null,
       "metadata": {
-        "colab": {},
-        "colab_type": "code",
         "id": "NxfYhtiSzHf-"
       },
       "outputs": [],
@@ -237,8 +219,6 @@
       "cell_type": "code",
       "execution_count": null,
       "metadata": {
-        "colab": {},
-        "colab_type": "code",
         "id": "1Y--0tK69SXf"
       },
       "outputs": [],
@@ -255,8 +235,6 @@
     "colab": {
       "collapsed_sections": [],
       "name": "optimizers_lazyadam.ipynb",
-      "private_outputs": true,
-      "provenance": [],
       "toc_visible": true
     },
     "kernelspec": {

--- a/docs/tutorials/time_stopping.ipynb
+++ b/docs/tutorials/time_stopping.ipynb
@@ -3,7 +3,6 @@
     {
       "cell_type": "markdown",
       "metadata": {
-        "colab_type": "text",
         "id": "mz0tl581YjZ0"
       },
       "source": [
@@ -15,8 +14,6 @@
       "execution_count": null,
       "metadata": {
         "cellView": "form",
-        "colab": {},
-        "colab_type": "code",
         "id": "hi0OrWAIYjZ4"
       },
       "outputs": [],
@@ -37,7 +34,6 @@
     {
       "cell_type": "markdown",
       "metadata": {
-        "colab_type": "text",
         "id": "gyGdPCvQYjaI"
       },
       "source": [
@@ -47,7 +43,6 @@
     {
       "cell_type": "markdown",
       "metadata": {
-        "colab_type": "text",
         "id": "Z5csJXPVYjaM"
       },
       "source": [
@@ -70,7 +65,6 @@
     {
       "cell_type": "markdown",
       "metadata": {
-        "colab_type": "text",
         "id": "BJhody3KYjaP"
       },
       "source": [
@@ -81,7 +75,6 @@
     {
       "cell_type": "markdown",
       "metadata": {
-        "colab_type": "text",
         "id": "SaZsCaGbYjaU"
       },
       "source": [
@@ -91,7 +84,9 @@
     {
       "cell_type": "code",
       "execution_count": null,
-      "metadata": {},
+      "metadata": {
+        "id": "VgJGPL3ts_1i"
+      },
       "outputs": [],
       "source": [
         "!pip install -U tensorflow-addons"
@@ -101,8 +96,6 @@
       "cell_type": "code",
       "execution_count": null,
       "metadata": {
-        "colab": {},
-        "colab_type": "code",
         "id": "fm_dHPvEYjar"
       },
       "outputs": [],
@@ -117,7 +110,6 @@
     {
       "cell_type": "markdown",
       "metadata": {
-        "colab_type": "text",
         "id": "vg0y1DrQYja4"
       },
       "source": [
@@ -128,13 +120,7 @@
       "cell_type": "code",
       "execution_count": null,
       "metadata": {
-        "colab": {
-          "base_uri": "https://localhost:8080/",
-          "height": 52
-        },
-        "colab_type": "code",
-        "id": "HydkzZTuYja8",
-        "outputId": "bacf85d9-1b6a-42a3-98ff-e3926f54a3f2"
+        "id": "HydkzZTuYja8"
       },
       "outputs": [],
       "source": [
@@ -147,7 +133,6 @@
     {
       "cell_type": "markdown",
       "metadata": {
-        "colab_type": "text",
         "id": "uX02I1kxYjbL"
       },
       "source": [
@@ -158,8 +143,6 @@
       "cell_type": "code",
       "execution_count": null,
       "metadata": {
-        "colab": {},
-        "colab_type": "code",
         "id": "Tlk0MyEfYjbN"
       },
       "outputs": [],
@@ -179,7 +162,6 @@
     {
       "cell_type": "markdown",
       "metadata": {
-        "colab_type": "text",
         "id": "b5Xcyt0qYjbX"
       },
       "source": [
@@ -190,14 +172,7 @@
       "cell_type": "code",
       "execution_count": null,
       "metadata": {
-        "colab": {
-          "base_uri": "https://localhost:8080/",
-          "height": 139
-        },
-        "colab_type": "code",
-        "id": "W82_IZ6iYjbZ",
-        "outputId": "3518f04b-38d1-4974-cbf9-42ff8a9b581e",
-        "scrolled": true
+        "id": "W82_IZ6iYjbZ"
       },
       "outputs": [],
       "source": [
@@ -218,8 +193,6 @@
   "metadata": {
     "colab": {
       "name": "time_stopping.ipynb",
-      "private_outputs": true,
-      "provenance": [],
       "toc_visible": true
     },
     "kernelspec": {

--- a/docs/tutorials/tqdm_progress_bar.ipynb
+++ b/docs/tutorials/tqdm_progress_bar.ipynb
@@ -3,7 +3,6 @@
     {
       "cell_type": "markdown",
       "metadata": {
-        "colab_type": "text",
         "id": "MyujzrAv2Vpk"
       },
       "source": [
@@ -15,8 +14,6 @@
       "execution_count": null,
       "metadata": {
         "cellView": "form",
-        "colab": {},
-        "colab_type": "code",
         "id": "rTUqXTqa2Vpm"
       },
       "outputs": [],
@@ -37,7 +34,6 @@
     {
       "cell_type": "markdown",
       "metadata": {
-        "colab_type": "text",
         "id": "rNnfCHh82Vpq"
       },
       "source": [
@@ -47,7 +43,6 @@
     {
       "cell_type": "markdown",
       "metadata": {
-        "colab_type": "text",
         "id": "4qrDJoTw2Vps"
       },
       "source": [
@@ -70,7 +65,6 @@
     {
       "cell_type": "markdown",
       "metadata": {
-        "colab_type": "text",
         "id": "bVS_PkvX2Vpt"
       },
       "source": [
@@ -81,7 +75,6 @@
     {
       "cell_type": "markdown",
       "metadata": {
-        "colab_type": "text",
         "id": "sRldODz32Vpu"
       },
       "source": [
@@ -91,7 +84,9 @@
     {
       "cell_type": "code",
       "execution_count": null,
-      "metadata": {},
+      "metadata": {
+        "id": "H0yZwcvcR4Gc"
+      },
       "outputs": [],
       "source": [
         "!pip install -U tensorflow-addons"
@@ -101,8 +96,6 @@
       "cell_type": "code",
       "execution_count": null,
       "metadata": {
-        "colab": {},
-        "colab_type": "code",
         "id": "etYr-Suo4KYj"
       },
       "outputs": [],
@@ -121,8 +114,6 @@
       "cell_type": "code",
       "execution_count": null,
       "metadata": {
-        "colab": {},
-        "colab_type": "code",
         "id": "SfXA0mI13pSE"
       },
       "outputs": [],
@@ -144,7 +135,6 @@
     {
       "cell_type": "markdown",
       "metadata": {
-        "colab_type": "text",
         "id": "2RGuwIwe2Vp7"
       },
       "source": [
@@ -155,8 +145,6 @@
       "cell_type": "code",
       "execution_count": null,
       "metadata": {
-        "colab": {},
-        "colab_type": "code",
         "id": "qKfrsOSP2Vp8"
       },
       "outputs": [],
@@ -170,7 +158,6 @@
     {
       "cell_type": "markdown",
       "metadata": {
-        "colab_type": "text",
         "id": "ORtL0s4X2VqB"
       },
       "source": [
@@ -181,8 +168,6 @@
       "cell_type": "code",
       "execution_count": null,
       "metadata": {
-        "colab": {},
-        "colab_type": "code",
         "id": "z8uAGGV32VqC"
       },
       "outputs": [],
@@ -202,7 +187,6 @@
     {
       "cell_type": "markdown",
       "metadata": {
-        "colab_type": "text",
         "id": "YWOnH1ga2VqF"
       },
       "source": [
@@ -213,10 +197,7 @@
       "cell_type": "code",
       "execution_count": null,
       "metadata": {
-        "colab": {},
-        "colab_type": "code",
-        "id": "Vl_oj_OW2VqG",
-        "scrolled": true
+        "id": "Vl_oj_OW2VqG"
       },
       "outputs": [],
       "source": [
@@ -237,7 +218,6 @@
     {
       "cell_type": "markdown",
       "metadata": {
-        "colab_type": "text",
         "id": "uFvBfwJN2VqK"
       },
       "source": [
@@ -249,8 +229,6 @@
       "cell_type": "code",
       "execution_count": null,
       "metadata": {
-        "colab": {},
-        "colab_type": "code",
         "id": "Np3dD8bhe10E"
       },
       "outputs": [],
@@ -262,7 +240,6 @@
     {
       "cell_type": "markdown",
       "metadata": {
-        "colab_type": "text",
         "id": "36WRBMo7e10I"
       },
       "source": [
@@ -274,8 +251,6 @@
   "metadata": {
     "colab": {
       "name": "tqdm_progress_bar.ipynb",
-      "private_outputs": true,
-      "provenance": [],
       "toc_visible": true
     },
     "kernelspec": {


### PR DESCRIPTION
This formats the tutorial notebooks using the latest [nbfmt](https://github.com/tensorflow/docs/tree/master/tools/tensorflow_docs/tools) to make more consistent by removing extra metadata fields, ensuring certain ones exist, etc. This helps reduce diff churn for better GitHub reviews.

To run:

```
python3 -m pip install -U --user git+https://github.com/tensorflow/docs

python3 -m tensorflow_docs.tools.nbfmt ./docs/
```

Thanks!