### PR TITLE
Fixes MCC during graph execution.

### DIFF
--- a/tensorflow_addons/metrics/matthews_correlation_coefficient.py
+++ b/tensorflow_addons/metrics/matthews_correlation_coefficient.py
@@ -14,6 +14,8 @@
 # ==============================================================================
 """Matthews Correlation Coefficient Implementation."""
 
+import numpy as np
+
 import tensorflow as tf
 from tensorflow.keras import backend as K
 
@@ -148,5 +150,5 @@ class MatthewsCorrelationCoefficient(tf.keras.metrics.Metric):
 
     def reset_states(self):
         """Resets all of the metric state variables."""
-        reset_value = tf.zeros(self.num_classes, dtype=self.dtype)
+        reset_value = np.zeros(self.num_classes, dtype=self.dtype)
         K.batch_set_value([(v, reset_value) for v in self.variables])

--- a/tensorflow_addons/metrics/tests/matthews_correlation_coefficient_test.py
+++ b/tensorflow_addons/metrics/tests/matthews_correlation_coefficient_test.py
@@ -14,7 +14,6 @@
 # ==============================================================================
 """Matthews Correlation Coefficient Test."""
 
-
 import tensorflow as tf
 
 import numpy as np
@@ -78,3 +77,18 @@ def test_keras_model():
     labels = np.random.random((10, 1))
     labels = np.where(labels > 0.5, 1.0, 0.0)
     model.fit(data, labels, epochs=1, batch_size=32, verbose=0)
+
+
+def test_reset_states_graph():
+    gt_label = tf.constant([[1.0], [1.0], [1.0], [0.0]], dtype=tf.float32)
+    preds = tf.constant([[1.0], [0.0], [1.0], [1.0]], dtype=tf.float32)
+    mcc = MatthewsCorrelationCoefficient(1)
+    mcc.update_state(gt_label, preds)
+
+    @tf.function
+    def reset_states():
+        mcc.reset_states()
+
+    reset_states()
+    # Check results
+    check_results(mcc, [0])


### PR DESCRIPTION
# Description

Brief Description of the PR:

Fixes # (issue)

## Type of change

- [X] Bug fix
- [ ] New Tutorial
- [ ] Updated or additional documentation
- [x] Additional Testing
- [ ] New Activation and the changes conform to the [activation contribution guidelines](https://github.com/tensorflow/addons/blob/master/tensorflow_addons/activations/README.md#contribution-guidelines)
- [ ] New Callback and the changes conform to the [callback contribution guidelines](https://github.com/tensorflow/addons/blob/master/tensorflow_addons/callbacks/README.md#contribution-guidelines)
- [ ] New Image addition and the changes conform to the [image op contribution guidelines](https://github.com/tensorflow/addons/blob/master/tensorflow_addons/image/README.md#contribution-guidelines)
- [ ] New Layer and the changes conform to the [layer contribution guidelines](https://github.com/tensorflow/addons/blob/master/tensorflow_addons/layers/README.md#contribution-guidelines)
- [ ] New Loss and the changes conform to the [loss contribution guidelines](https://github.com/tensorflow/addons/blob/master/tensorflow_addons/losses/README.md#contribution-guidelines)
- [ ] New Metric and the changes conform to the [metric contribution guidelines](https://github.com/tensorflow/addons/blob/master/tensorflow_addons/metrics/README.md#contribution-guidelines)
- [ ] New Optimizer and the changes conform to the [optimizer contribution guidelines](https://github.com/tensorflow/addons/blob/master/tensorflow_addons/optimizers/README.md#contribution-guidelines)
- [ ] New RNN Cell and the changes conform to the [rnn contribution guidelines](https://github.com/tensorflow/addons/blob/master/tensorflow_addons/rnn/README.md#contribution-guidelines)
- [ ] New Seq2seq addition and the changes conform to the [seq2seq contribution guidelines](https://github.com/tensorflow/addons/blob/master/tensorflow_addons/seq2seq/README.md#contribution-guidelines)
- [ ] New Text addition and the changes conform to the [text op contribution guidelines](https://github.com/tensorflow/addons/blob/master/tensorflow_addons/text/README.md#contribution-guidelines)

# Checklist:

- [X] I've properly [formatted my code according to the guidelines](https://github.com/tensorflow/addons/blob/master/CONTRIBUTING.md#coding-style)
    - [X] By running Black + Flake8
    - [X] By running pre-commit hooks
- [ ] This PR addresses an already submitted issue for TensorFlow Addons
- [ ] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] This PR contains modifications to C++ custom-ops

# How Has This Been Tested?

If you're adding a bugfix or new feature please describe the tests that you ran to verify your changes:
*  

As per the [documentation](https://www.tensorflow.org/api_docs/python/tf/keras/backend/batch_set_value), the values in `batch_set_value` should be a numpy array. Passing a `tf.Tensor` throws the following exception when not running eagerly:
`TypeError: __array__() takes 1 positional argument but 2 were given`

This can easily be reproduced by either disabling eager exeuction, or by subclassing MCC and decorating `reset_states` with `tf.function` like so:
```
class MyMCC(tfa.metrics.MatthewsCorrelationCoefficient):

    @tf.function
    def reset_states(self):
        """Resets all of the metric state variables."""
        reset_value = tf.zeros((self.num_classes,), dtype=self.dtype)
        tf.keras.backend.batch_set_value(((v, reset_value) for v in self.variables))

mcc = MyMCC(num_classes=1)
mcc.reset_states() # Throws TypeError
```