### PR TITLE
add noisy_dense support ...

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -88,8 +88,8 @@
 /tensorflow_addons/layers/tests/snake_test.py @failure-to-thrive
 /tensorflow_addons/layers/stochastic_depth.py @mhstadler @windqaq
 /tensorflow_addons/layers/tests/stochastic_depth_test.py @mhstadler @windqaq
-/tensorflow_addons/layers/noisy_dense.py @leonshams
-/tensorflow_addons/layers/tests/noisy_dense_test.py @leonshams
+/tensorflow_addons/layers/noisy_dense.py @markub3327
+/tensorflow_addons/layers/tests/noisy_dense_test.py @markub3327
 
 /tensorflow_addons/losses/contrastive.py @windqaq
 /tensorflow_addons/losses/tests/contrastive_test.py @windqaq

--- a/tensorflow_addons/layers/noisy_dense.py
+++ b/tensorflow_addons/layers/noisy_dense.py
@@ -15,7 +15,8 @@
 
 import tensorflow as tf
 
-from tensorflow.keras.layers import Dense, regularizers, constraints, initializers, InputSpec 
+from tensorflow.keras import regularizers, constraints, initializers
+from tensorflow.keras.layers import Dense, InputSpec 
 from tensorflow.keras import backend as K
 
 

--- a/tensorflow_addons/layers/noisy_dense.py
+++ b/tensorflow_addons/layers/noisy_dense.py
@@ -89,7 +89,7 @@ class NoisyDense(Dense):
                bias_constraint=None, 
                bias_sigma_constraint=None,
                **kwargs):
-    super(NoisyDense, self).__init__(units=units, 
+    super().__init__(units=units, 
                                      activation=activation, 
                                      use_bias=use_bias, 
                                      kernel_initializer=kernel_initializer, 
@@ -192,15 +192,15 @@ class NoisyDense(Dense):
     self.built = True
 
   def call(self, inputs):
-    self.kernel = tf.add(self.kernel_mu, tf.mul(self.kernel_sigma, self.kernel_epsilon))
+    self.kernel = tf.add(self.kernel_mu, (self.kernel_sigma * self.kernel_epsilon))
     self.bias = self.bias_mu
     if self.bias is not None:
-      self.bias = tf.add(self.bias_mu, tf.mul(self.bias_sigma, self.bias_epsilon))
+      self.bias = tf.add(self.bias_mu, (self.bias_sigma * self.bias_epsilon))
     
     return super().call(inputs)
 
   def get_config(self):
-    config = super(NoisyDense, self).get_config()
+    config = super().get_config()
     config.update({
         'sigma0':
             self.sigma0,
@@ -222,7 +222,7 @@ class NoisyDense(Dense):
                         mean=0.0,
                         stddev=1.0,
                         dtype=self.dtype)
-    return tf.mul(tf.sign(x), tf.sqrt(tf.abs(x)))
+    return tf.sign(x) * tf.sqrt(tf.abs(x))
     
   def reset_noise(self):
     if self.use_factorised:

--- a/tensorflow_addons/layers/noisy_dense.py
+++ b/tensorflow_addons/layers/noisy_dense.py
@@ -161,7 +161,7 @@ class NoisyDense(Dense):
     if self.use_bias:
       self.bias_sigma = self.add_weight(
           'bias_sigma',
-          shape=self.bias.shape,
+          shape=self.bias_mu.shape,
           initializer=initializers.Constant(value=sigma_init),
           regularizer=self.bias_sigma_regularizer,
           constraint=self.bias_sigma_constraint,
@@ -180,7 +180,7 @@ class NoisyDense(Dense):
     if self.use_bias:
       self.bias_epsilon = self.add_weight(
             name='bias_epsilon',
-            shape=self.bias.shape,
+            shape=self.bias_mu.shape,
             dtype=self.dtype,
             initializer='zeros',
             trainable=False)

--- a/tensorflow_addons/layers/noisy_dense.py
+++ b/tensorflow_addons/layers/noisy_dense.py
@@ -144,7 +144,7 @@ class NoisyDense(Dense):
 
     # use factorising Gaussian variables
     if self.use_factorised:
-      sigma_init = self.sigma0 / tf.sqrt(self.kernel.shape[0])
+      sigma_init = self.sigma0 / tf.sqrt(self.kernel_mu.shape[0])
     # use independent Gaussian variables  
     else:
       sigma_init = 0.017
@@ -152,7 +152,7 @@ class NoisyDense(Dense):
     # create sigma weights
     self.kernel_sigma = self.add_weight(
         'kernel_sigma',
-        shape=self.kernel.shape,
+        shape=self.kernel_mu.shape,
         initializer=initializers.Constant(value=sigma_init),
         regularizer=self.kernel_sigma_regularizer,
         constraint=self.kernel_sigma_constraint,
@@ -173,7 +173,7 @@ class NoisyDense(Dense):
     # create noise variables
     self.kernel_epsilon = self.add_weight(
           name='kernel_epsilon',
-          shape=self.kernel.shape,
+          shape=self.kernel_mu.shape,
           dtype=self.dtype,
           initializer='zeros',
           trainable=False)

--- a/tensorflow_addons/layers/noisy_dense.py
+++ b/tensorflow_addons/layers/noisy_dense.py
@@ -139,7 +139,7 @@ class NoisyDense(Dense):
           dtype=self.dtype,
           trainable=True)
     else:
-      self.bias = None
+      self.bias_mu = None
     self.built = True
 
     # use factorising Gaussian variables

--- a/tensorflow_addons/layers/noisy_dense.py
+++ b/tensorflow_addons/layers/noisy_dense.py
@@ -144,7 +144,7 @@ class NoisyDense(Dense):
 
     # use factorising Gaussian variables
     if self.use_factorised:
-      sigma_init = self.sigma0 / tf.sqrt(self.kernel_mu.shape[0])
+      sigma_init = self.sigma0 / tf.sqrt(float(self.kernel_mu.shape[0]))
     # use independent Gaussian variables  
     else:
       sigma_init = 0.017

--- a/tensorflow_addons/layers/tests/noisy_dense_test.py
+++ b/tensorflow_addons/layers/tests/noisy_dense_test.py
@@ -28,16 +28,16 @@ from tensorflow_addons.layers.noisy_dense import NoisyDense
 
 def test_noisy_dense():
     test_utils.layer_test(
-        keras.layers.NoisyDense, kwargs={'units': 3, 'sigma0': 0.4, 'use_factorised': True}, input_shape=(3, 2))
+        NoisyDense, kwargs={'units': 3, 'sigma0': 0.4, 'use_factorised': True}, input_shape=(3, 2))
 
     test_utils.layer_test(
-        keras.layers.NoisyDense, kwargs={'units': 3, 'sigma0': 0.4, 'use_factorised': False}, input_shape=(3, 4, 2))
+        NoisyDense, kwargs={'units': 3, 'sigma0': 0.4, 'use_factorised': False}, input_shape=(3, 4, 2))
 
     test_utils.layer_test(
-        keras.layers.NoisyDense, kwargs={'units': 3, 'sigma0': 0.4, 'use_factorised': True}, input_shape=(None, None, 2))
+        NoisyDense, kwargs={'units': 3, 'sigma0': 0.4, 'use_factorised': True}, input_shape=(None, None, 2))
 
     test_utils.layer_test(
-        keras.layers.NoisyDense, kwargs={'units': 3, 'sigma0': 0.4, 'use_factorised': False}, input_shape=(3, 4, 5, 2))
+        NoisyDense, kwargs={'units': 3, 'sigma0': 0.4, 'use_factorised': False}, input_shape=(3, 4, 5, 2))
 
 
 @pytest.mark.usefixtures("maybe_run_functions_eagerly")
