### PR TITLE
Add TF2.2 testing

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -40,7 +40,7 @@ jobs:
       matrix:
         os: ['macos-latest', 'windows-latest', 'ubuntu-18.04']
         py-version: ['3.5', '3.6', '3.7', '3.8']
-        tf-version: ['2.3.0']
+        tf-version: ['2.2.0', '2.3.0']
       fail-fast: false
     steps:
       - uses: actions/github-script@0.3.0

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -34,7 +34,7 @@ jobs:
           python configure.py
           bazel test -c opt -k --test_timeout 300,450,1200,3600 --test_output=errors //tensorflow_addons/...
   release-wheel:
-    name: Build release wheels
+    name: Test and build release wheels
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:


### PR DESCRIPTION
# Description

Per our compatibility matrix we want to test both TF2.2 and TF2.3 (TF2.4rc soon as well). This change will make it so wheels are built and tested against 2.2 and 2.3, but we will only publish the 2.3 built wheels as per the compatibility matrix. 

The testing is kind of buried in the build so I updated the Action name to be more clear about what it's doing.