### PR TITLE
Update ABI compatibility version

### DIFF
--- a/tensorflow_addons/utils/resource_loader.py
+++ b/tensorflow_addons/utils/resource_loader.py
@@ -20,8 +20,8 @@ import warnings
 
 import tensorflow as tf
 
-MIN_TF_VERSION_FOR_ABI_COMPATIBILITY = "2.2.0"
-MAX_TF_VERSION_FOR_ABI_COMPATIBILITY = "2.3.0"
+MIN_TF_VERSION_FOR_ABI_COMPATIBILITY = "2.3.0"
+MAX_TF_VERSION_FOR_ABI_COMPATIBILITY = "2.4.0"
 abi_warning_already_raised = False
 SKIP_CUSTOM_OPS = False
 


### PR DESCRIPTION
Fix https://colab.research.google.com/drive/19AFVhLDcFa1OHMkaZm5K3alytnxODaGh?usp=sharing. This is not the desired warning. We are built custom ops against TF2.3.*.