### PR TITLE
Remove subpackage maintainer concept

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,24 +1,5 @@
 # TensorFlow Addons Codeowners
 
-#####################################################################################
-# Subpackage Owners
-
-/tensorflow_addons/activations/ @facaiy @seanpmorgan
-/tensorflow_addons/callbacks/ @shun-lin
-/tensorflow_addons/image/ @windqaq @facaiy
-/tensorflow_addons/layers/ @seanpmorgan @facaiy
-/tensorflow_addons/losses/ @facaiy @windqaq
-/tensorflow_addons/metrics/ @marload
-/tensorflow_addons/optimizers/ @facaiy @windqaq
-/tensorflow_addons/rnn/ @qlzh727
-/tensorflow_addons/seq2seq/ @qlzh727 @guillaumekln
-/tensorflow_addons/text/ @seanpmorgan @facaiy
-
-/tensorflow_addons/custom_ops/image/ @windqaq @facaiy
-/tensorflow_addons/custom_ops/seq2seq/ @qlzh727
-/tensorflow_addons/custom_ops/text/ @seanpmorgan @facaiy
-
-#####################################################################################
 # Submodule Owners
 # These will not always trigger a GitHub review because submodule owners do not
 # always have write access. However, a bot will notify them of the needed review.

--- a/README.md
+++ b/README.md
@@ -214,11 +214,12 @@ tfa.options.TF_ADDONS_PY_OPS = True
 This variable defaults to `True` on Windows and macOS, and `False` on Linux.
 
 #### Proxy Maintainership
-TensorFlow Addons has been designed to compartmentalize subpackages and submodules so 
-that they can be maintained by users who have expertise and a vested interest 
-in that component. 
+TensorFlow Addons has been designed to compartmentalize submodules so 
+that they can be maintained by community users who have expertise, and a vested 
+interest in that component. We heavily encourage users to submit sign up to maintain a 
+submodule by submitting your username to the [CODEOWNERS](.github/CODEOWNERS) file.
 
-Subpackage maintainership will only be granted after substantial contribution 
+Full write access will only be granted after substantial contribution 
 has been made in order to limit the number of users with write permission. 
 Contributions can come in the form of issue closings, bug fixes, documentation, 
 new code, or optimizing existing code. Submodule maintainership can be granted 
@@ -229,7 +230,7 @@ For more information see [the RFC](https://github.com/tensorflow/community/blob/
 on this topic.
 
 #### Periodic Evaluation of Subpackages
-Given the nature of this repository, subpackages and submodules may become less 
+Given the nature of this repository, submodules may become less 
 and less useful to the community as time goes on. In order to keep the 
 repository sustainable, we'll be performing bi-annual reviews of our code to 
 ensure everything still belongs within the repo. Contributing factors to this 


### PR DESCRIPTION
# Description

The repo maintainers have discussed and we feel that the subpackage maintainer concept has grown stale. Originally we wanted to split subpackages amongst ourselves where small groups of maintainers would serve as the failsafe for given subpackages. In practice this meant every subpackage would have had a very limited amount of people who were ultimately responsible. This created unnecessary stress on maintainers to feel like they were required to keep working on the project in order for the subpackage to remain viable. 

Ultimately all write access maintainers can help across the repo and have been doing so for an extended period of time. However, there is an added need for reliable submodule owners which is what we've discovered over the past few months. We'll be working on improving that system through https://github.com/tensorflow/addons/pull/2024


## Type of change

- [x] Updated or additional documentation

# Checklist:

- [x] I've properly [formatted my code according to the guidelines]