@@ -45,7 +45,7 @@ def test_noisy_dense():
 def test_noisy_dense_dtype(dtype):
     inputs = tf.convert_to_tensor(
         np.random.randint(low=0, high=7, size=(2, 2)))
-    layer = keras.layers.NoisyDense(5, sigma0=0.4, dtype=dtype)
+    layer = NoisyDense(5, sigma0=0.4, dtype=dtype)
     outputs = layer(inputs)    
     layer.remove_noise()
     np.testing.assert_array_equal(outputs.dtype, dtype)


### PR DESCRIPTION
Hello,

I have created support for noisy dense since 5 Aug. It was published in https://github.com/tensorflow/tensorflow/pull/42069, but reviewers told me that it must be in tensorflow/addons repository instead of tensorflow/tensorflow. Meantime, somebody created a very similar implementation of this.

@fchollet @pavithrasv 

Here is my original post from tensorflow/tensorflow PR:

> Hello, 

>   I implemented NoisyNet layers into Keras API. It's useful for users, that experiments with reinforcement learning algorithms (NoisyDQN or NoisyA3C). For more information, I made a description of those layers in the code.

> ## Links
> [Noisy Networks for Exploration](https://arxiv.org/abs/1706.10295)

> ## Chart
> ![W B Chart 29  8  2020, 11 06 32](https://user-images.githubusercontent.com/16693449/91633376-21625b80-e9e8-11ea-99ba-efc7711e244a.png)

> NoisyNet is faster finding the optimal policy than Deep Q networks with epsilon-greedy.

> ## Example of usage
> [Noisy DQN MazeSolver](https://github.com/markub3327/DQN_MazeSolver)