### PR TITLE
make cutout op compatible with non eager mode

### DIFF
--- a/tensorflow_addons/image/cutout_ops.py
+++ b/tensorflow_addons/image/cutout_ops.py
@@ -189,7 +189,7 @@ def cutout(
             mask_4d = tf.expand_dims(masks.stack(), 1)
             mask = tf.tile(mask_4d, [1, tf.shape(images)[1], 1, 1])
         images = tf.where(
-            mask == 0,
+            tf.equal(mask, 0),
             tf.ones_like(images, dtype=images.dtype) * constant_values,
             images,
         )


### PR DESCRIPTION
# Description

cutout op is not compatible with non eager mode because of condition: (mask == 0) - it is compatible only with eager mode
fix is replace it by tf.equal(mask, 0)

# Tested it by running below code (it printed zero masks confirming that it works)
```
class Cutout(tf.keras.layers.Layer):

  def __init__(self,
               seed=None,
               **kwargs):
    super(Cutout, self).__init__(**kwargs)
    self.seed = seed

  def call(self, inputs, training=None):

    if inputs.shape.rank != 3:  # [batch, time, feature]
      raise ValueError('inputs.shape.rank:%d must be 3' % inputs.shape.rank)

    if training is None:
      training = tf.keras.backend.learning_phase()

    net = tf.keras.backend.expand_dims(inputs, axis=-1)
    net = random_cutout(net, (4, 2),
        seed=self.seed)
    net = tf.keras.backend.squeeze(net, axis=-1)
    return net

input_shape = [2, 7, 5]
seed = 4
spectrogram = np.ones(input_shape)
inputs = tf.keras.layers.Input(
    shape=input_shape[1:],
    batch_size=input_shape[0],
    dtype=tf.float32)
outputs = Cutout(
    seed=seed)(
        inputs, training=True)
model = tf.keras.models.Model(inputs, outputs)
prediction = model.predict(spectrogram)
print(prediction[0,:,:])
print(prediction[1,:,:])
```
