### PR TITLE
Avoid unnecessary reshapes for instance norm

### DIFF
--- a/tensorflow_addons/layers/normalizations.py
+++ b/tensorflow_addons/layers/normalizations.py
@@ -126,9 +126,9 @@ class GroupNormalization(tf.keras.layers.Layer):
         normalized_inputs = self._apply_normalization(reshaped_inputs, input_shape)
 
         if not self.is_instance_norm:
-          outputs = tf.reshape(normalized_inputs, tensor_input_shape)
+            outputs = tf.reshape(normalized_inputs, tensor_input_shape)
         else:
-          outputs = normalized_inputs
+            outputs = normalized_inputs
 
         return outputs
 
@@ -160,22 +160,22 @@ class GroupNormalization(tf.keras.layers.Layer):
 
         group_shape = [tensor_input_shape[i] for i in range(len(input_shape))]
         if not self.is_instance_norm:
-          group_shape[self.axis] = input_shape[self.axis] // self.groups
-          group_shape.insert(self.axis, self.groups)
-          group_shape = tf.stack(group_shape)
-          reshaped_inputs = tf.reshape(inputs, group_shape)
-          return reshaped_inputs, group_shape
+            group_shape[self.axis] = input_shape[self.axis] // self.groups
+            group_shape.insert(self.axis, self.groups)
+            group_shape = tf.stack(group_shape)
+            reshaped_inputs = tf.reshape(inputs, group_shape)
+            return reshaped_inputs, group_shape
         else:
-          return inputs, group_shape
+            return inputs, group_shape
 
     def _apply_normalization(self, reshaped_inputs, input_shape):
 
         group_shape = tf.keras.backend.int_shape(reshaped_inputs)
         group_reduction_axes = list(range(1, len(group_shape)))
         if not self.is_instance_norm:
-          axis = -2 if self.axis == -1 else self.axis - 1
+            axis = -2 if self.axis == -1 else self.axis - 1
         else:
