### PR TITLE
Change GroupNormalization default groups to 32.

### DIFF
--- a/tensorflow_addons/layers/normalizations.py
+++ b/tensorflow_addons/layers/normalizations.py
@@ -74,7 +74,7 @@ class GroupNormalization(tf.keras.layers.Layer):
     @typechecked
     def __init__(
         self,
-        groups: int = 2,
+        groups: int = 32,
         axis: int = -1,
         epsilon: float = 1e-3,
         center: bool = True,

--- a/tensorflow_addons/layers/normalizations.py
+++ b/tensorflow_addons/layers/normalizations.py
@@ -25,6 +25,9 @@ from tensorflow_addons.utils import types
 @tf.keras.utils.register_keras_serializable(package="Addons")
 class GroupNormalization(tf.keras.layers.Layer):
     """Group normalization layer.
+    
+    Source: "Group Normalization" (Yuxin Wu & Kaiming He, 2018)
+    https://arxiv.org/abs/1803.08494
 
     Group Normalization divides the channels into groups and computes
     within each group the mean and variance for normalization.
@@ -46,6 +49,7 @@ class GroupNormalization(tf.keras.layers.Layer):
         groups: Integer, the number of groups for Group Normalization.
             Can be in the range [1, N] where N is the input dimension.
             The input dimension must be divisible by the number of groups.
+            Defaults to 32.
         axis: Integer, the axis that should be normalized.
         epsilon: Small float added to variance to avoid dividing by zero.
         center: If True, add offset of `beta` to normalized tensor.

--- a/tensorflow_addons/layers/normalizations.py
+++ b/tensorflow_addons/layers/normalizations.py
@@ -25,7 +25,7 @@ from tensorflow_addons.utils import types
 @tf.keras.utils.register_keras_serializable(package="Addons")
 class GroupNormalization(tf.keras.layers.Layer):
     """Group normalization layer.
-    
+
     Source: "Group Normalization" (Yuxin Wu & Kaiming He, 2018)
     https://arxiv.org/abs/1803.08494
 

--- a/tensorflow_addons/layers/normalizations.py
+++ b/tensorflow_addons/layers/normalizations.py
@@ -26,9 +26,6 @@ from tensorflow_addons.utils import types
 class GroupNormalization(tf.keras.layers.Layer):
     """Group normalization layer.
 
-    Source: "Group Normalization" (Yuxin Wu & Kaiming He, 2018)
-    https://arxiv.org/abs/1803.08494
-
     Group Normalization divides the channels into groups and computes
     within each group the mean and variance for normalization.
     Empirically, its accuracy is more stable than batch norm in a wide

--- a/tensorflow_addons/layers/normalizations.py
+++ b/tensorflow_addons/layers/normalizations.py
@@ -26,6 +26,9 @@ from tensorflow_addons.utils import types
 class GroupNormalization(tf.keras.layers.Layer):
     """Group normalization layer.
 
+    Source: "Group Normalization" (Yuxin Wu & Kaiming He, 2018)
+    https://arxiv.org/abs/1803.08494
+
     Group Normalization divides the channels into groups and computes
     within each group the mean and variance for normalization.
     Empirically, its accuracy is more stable than batch norm in a wide
@@ -67,9 +70,6 @@ class GroupNormalization(tf.keras.layers.Layer):
 
     Output shape:
         Same shape as input.
-
-    References:
-        - [Group Normalization](https://arxiv.org/abs/1803.08494)
     """
 
     @typechecked

--- a/tensorflow_addons/layers/tests/normalizations_test.py
+++ b/tensorflow_addons/layers/tests/normalizations_test.py
@@ -251,7 +251,9 @@ def test_regularizations():
     layer.build((None, 4, 4))
     assert len(layer.losses) == 2
     max_norm = tf.keras.constraints.max_norm
-    layer = GroupNormalization(gamma_constraint=max_norm, beta_constraint=max_norm)
+    layer = GroupNormalization(
+        groups=2, gamma_constraint=max_norm, beta_constraint=max_norm
+    )
     layer.build((None, 3, 4))
     assert layer.gamma.constraint == max_norm
     assert layer.beta.constraint == max_norm


### PR DESCRIPTION
This changes the default `groups` parameter to `32`, as recommended by the authors of [Group Normalization](https://arxiv.org/abs/1803.08494).

Fixes #2240

- [x] This PR addresses an already submitted issue for TensorFlow Addons

