### PR TITLE
Fix typo in test_keras_binary_classification_model() name

### DIFF
--- a/tensorflow_addons/metrics/tests/cohens_kappa_test.py
+++ b/tensorflow_addons/metrics/tests/cohens_kappa_test.py
@@ -189,7 +189,7 @@ def test_keras_multiclass_reg_model():
 
 
 @pytest.mark.usefixtures("maybe_run_functions_eagerly")
-def test_keras_binary_clasasification_model():
+def test_keras_binary_classification_model():
     kp = CohenKappa(num_classes=2)
     inputs = tf.keras.layers.Input(shape=(10,))
     outputs = tf.keras.layers.Dense(1, activation="sigmoid")(inputs)


### PR DESCRIPTION
Fixes #2235, which is a minor typo.