-          axis = -1 if self.axis == -1 else self.axis - 1
+            axis = -1 if self.axis == -1 else self.axis - 1
         group_reduction_axes.pop(axis)
 
         mean, variance = tf.nn.moments(
@@ -289,10 +289,10 @@ class GroupNormalization(tf.keras.layers.Layer):
     def _create_broadcast_shape(self, input_shape):
         broadcast_shape = [1] * len(input_shape)
         if not self.is_instance_norm:
-          broadcast_shape[self.axis] = input_shape[self.axis] // self.groups
-          broadcast_shape.insert(self.axis, self.groups)
+            broadcast_shape[self.axis] = input_shape[self.axis] // self.groups
+            broadcast_shape.insert(self.axis, self.groups)
         else:
-          broadcast_shape[self.axis] = self.groups
+            broadcast_shape[self.axis] = self.groups
         return broadcast_shape
 
 

--- a/tensorflow_addons/layers/normalizations.py
+++ b/tensorflow_addons/layers/normalizations.py
@@ -125,7 +125,10 @@ class GroupNormalization(tf.keras.layers.Layer):
 
         normalized_inputs = self._apply_normalization(reshaped_inputs, input_shape)
 
-        outputs = tf.reshape(normalized_inputs, tensor_input_shape)
+        if not self.is_instance_norm:
+          outputs = tf.reshape(normalized_inputs, tensor_input_shape)
+        else:
+          outputs = normalized_inputs
 
         return outputs
 
@@ -156,17 +159,23 @@ class GroupNormalization(tf.keras.layers.Layer):
     def _reshape_into_groups(self, inputs, input_shape, tensor_input_shape):
 
         group_shape = [tensor_input_shape[i] for i in range(len(input_shape))]
-        group_shape[self.axis] = input_shape[self.axis] // self.groups
-        group_shape.insert(self.axis, self.groups)
-        group_shape = tf.stack(group_shape)
-        reshaped_inputs = tf.reshape(inputs, group_shape)
-        return reshaped_inputs, group_shape
+        if not self.is_instance_norm:
+          group_shape[self.axis] = input_shape[self.axis] // self.groups
+          group_shape.insert(self.axis, self.groups)
+          group_shape = tf.stack(group_shape)
+          reshaped_inputs = tf.reshape(inputs, group_shape)
+          return reshaped_inputs, group_shape
+        else:
+          return inputs, group_shape
 
     def _apply_normalization(self, reshaped_inputs, input_shape):
 
         group_shape = tf.keras.backend.int_shape(reshaped_inputs)
         group_reduction_axes = list(range(1, len(group_shape)))
-        axis = -2 if self.axis == -1 else self.axis - 1
+        if not self.is_instance_norm:
+          axis = -2 if self.axis == -1 else self.axis - 1
+        else:
+          axis = -1 if self.axis == -1 else self.axis - 1
         group_reduction_axes.pop(axis)
 
         mean, variance = tf.nn.moments(
@@ -207,8 +216,13 @@ class GroupNormalization(tf.keras.layers.Layer):
     def _set_number_of_groups_for_instance_norm(self, input_shape):
         dim = input_shape[self.axis]
 
+        # is_instance_norm is used to avoid unneccessary reshape ops, which
+        # might prevent the TF layout optimization from eliding redundant
+        # transpose nodes.
+        self.is_instance_norm = False
         if self.groups == -1:
             self.groups = dim
+            self.is_instance_norm = True
 
     def _check_size_of_dimensions(self, input_shape):
 
@@ -274,8 +288,11 @@ class GroupNormalization(tf.keras.layers.Layer):
 
     def _create_broadcast_shape(self, input_shape):
         broadcast_shape = [1] * len(input_shape)
-        broadcast_shape[self.axis] = input_shape[self.axis] // self.groups
-        broadcast_shape.insert(self.axis, self.groups)
+        if not self.is_instance_norm:
+          broadcast_shape[self.axis] = input_shape[self.axis] // self.groups
+          broadcast_shape.insert(self.axis, self.groups)
+        else:
+          broadcast_shape[self.axis] = self.groups
         return broadcast_shape
 
 

--- a/tensorflow_addons/layers/tests/normalizations_test.py
+++ b/tensorflow_addons/layers/tests/normalizations_test.py
@@ -48,6 +48,7 @@ def test_weights():
     assert len(layer.trainable_weights) == 2
     assert len(layer.weights) == 2
 
+
 def test_instance_norm_flag_after_build():
     # Check if instance norm flag get initialized correctly
     layer = InstanceNormalization()
@@ -57,6 +58,7 @@ def test_instance_norm_flag_after_build():
     layer = GroupNormalization()
     layer.build((None, 3, 4))
     assert not layer.is_instance_norm
+
 
 def test_apply_normalization():
     input_shape = (1, 4)

--- a/tensorflow_addons/layers/tests/normalizations_test.py
+++ b/tensorflow_addons/layers/tests/normalizations_test.py
@@ -139,9 +139,9 @@ def _test_specific_layer(inputs, axis, groups, center, scale):
 
     group_reduction_axes = list(range(1, len(reshaped_dims)))
     if not is_instance_norm:
-      axis = -2 if axis == -1 else axis - 1
+        axis = -2 if axis == -1 else axis - 1
     else:
-      axis = -1 if axis == -1 else axis - 1
+        axis = -1 if axis == -1 else axis - 1
     group_reduction_axes.pop(axis)
 
     # Calculate mean and variance

--- a/tensorflow_addons/layers/tests/normalizations_test.py
+++ b/tensorflow_addons/layers/tests/normalizations_test.py
@@ -48,6 +48,15 @@ def test_weights():
     assert len(layer.trainable_weights) == 2
     assert len(layer.weights) == 2
 
+def test_instance_norm_flag_after_build():
+    # Check if instance norm flag get initialized correctly
+    layer = InstanceNormalization()
+    layer.build((None, 3, 4))
+    assert layer.is_instance_norm
+
+    layer = GroupNormalization()
+    layer.build((None, 3, 4))
+    assert not layer.is_instance_norm
 
 def test_apply_normalization():
     input_shape = (1, 4)

--- a/tensorflow_addons/layers/tests/normalizations_test.py
+++ b/tensorflow_addons/layers/tests/normalizations_test.py
@@ -49,17 +49,6 @@ def test_weights():
     assert len(layer.weights) == 2
 
 
-def test_instance_norm_flag_after_build():
-    # Check if instance norm flag get initialized correctly
-    layer = InstanceNormalization()
-    layer.build((None, 3, 4))
-    assert layer.is_instance_norm
-
-    layer = GroupNormalization()
-    layer.build((None, 3, 4))
-    assert not layer.is_instance_norm
-
-
 def test_apply_normalization():
     input_shape = (1, 4)
     reshaped_inputs = tf.constant([[[2.0, 2.0], [3.0, 3.0]]])
@@ -91,7 +80,7 @@ def test_reshape():
     run_reshape_test(1, 2, input_shape, expected_shape)
 
     input_shape = (10, 10, 10)
-    expected_shape = [10, 10, 1, 10]
+    expected_shape = [10, 10, 10]
     run_reshape_test(1, -1, input_shape, expected_shape)
 
     input_shape = (10, 10, 10)
@@ -133,17 +122,26 @@ def _test_specific_layer(inputs, axis, groups, center, scale):
     outputs = model.predict(inputs, steps=1)
     assert not np.isnan(outputs).any()
 
+    is_instance_norm = False
     # Create shapes
     if groups == -1:
         groups = input_shape[axis]
+    if (input_shape[axis] // groups) == 1:
+        is_instance_norm = True
     np_inputs = inputs
     reshaped_dims = list(np_inputs.shape)
-    reshaped_dims[axis] = reshaped_dims[axis] // groups
-    reshaped_dims.insert(axis, groups)
-    reshaped_inputs = np.reshape(np_inputs, tuple(reshaped_dims))
+    if not is_instance_norm:
+        reshaped_dims[axis] = reshaped_dims[axis] // groups
+        reshaped_dims.insert(axis, groups)
+        reshaped_inputs = np.reshape(np_inputs, tuple(reshaped_dims))
+    else:
+        reshaped_inputs = np_inputs
 
     group_reduction_axes = list(range(1, len(reshaped_dims)))
-    axis = -2 if axis == -1 else axis - 1
+    if not is_instance_norm:
+      axis = -2 if axis == -1 else axis - 1
+    else:
+      axis = -1 if axis == -1 else axis - 1
     group_reduction_axes.pop(axis)
 
     # Calculate mean and variance


### PR DESCRIPTION
# Description

Brief Description of the PR:
* Previously, to conform to the GroupNorm, the InstanceNorm needs to insert a singleton dim after the channel axis by using reshape ops. These reshape ops might prevent the TF layout optimizer from eliding unnecessary NHWC/NCHW transposes. This PR removes the unnecessary reshape ops for the instance norm. 

Fixes # (issue)

## Type of change

- [x] Bug fix
- [ ] New Tutorial
- [ ] Updated or additional documentation
- [ ] Additional Testing
- [ ] New Activation and the changes conform to the [activation contribution guidelines](https://github.com/tensorflow/addons/blob/master/tensorflow_addons/activations/README.md#contribution-guidelines)
- [ ] New Callback and the changes conform to the [callback contribution guidelines](https://github.com/tensorflow/addons/blob/master/tensorflow_addons/callbacks/README.md#contribution-guidelines)
- [ ] New Image addition and the changes conform to the [image op contribution guidelines](https://github.com/tensorflow/addons/blob/master/tensorflow_addons/image/README.md#contribution-guidelines)
- [ ] New Layer and the changes conform to the [layer contribution guidelines](https://github.com/tensorflow/addons/blob/master/tensorflow_addons/layers/README.md#contribution-guidelines)
- [ ] New Loss and the changes conform to the [loss contribution guidelines](https://github.com/tensorflow/addons/blob/master/tensorflow_addons/losses/README.md#contribution-guidelines)
- [ ] New Metric and the changes conform to the [metric contribution guidelines](https://github.com/tensorflow/addons/blob/master/tensorflow_addons/metrics/README.md#contribution-guidelines)
- [ ] New Optimizer and the changes conform to the [optimizer contribution guidelines](https://github.com/tensorflow/addons/blob/master/tensorflow_addons/optimizers/README.md#contribution-guidelines)
- [ ] New RNN Cell and the changes conform to the [rnn contribution guidelines](https://github.com/tensorflow/addons/blob/master/tensorflow_addons/rnn/README.md#contribution-guidelines)
- [ ] New Seq2seq addition and the changes conform to the [seq2seq contribution guidelines](https://github.com/tensorflow/addons/blob/master/tensorflow_addons/seq2seq/README.md#contribution-guidelines)
- [ ] New Text addition and the changes conform to the [text op contribution guidelines](https://github.com/tensorflow/addons/blob/master/tensorflow_addons/text/README.md#contribution-guidelines)

# Checklist:

- [x] I've properly [formatted my code according to the guidelines](https://github.com/tensorflow/addons/blob/master/CONTRIBUTING.md#coding-style)
    - [ ] By running Black + Flake8
    - [ ] By running pre-commit hooks
- [ ] This PR addresses an already submitted issue for TensorFlow Addons
- [ ] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] This PR contains modifications to C++ custom-ops

# How Has This Been Tested?

If you're adding a bugfix or new feature please describe the tests that you ran to verify your

*  Corresponding changes are made for test_reshape, test_feature_input, test_picture_input to support the shape checking after this PR.
*  The existing test_groupnorm_conv can be used to test the correctness of the change.

cc. @nluehr 
