### PR TITLE
Fix crash in CLR optimizer callback

### DIFF
--- a/tensorflow_addons/optimizers/cyclical_learning_rate.py
+++ b/tensorflow_addons/optimizers/cyclical_learning_rate.py
@@ -91,6 +91,7 @@ class CyclicalLearningRate(tf.keras.optimizers.schedules.LearningRateSchedule):
             dtype = initial_learning_rate.dtype
             maximal_learning_rate = tf.cast(self.maximal_learning_rate, dtype)
             step_size = tf.cast(self.step_size, dtype)
+            step = tf.cast(step, dtype)
             cycle = tf.floor(1 + step / (2 * step_size))
             x = tf.abs(step / step_size - 2 * cycle + 1)
 

--- a/tensorflow_addons/optimizers/cyclical_learning_rate.py
+++ b/tensorflow_addons/optimizers/cyclical_learning_rate.py
@@ -91,9 +91,9 @@ class CyclicalLearningRate(tf.keras.optimizers.schedules.LearningRateSchedule):
             dtype = initial_learning_rate.dtype
             maximal_learning_rate = tf.cast(self.maximal_learning_rate, dtype)
             step_size = tf.cast(self.step_size, dtype)
-            step = tf.cast(step, dtype)
-            cycle = tf.floor(1 + step / (2 * step_size))
-            x = tf.abs(step / step_size - 2 * cycle + 1)
+            step_as_dtype = tf.cast(step, dtype)
+            cycle = tf.floor(1 + step_as_dtype / (2 * step_size))
+            x = tf.abs(step_as_dtype / step_size - 2 * cycle + 1)
 
             mode_step = cycle if self.scale_mode == "cycle" else step
 


### PR DESCRIPTION
I experienced the following stack trace when TF 2.4 nightly passes "step" as an int64. This happens, for example, when using the nightly version of TensorBoard.

Minimal repro: https://pastebin.com/Ni2dgDgh

Environment:
tf-nightly-gpu 2.4.0.dev20200917
tfa-nightly 0.12.0.dev20200918223509
tb-nightly 2.4.0a20200921

# Description

 File "...\Python38\lib\site-packages\tensorflow\python\keras\engine\training.py", line 1117, in fit
    callbacks.on_epoch_end(epoch, epoch_logs)
  File "...\Python38\lib\site-packages\tensorflow\python\keras\callbacks.py", line 427, in on_epoch_end
    callback.on_epoch_end(epoch, logs)
  File "...\Python38\lib\site-packages\tensorflow\python\keras\callbacks.py", line 2274, in on_epoch_end
    self._log_epoch_metrics(epoch, logs)
  File "...\Python38\lib\site-packages\tensorflow\python\keras\callbacks.py", line 2316, in _log_epoch_metrics
    train_logs = self._collect_learning_rate(train_logs)
  File "...\Python38\lib\site-packages\tensorflow\python\keras\callbacks.py", line 2301, in _collect_learning_rate
    logs['learning_rate'] = lr_schedule(self.model.optimizer.iterations)
  File "...\Python38\lib\site-packages\tensorflow_addons\optimizers\cyclical_learning_rate.py", line 94, in __call__
    cycle = tf.floor(1 + step / (2 * step_size))
  File "...\Python38\lib\site-packages\tensorflow\python\ops\variables.py", line 1074, in _run_op
    return tensor_oper(a.value(), *args, **kwargs)
  File "...\Python38\lib\site-packages\tensorflow\python\ops\math_ops.py", line 1155, in binary_op_wrapper
    raise e
  File "...\Python38\lib\site-packages\tensorflow\python\ops\math_ops.py", line 1139, in binary_op_wrapper
    return func(x, y, name=name)
  File "...\Python38\lib\site-packages\tensorflow\python\util\dispatch.py", line 201, in wrapper
    return target(*args, **kwargs)
  File "...\Python38\lib\site-packages\tensorflow\python\ops\math_ops.py", line 1311, in truediv
    return _truediv_python3(x, y, name)
  File "...\Python38\lib\site-packages\tensorflow\python\ops\math_ops.py", line 1241, in _truediv_python3
    raise TypeError("x and y must have the same dtype, got %r != %r" %
TypeError: x and y must have the same dtype, got tf.int64 != tf.float32

Brief Description of the PR:

Fixes # (issue)

## Type of change

- [x] Bug fix
- [ ] New Tutorial
- [ ] Updated or additional documentation
- [ ] Additional Testing
- [ ] New Activation and the changes conform to the [activation contribution guidelines](https://github.com/tensorflow/addons/blob/master/tensorflow_addons/activations/README.md#contribution-guidelines)
- [ ] New Callback and the changes conform to the [callback contribution guidelines](https://github.com/tensorflow/addons/blob/master/tensorflow_addons/callbacks/README.md#contribution-guidelines)
- [ ] New Image addition and the changes conform to the [image op contribution guidelines](https://github.com/tensorflow/addons/blob/master/tensorflow_addons/image/README.md#contribution-guidelines)
- [ ] New Layer and the changes conform to the [layer contribution guidelines](https://github.com/tensorflow/addons/blob/master/tensorflow_addons/layers/README.md#contribution-guidelines)
- [ ] New Loss and the changes conform to the [loss contribution guidelines](https://github.com/tensorflow/addons/blob/master/tensorflow_addons/losses/README.md#contribution-guidelines)
- [ ] New Metric and the changes conform to the [metric contribution guidelines](https://github.com/tensorflow/addons/blob/master/tensorflow_addons/metrics/README.md#contribution-guidelines)
- [ ] New Optimizer and the changes conform to the [optimizer contribution guidelines](https://github.com/tensorflow/addons/blob/master/tensorflow_addons/optimizers/README.md#contribution-guidelines)
- [ ] New RNN Cell and the changes conform to the [rnn contribution guidelines](https://github.com/tensorflow/addons/blob/master/tensorflow_addons/rnn/README.md#contribution-guidelines)
- [ ] New Seq2seq addition and the changes conform to the [seq2seq contribution guidelines](https://github.com/tensorflow/addons/blob/master/tensorflow_addons/seq2seq/README.md#contribution-guidelines)
- [ ] New Text addition and the changes conform to the [text op contribution guidelines](https://github.com/tensorflow/addons/blob/master/tensorflow_addons/text/README.md#contribution-guidelines)

# Checklist:

- [x] I've properly [formatted my code according to the guidelines](https://github.com/tensorflow/addons/blob/master/CONTRIBUTING.md#coding-style)
    - [ ] By running Black + Flake8
    - [ ] By running pre-commit hooks
- [ ] This PR addresses an already submitted issue for TensorFlow Addons
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] This PR contains modifications to C++ custom-ops

# How Has This Been Tested?

Run on
tf-nightly-gpu 2.4.0.dev20200917
and
tfa-nightly 0.12.0.dev20200918223509

My project code looks like:
clr = CyclicalLearningRate(initial_learning_rate=1e-3,
                           maximal_learning_rate=1e-2,
                           step_size=3*STEPS_PER_EPOCH_TRAIN,
                           scale_fn=lambda x:1.)
loss = tf.keras.losses.CategoricalCrossentropy(from_logits=True)
optimizer = LAMB(clr)
model.compile(optimizer=optimizer, loss=loss, metrics=['accuracy'])

If you're adding a bugfix or new feature please describe the tests that you ran to verify your changes:
*  
