### PR TITLE
Test against TF2.4

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -40,7 +40,7 @@ jobs:
       matrix:
         os: ['macos-latest', 'windows-latest', 'ubuntu-18.04']
         py-version: ['3.6', '3.7', '3.8']
-        tf-version: ['2.3.0']
+        tf-version: ['2.3.0', '2.4.0rc0']
       fail-fast: false
     steps:
       - uses: actions/github-script@0.3.0

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -40,7 +40,7 @@ jobs:
       matrix:
         os: ['macos-latest', 'windows-latest', 'ubuntu-18.04']
         py-version: ['3.6', '3.7', '3.8']
-        tf-version: ['2.3.0', '2.4.0rc0']
+        tf-version: ['2.3.0', '2.4.0rc2']
       fail-fast: false
     steps:
       - uses: actions/github-script@0.3.0

--- a/tensorflow_addons/version.py
+++ b/tensorflow_addons/version.py
@@ -15,8 +15,8 @@
 """Define TensorFlow Addons version information."""
 
 # Required TensorFlow version [min, max)
-MIN_TF_VERSION = "2.2.0"
-MAX_TF_VERSION = "2.4.0"
+MIN_TF_VERSION = "2.3.0"
+MAX_TF_VERSION = "2.5.0"
 
 # We follow Semantic Versioning (https://semver.org/)
 _MAJOR_VERSION = "0"


### PR DESCRIPTION
# Description

Starting this PR to see if there are any issues. A number of version strings will need to be upgraded once TF2.4 is out of release-candidate using https://github.com/tensorflow/addons/blob/master/tools/update_release_version.sh

FWIW there are expected issues here and we'll need to build our GPU kernels against CUDA11. Can use this PR to troubleshoot though.