### PR TITLE
Update testing dependency

### DIFF
--- a/tools/install_deps/pytest.txt
+++ b/tools/install_deps/pytest.txt
@@ -2,6 +2,6 @@ pytest~=5.3
 pytest-xdist~=1.31
 pytest-extra-durations~=0.1.3
 scikit-learn~=0.22
-scikit-image~=0.15.0
+scikit-image~=0.17.0
 Pillow~=7.0.0
 tqdm>=4.36.1


### PR DESCRIPTION
# Description

MacOS py3.8 is failing to pip install scikit-image for testing. Should be no issue in upgrading this testing dependency.

## Type of change

- [x] Bug fix
