### PR TITLE
Support empty batches in ResamplerOp

### DIFF
--- a/tensorflow_addons/image/tests/resampler_ops_test.py
+++ b/tensorflow_addons/image/tests/resampler_ops_test.py
@@ -211,3 +211,28 @@ def test_op_backward_pass(dtype):
         test_utils.assert_allclose_according_to_type(
             t, n, float_rtol=5e-5, float_atol=5e-5
         )
+
+
+@pytest.mark.with_device(["cpu", "gpu"])
+def test_op_empty_batch():
+    np.random.seed(13)
+    data_width = 5
+    data_height = 4
+    data_channels = 3
+    warp_width = 2
+    warp_height = 6
+    batch_size = 0
+    dtype = np.float32
+
+    warp = _make_warp(batch_size, warp_height, warp_width, dtype)
+    data_shape = (batch_size, data_height, data_width, data_channels)
+    data = np.zeros(data_shape).astype(dtype)
+    data_tensor = tf.constant(data)
+    warp_tensor = tf.constant(warp)
+    with tf.GradientTape() as tape:
+        tape.watch(data_tensor)
+        tape.watch(warp_tensor)
+        outputs = resampler_ops.resampler(data=data_tensor, warp=warp_tensor)
+    data_grad, warp_grad = tape.gradient(outputs, (data_tensor, warp_tensor))
+    assert data_grad.shape == data.shape
+    assert warp_grad.shape == warp.shape


### PR DESCRIPTION
# Description

Empty batches are possible in distributed synchronous training. If some
replicas have run out of data while some haven't, tf.distribute produces
empty batches so that the training can proceed.

Fixes # (issue)

## Type of change

- [x] Bug fix

# Checklist:

- [x] I've properly [formatted my code according to the guidelines](https://github.com/tensorflow/addons/blob/master/CONTRIBUTING.md#coding-style)
    - [ ] By running Black + Flake8
    - [x] By running pre-commit hooks
- [ ] This PR addresses an already submitted issue for TensorFlow Addons
- [ ] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] This PR contains modifications to C++ custom-ops

# How Has This Been Tested?

unit test

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tensorflow/addons/2219)
<!-- Reviewable:end -->
