### PR TITLE
Drop TF2.2 compatibility

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -34,7 +34,7 @@ jobs:
           python configure.py
           bazel test -c opt -k --test_timeout 300,450,1200,3600 --test_output=errors //tensorflow_addons/...
   release-wheel:
-    name: Build release wheels
+    name: Test and build release wheels
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:

--- a/README.md
+++ b/README.md
@@ -80,7 +80,7 @@ what it was tested against.
 #### Python Op Compatibility Matrix
 | TensorFlow Addons | TensorFlow | Python  |
 |:----------------------- |:---|:---------- |
-| tfa-nightly | 2.2, 2.3 | 3.6, 3.7, 3.8 | 
+| tfa-nightly | 2.3 | 3.6, 3.7, 3.8 | 
 | tensorflow-addons-0.11.2 | 2.2, 2.3 |3.5, 3.6, 3.7, 3.8 |
 | tensorflow-addons-0.10.0 | 2.2 |3.5, 3.6, 3.7, 3.8 |
 | tensorflow-addons-0.9.1 | 2.1, 2.2 |3.5, 3.6, 3.7 |


### PR DESCRIPTION
# Description

As found in https://github.com/tensorflow/addons/pull/2205 we are no longer TF2.2 compatible. Going forward we should make sure we include previous TF versions in the build tests. I've rewritten the doc string so the intended use of that CI Action is known.

## Type of change

- [ ] Bug fix
- [ ] New Tutorial
- [x] Updated or additional documentation
- [ ] Additional Testing

# Checklist:

- [x] I've properly [formatted my code according to the guidelines](https://github.com/tensorflow/addons/blob/master/CONTRIBUTING.md#coding-style)
    - [ ] By running Black + Flake8
    - [x] By running pre-commit hooks
- [ ] This PR addresses an already submitted issue for TensorFlow Addons
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] This PR contains modifications to C++ custom-ops
