### PR TITLE
make MultiHeadAttention agnostic to dtype (float32 vs. float16)

### DIFF
--- a/tensorflow_addons/layers/multihead_attention.py
+++ b/tensorflow_addons/layers/multihead_attention.py
@@ -216,7 +216,7 @@ class MultiHeadAttention(tf.keras.layers.Layer):
 
         # Scale dot-product, doing the division to either query or key
         # instead of their product saves some computation
-        depth = tf.constant(self.head_size, dtype=tf.float32)
+        depth = tf.constant(self.head_size, dtype=query.dtype)
         query /= tf.sqrt(depth)
 
         # Calculate dot product attention

--- a/tensorflow_addons/layers/tests/multihead_attention_test.py
+++ b/tensorflow_addons/layers/tests/multihead_attention_test.py
@@ -279,6 +279,7 @@ def test_save_load_model():
     assert model.layers[1].get_config() == new_model.layers[1].get_config()
 
 
+@pytest.mark.usefixtures("run_with_mixed_precision_policy")
 def test_fit_predict_eval():
 
     num_heads = 8


### PR DESCRIPTION
# Description

I was running with mixed precision (using `float16`s) and MultiHeadAttention caused me a mismatch error (`TypeError: x and y must have the same dtype, got tf.float16 != tf.float32`).

There might be a reason this layer absolutely needs to be float32 (for better precision). But if not, it would be nice to add the flexibility by using use `query`'s dtype instead of defaulting to `tf.float32` for the `depth` constant (see commit).

## Type of change

- [x] Bug fix
- [ ] New Tutorial
- [ ] Updated or additional documentation
- [ ] Additional Testing
- [ ] New Activation and the changes conform to the [activation contribution guidelines](https://github.com/tensorflow/addons/blob/master/tensorflow_addons/activations/README.md#contribution-guidelines)
- [ ] New Callback and the changes conform to the [callback contribution guidelines](https://github.com/tensorflow/addons/blob/master/tensorflow_addons/callbacks/README.md#contribution-guidelines)
- [ ] New Image addition and the changes conform to the [image op contribution guidelines](https://github.com/tensorflow/addons/blob/master/tensorflow_addons/image/README.md#contribution-guidelines)
- [ ] New Layer and the changes conform to the [layer contribution guidelines](https://github.com/tensorflow/addons/blob/master/tensorflow_addons/layers/README.md#contribution-guidelines)
- [ ] New Loss and the changes conform to the [loss contribution guidelines](https://github.com/tensorflow/addons/blob/master/tensorflow_addons/losses/README.md#contribution-guidelines)
- [ ] New Metric and the changes conform to the [metric contribution guidelines](https://github.com/tensorflow/addons/blob/master/tensorflow_addons/metrics/README.md#contribution-guidelines)
- [ ] New Optimizer and the changes conform to the [optimizer contribution guidelines](https://github.com/tensorflow/addons/blob/master/tensorflow_addons/optimizers/README.md#contribution-guidelines)
- [ ] New RNN Cell and the changes conform to the [rnn contribution guidelines](https://github.com/tensorflow/addons/blob/master/tensorflow_addons/rnn/README.md#contribution-guidelines)
- [ ] New Seq2seq addition and the changes conform to the [seq2seq contribution guidelines](https://github.com/tensorflow/addons/blob/master/tensorflow_addons/seq2seq/README.md#contribution-guidelines)
- [ ] New Text addition and the changes conform to the [text op contribution guidelines](https://github.com/tensorflow/addons/blob/master/tensorflow_addons/text/README.md#contribution-guidelines)

# Checklist:

- [x] I've properly [formatted my code according to the guidelines](https://github.com/tensorflow/addons/blob/master/CONTRIBUTING.md#coding-style)
    - [ ] By running Black + Flake8
    - [ ] By running pre-commit hooks
- [ ] This PR addresses an already submitted issue for TensorFlow Addons
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] This PR contains modifications to C++ custom-ops

# How Has This Been Tested?

I made the change on my local machine and it resolved the error I was having. Also, it should not change the default behavior, since `query` is by default `tf.float32`. It should only have an effect when using `tf.float16`, etc, and that case is currently broken anyway.
