### PR TITLE
PyPi upload skip if exists

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -94,6 +94,7 @@ jobs:
           sha256sum dist/*.whl
       - uses: pypa/gh-action-pypi-publish@v1.1.0
         with:
+          skip_existing: true
           user: __token__
           password: ${{ secrets.pypi_token }}
   upload-dev-container:


### PR DESCRIPTION
# Description

This partially addresses #2222 but does not actually fix windows nightlies. It will come in handy though we we restart builds due to some other flaky failure.

https://github.com/pypa/gh-action-pypi-publish/blob/master/README.md#tolerating-release-package-file-duplicates