### PR TITLE
 Bump target py versions for black

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [tool.black]
-target-version = ['py35', 'py36', 'py37']
+target-version = ['py36', 'py37', 'py38']
 exclude = '''
 (
   /(

--- a/tensorflow_addons/callbacks/average_model_checkpoint.py
+++ b/tensorflow_addons/callbacks/average_model_checkpoint.py
@@ -47,7 +47,7 @@ class AverageModelCheckpoint(tf.keras.callbacks.ModelCheckpoint):
         save_weights_only: bool = False,
         mode: str = "auto",
         save_freq: str = "epoch",
-        **kwargs
+        **kwargs,
     ):
         self.update_weights = update_weights
         super().__init__(

--- a/tensorflow_addons/layers/adaptive_pooling.py
+++ b/tensorflow_addons/layers/adaptive_pooling.py
@@ -45,7 +45,7 @@ class AdaptivePooling1D(tf.keras.layers.Layer):
         reduce_function: Callable,
         output_size: Union[int, Iterable[int]],
         data_format=None,
-        **kwargs
+        **kwargs,
     ):
         self.data_format = conv_utils.normalize_data_format(data_format)
         self.reduce_function = reduce_function
@@ -178,7 +178,7 @@ class AdaptivePooling2D(tf.keras.layers.Layer):
         reduce_function: Callable,
         output_size: Union[int, Iterable[int]],
         data_format=None,
-        **kwargs
+        **kwargs,
     ):
         self.data_format = conv_utils.normalize_data_format(data_format)
         self.reduce_function = reduce_function
@@ -326,7 +326,7 @@ class AdaptivePooling3D(tf.keras.layers.Layer):
         reduce_function: Callable,
         output_size: Union[int, Iterable[int]],
         data_format=None,
-        **kwargs
+        **kwargs,
     ):
         self.data_format = conv_utils.normalize_data_format(data_format)
         self.reduce_function = reduce_function

--- a/tensorflow_addons/layers/crf.py
+++ b/tensorflow_addons/layers/crf.py
@@ -69,7 +69,7 @@ class CRF(tf.keras.layers.Layer):
         use_boundary: bool = True,
         boundary_initializer: types.Initializer = "zeros",
         use_kernel: bool = True,
-        **kwargs
+        **kwargs,
     ):
         super().__init__(**kwargs)
 

--- a/tensorflow_addons/layers/esn.py
+++ b/tensorflow_addons/layers/esn.py
@@ -108,7 +108,7 @@ class ESN(tf.keras.layers.RNN):
         return_sequences=False,
         go_backwards=False,
         unroll=False,
-        **kwargs
+        **kwargs,
     ):
         cell = ESNCell(
             units,

--- a/tensorflow_addons/layers/multihead_attention.py
+++ b/tensorflow_addons/layers/multihead_attention.py
@@ -95,7 +95,7 @@ class MultiHeadAttention(tf.keras.layers.Layer):
         bias_initializer: typing.Union[str, typing.Callable] = "zeros",
         bias_regularizer: typing.Union[str, typing.Callable] = None,
         bias_constraint: typing.Union[str, typing.Callable] = None,
-        **kwargs
+        **kwargs,
     ):
         warnings.warn(
             "`MultiHeadAttention` will be deprecated in Addons 0.13. "

--- a/tensorflow_addons/layers/noisy_dense.py
+++ b/tensorflow_addons/layers/noisy_dense.py
@@ -109,7 +109,7 @@ class NoisyDense(tf.keras.layers.Dense):
         activity_regularizer: types.Regularizer = None,
         kernel_constraint: types.Constraint = None,
         bias_constraint: types.Constraint = None,
-        **kwargs
+        **kwargs,
     ):
         super().__init__(
             units=units,

--- a/tensorflow_addons/layers/normalizations.py
+++ b/tensorflow_addons/layers/normalizations.py
@@ -86,7 +86,7 @@ class GroupNormalization(tf.keras.layers.Layer):
         gamma_regularizer: types.Regularizer = None,
         beta_constraint: types.Constraint = None,
         gamma_constraint: types.Constraint = None,
-        **kwargs
+        **kwargs,
     ):
         super().__init__(**kwargs)
         self.supports_masking = True
@@ -395,7 +395,7 @@ class FilterResponseNormalization(tf.keras.layers.Layer):
         learned_epsilon: bool = False,
         learned_epsilon_constraint: types.Constraint = None,
         name: str = None,
-        **kwargs
+        **kwargs,
     ):
         super().__init__(name=name, **kwargs)
         self.epsilon = tf.math.abs(tf.cast(epsilon, dtype=self.dtype))

--- a/tensorflow_addons/layers/optical_flow.py
+++ b/tensorflow_addons/layers/optical_flow.py
@@ -166,7 +166,7 @@ class CorrelationCost(tf.keras.layers.Layer):
         stride_2: int,
         pad: int,
         data_format: str,
-        **kwargs
+        **kwargs,
     ):
         self.kernel_size = kernel_size
         self.max_displacement = max_displacement

--- a/tensorflow_addons/layers/polynomial.py
+++ b/tensorflow_addons/layers/polynomial.py
@@ -81,7 +81,7 @@ class PolynomialCrossing(tf.keras.layers.Layer):
         bias_initializer: types.Initializer = "zeros",
         kernel_regularizer: types.Regularizer = None,
         bias_regularizer: types.Regularizer = None,
-        **kwargs
+        **kwargs,
     ):
         super(PolynomialCrossing, self).__init__(**kwargs)
 

--- a/tensorflow_addons/layers/spatial_pyramid_pooling.py
+++ b/tensorflow_addons/layers/spatial_pyramid_pooling.py
@@ -66,7 +66,7 @@ class SpatialPyramidPooling2D(tf.keras.layers.Layer):
         bins: Union[Iterable[int], Iterable[Iterable[int]]],
         data_format=None,
         *args,
-        **kwargs
+        **kwargs,
     ):
         self.bins = [conv_utils.normalize_tuple(bin, 2, "bin") for bin in bins]
         self.data_format = conv_utils.normalize_data_format(data_format)

--- a/tensorflow_addons/layers/tlu.py
+++ b/tensorflow_addons/layers/tlu.py
@@ -51,7 +51,7 @@ class TLU(tf.keras.layers.Layer):
         alpha_initializer: types.Initializer = "zeros",
         alpha_regularizer: types.Regularizer = None,
         alpha_constraint: types.Constraint = None,
-        **kwargs
+        **kwargs,
     ):
         super().__init__(**kwargs)
         self.supports_masking = True

--- a/tensorflow_addons/losses/triplet.py
+++ b/tensorflow_addons/losses/triplet.py
@@ -333,7 +333,7 @@ class TripletSemiHardLoss(LossFunctionWrapper):
         margin: FloatTensorLike = 1.0,
         distance_metric: Union[str, Callable] = "L2",
         name: Optional[str] = None,
-        **kwargs
+        **kwargs,
     ):
         super().__init__(
             triplet_semihard_loss,
@@ -372,7 +372,7 @@ class TripletHardLoss(LossFunctionWrapper):
         soft: bool = False,
         distance_metric: Union[str, Callable] = "L2",
         name: Optional[str] = None,
-        **kwargs
+        **kwargs,
     ):
         super().__init__(
             triplet_hard_loss,

--- a/tensorflow_addons/metrics/f_scores.py
+++ b/tensorflow_addons/metrics/f_scores.py
@@ -96,7 +96,7 @@ class FBetaScore(tf.keras.metrics.Metric):
         threshold: Optional[FloatTensorLike] = None,
         name: str = "fbeta_score",
         dtype: AcceptableDTypes = None,
-        **kwargs
+        **kwargs,
     ):
         super().__init__(name=name, dtype=dtype)
 

--- a/tensorflow_addons/metrics/hamming.py
+++ b/tensorflow_addons/metrics/hamming.py
@@ -156,7 +156,7 @@ class HammingLoss(MeanMetricWrapper):
         name: str = "hamming_loss",
         threshold: Optional[FloatTensorLike] = None,
         dtype: AcceptableDTypes = None,
-        **kwargs
+        **kwargs,
     ):
         super().__init__(
             hamming_loss_fn, name=name, dtype=dtype, mode=mode, threshold=threshold

--- a/tensorflow_addons/metrics/matthews_correlation_coefficient.py
+++ b/tensorflow_addons/metrics/matthews_correlation_coefficient.py
@@ -65,7 +65,7 @@ class MatthewsCorrelationCoefficient(tf.keras.metrics.Metric):
         num_classes: FloatTensorLike,
         name: str = "MatthewsCorrelationCoefficient",
         dtype: AcceptableDTypes = None,
-        **kwargs
+        **kwargs,
     ):
         """Creates a Matthews Correlation Coefficient instance."""
         super().__init__(name=name, dtype=dtype)

--- a/tensorflow_addons/metrics/multilabel_confusion_matrix.py
+++ b/tensorflow_addons/metrics/multilabel_confusion_matrix.py
@@ -92,7 +92,7 @@ class MultiLabelConfusionMatrix(Metric):
         num_classes: FloatTensorLike,
         name: str = "Multilabel_confusion_matrix",
         dtype: AcceptableDTypes = None,
-        **kwargs
+        **kwargs,
     ):
         super().__init__(name=name, dtype=dtype)
         self.num_classes = num_classes

--- a/tensorflow_addons/metrics/r_square.py
+++ b/tensorflow_addons/metrics/r_square.py
@@ -83,7 +83,7 @@ class RSquare(Metric):
         dtype: AcceptableDTypes = None,
         y_shape: Tuple[int, ...] = (),
         multioutput: str = "uniform_average",
-        **kwargs
+        **kwargs,
     ):
         super().__init__(name=name, dtype=dtype, **kwargs)
         self.y_shape = y_shape

--- a/tensorflow_addons/metrics/utils.py
+++ b/tensorflow_addons/metrics/utils.py
@@ -31,7 +31,7 @@ class MeanMetricWrapper(tf.keras.metrics.Mean):
         fn: Callable,
         name: Optional[str] = None,
         dtype: AcceptableDTypes = None,
-        **kwargs
+        **kwargs,
     ):
         """Creates a `MeanMetricWrapper` instance.
         Args:

--- a/tensorflow_addons/optimizers/conditional_gradient.py
+++ b/tensorflow_addons/optimizers/conditional_gradient.py
@@ -60,7 +60,7 @@ class ConditionalGradient(tf.keras.optimizers.Optimizer):
         epsilon: FloatTensorLike = 1e-7,
         ord: str = "fro",
         name: str = "ConditionalGradient",
-        **kwargs
+        **kwargs,
     ):
         """Construct a new conditional gradient optimizer.
 

--- a/tensorflow_addons/optimizers/discriminative_layer_training.py
+++ b/tensorflow_addons/optimizers/discriminative_layer_training.py
@@ -79,7 +79,7 @@ class MultiOptimizer(tf.keras.optimizers.Optimizer):
         optimizers_and_layers: Union[list, None] = None,
         optimizer_specs: Union[list, None] = None,
         name: str = "MultiOptimizer",
-        **kwargs
+        **kwargs,
     ):
 
         super(MultiOptimizer, self).__init__(name, **kwargs)

--- a/tensorflow_addons/optimizers/lamb.py
+++ b/tensorflow_addons/optimizers/lamb.py
@@ -45,7 +45,7 @@ class LAMB(tf.keras.optimizers.Optimizer):
         exclude_from_weight_decay: Optional[List[str]] = None,
         exclude_from_layer_adaptation: Optional[List[str]] = None,
         name: str = "LAMB",
-        **kwargs
+        **kwargs,
     ):
         """Construct a new LAMB optimizer.
 

--- a/tensorflow_addons/optimizers/lazy_adam.py
+++ b/tensorflow_addons/optimizers/lazy_adam.py
@@ -55,7 +55,7 @@ class LazyAdam(tf.keras.optimizers.Adam):
         epsilon: FloatTensorLike = 1e-7,
         amsgrad: bool = False,
         name: str = "LazyAdam",
-        **kwargs
+        **kwargs,
     ):
         """Constructs a new LazyAdam optimizer.
 

--- a/tensorflow_addons/optimizers/lookahead.py
+++ b/tensorflow_addons/optimizers/lookahead.py
@@ -47,7 +47,7 @@ class Lookahead(tf.keras.optimizers.Optimizer):
         sync_period: int = 6,
         slow_step_size: types.FloatTensorLike = 0.5,
         name: str = "Lookahead",
-        **kwargs
+        **kwargs,
     ):
         r"""Wrap optimizer with the lookahead mechanism.
 

--- a/tensorflow_addons/optimizers/moving_average.py
+++ b/tensorflow_addons/optimizers/moving_average.py
@@ -50,7 +50,7 @@ class MovingAverage(AveragedOptimizerWrapper):
         start_step: int = 0,
         dynamic_decay: bool = False,
         name: str = "MovingAverage",
-        **kwargs
+        **kwargs,
     ):
         r"""Construct a new MovingAverage optimizer.
 

--- a/tensorflow_addons/optimizers/novograd.py
+++ b/tensorflow_addons/optimizers/novograd.py
@@ -78,7 +78,7 @@ class NovoGrad(tf.keras.optimizers.Optimizer):
         grad_averaging: bool = False,
         amsgrad: bool = False,
         name: str = "NovoGrad",
-        **kwargs
+        **kwargs,
     ):
         r"""Construct a new NovoGrad optimizer.
 

--- a/tensorflow_addons/optimizers/proximal_adagrad.py
+++ b/tensorflow_addons/optimizers/proximal_adagrad.py
@@ -39,7 +39,7 @@ class ProximalAdagrad(tf.keras.optimizers.Optimizer):
         l1_regularization_strength: float = 0.0,
         l2_regularization_strength: float = 0.0,
         name: str = "ProximalAdagrad",
-        **kwargs
+        **kwargs,
     ):
         """Construct a new Proximal Adagrad optimizer.
 

--- a/tensorflow_addons/optimizers/rectified_adam.py
+++ b/tensorflow_addons/optimizers/rectified_adam.py
@@ -82,7 +82,7 @@ class RectifiedAdam(tf.keras.optimizers.Optimizer):
         warmup_proportion: FloatTensorLike = 0.1,
         min_lr: FloatTensorLike = 0.0,
         name: str = "RectifiedAdam",
-        **kwargs
+        **kwargs,
     ):
         r"""Construct a new RAdam optimizer.
 

--- a/tensorflow_addons/optimizers/stochastic_weight_averaging.py
+++ b/tensorflow_addons/optimizers/stochastic_weight_averaging.py
@@ -78,7 +78,7 @@ class SWA(AveragedOptimizerWrapper):
         start_averaging: int = 0,
         average_period: int = 10,
         name: str = "SWA",
-        **kwargs
+        **kwargs,
     ):
         r"""Wrap optimizer with the Stochastic Weight Averaging mechanism.
 

--- a/tensorflow_addons/optimizers/tests/weight_decay_optimizers_test.py
+++ b/tensorflow_addons/optimizers/tests/weight_decay_optimizers_test.py
@@ -30,7 +30,7 @@ def do_test(
     update_fn,
     do_sparse=False,
     do_decay_var_list=False,
-    **optimizer_kwargs
+    **optimizer_kwargs,
 ):
     """The major test function.
 

--- a/tensorflow_addons/optimizers/weight_decay_optimizers.py
+++ b/tensorflow_addons/optimizers/weight_decay_optimizers.py
@@ -363,7 +363,7 @@ class SGDW(DecoupledWeightDecayExtension, tf.keras.optimizers.SGD):
         momentum: Union[FloatTensorLike, Callable] = 0.0,
         nesterov: bool = False,
         name: str = "SGDW",
-        **kwargs
+        **kwargs,
     ):
         """Construct a new SGDW optimizer.
 
@@ -443,7 +443,7 @@ class AdamW(DecoupledWeightDecayExtension, tf.keras.optimizers.Adam):
         epsilon: FloatTensorLike = 1e-07,
         amsgrad: bool = False,
         name: str = "AdamW",
-        **kwargs
+        **kwargs,
     ):
         """Construct a new AdamW optimizer.
 

--- a/tensorflow_addons/optimizers/yogi.py
+++ b/tensorflow_addons/optimizers/yogi.py
@@ -69,7 +69,7 @@ class Yogi(tf.keras.optimizers.Optimizer):
         initial_accumulator_value: FloatTensorLike = 1e-6,
         activation: str = "sign",
         name: str = "Yogi",
-        **kwargs
+        **kwargs,
     ):
         """Construct a new Yogi optimizer.
 

--- a/tensorflow_addons/rnn/esn_cell.py
+++ b/tensorflow_addons/rnn/esn_cell.py
@@ -91,7 +91,7 @@ class ESNCell(keras.layers.AbstractRNNCell):
         kernel_initializer: Initializer = "glorot_uniform",
         recurrent_initializer: Initializer = "glorot_uniform",
         bias_initializer: Initializer = "zeros",
-        **kwargs
+        **kwargs,
     ):
         super().__init__(**kwargs)
         self.units = units

--- a/tensorflow_addons/rnn/layer_norm_lstm_cell.py
+++ b/tensorflow_addons/rnn/layer_norm_lstm_cell.py
@@ -83,7 +83,7 @@ class LayerNormLSTMCell(keras.layers.LSTMCell):
         norm_gamma_initializer: Initializer = "ones",
         norm_beta_initializer: Initializer = "zeros",
         norm_epsilon: FloatTensorLike = 1e-3,
-        **kwargs
+        **kwargs,
     ):
         """Initializes the LSTM cell.
 

--- a/tensorflow_addons/rnn/layer_norm_simple_rnn_cell.py
+++ b/tensorflow_addons/rnn/layer_norm_simple_rnn_cell.py
@@ -136,7 +136,7 @@ class LayerNormSimpleRNNCell(keras.layers.SimpleRNNCell):
         gamma_constraint: Constraint = None,
         dropout: FloatTensorLike = 0.0,
         recurrent_dropout: FloatTensorLike = 0.0,
-        **kwargs
+        **kwargs,
     ):
         super(LayerNormSimpleRNNCell, self).__init__(
             units,

--- a/tensorflow_addons/rnn/nas_cell.py
+++ b/tensorflow_addons/rnn/nas_cell.py
@@ -66,7 +66,7 @@ class NASCell(keras.layers.AbstractRNNCell):
         recurrent_initializer: Initializer = "glorot_uniform",
         projection_initializer: Initializer = "glorot_uniform",
         bias_initializer: Initializer = "zeros",
-        **kwargs
+        **kwargs,
     ):
         """Initialize the parameters for a NAS cell.
 

--- a/tensorflow_addons/seq2seq/attention_wrapper.py
+++ b/tensorflow_addons/seq2seq/attention_wrapper.py
@@ -74,7 +74,7 @@ class AttentionMechanism(tf.keras.layers.Layer):
         query_layer: Optional[tf.keras.layers.Layer] = None,
         memory_layer: Optional[tf.keras.layers.Layer] = None,
         memory_sequence_length: Optional[TensorLike] = None,
-        **kwargs
+        **kwargs,
     ):
         """Construct base AttentionMechanism class.
 
@@ -514,7 +514,7 @@ class LuongAttention(AttentionMechanism):
         probability_fn: str = "softmax",
         dtype: AcceptableDTypes = None,
         name: str = "LuongAttention",
-        **kwargs
+        **kwargs,
     ):
         """Construct the AttentionMechanism mechanism.
 
@@ -690,7 +690,7 @@ class BahdanauAttention(AttentionMechanism):
         kernel_initializer: Initializer = "glorot_uniform",
         dtype: AcceptableDTypes = None,
         name: str = "BahdanauAttention",
-        **kwargs
+        **kwargs,
     ):
         """Construct the Attention mechanism.
 
@@ -1047,7 +1047,7 @@ class BahdanauMonotonicAttention(_BaseMonotonicAttentionMechanism):
         kernel_initializer: Initializer = "glorot_uniform",
         dtype: AcceptableDTypes = None,
         name: str = "BahdanauMonotonicAttention",
-        **kwargs
+        **kwargs,
     ):
         """Construct the attention mechanism.
 
@@ -1228,7 +1228,7 @@ class LuongMonotonicAttention(_BaseMonotonicAttentionMechanism):
         mode: str = "parallel",
         dtype: AcceptableDTypes = None,
         name: str = "LuongMonotonicAttention",
-        **kwargs
+        **kwargs,
     ):
         """Construct the attention mechanism.
 
@@ -1603,7 +1603,7 @@ class AttentionWrapper(tf.keras.layers.AbstractRNNCell):
             Union[tf.keras.layers.Layer, List[tf.keras.layers.Layer]]
         ] = None,
         attention_fn: Optional[Callable] = None,
-        **kwargs
+        **kwargs,
     ):
         """Construct the `AttentionWrapper`.
 

--- a/tensorflow_addons/seq2seq/basic_decoder.py
+++ b/tensorflow_addons/seq2seq/basic_decoder.py
@@ -101,7 +101,7 @@ class BasicDecoder(decoder.BaseDecoder):
         cell: tf.keras.layers.Layer,
         sampler: sampler_py.Sampler,
         output_layer: Optional[tf.keras.layers.Layer] = None,
-        **kwargs
+        **kwargs,
     ):
         """Initialize BasicDecoder.
 

--- a/tensorflow_addons/seq2seq/beam_search_decoder.py
+++ b/tensorflow_addons/seq2seq/beam_search_decoder.py
@@ -384,7 +384,7 @@ class BeamSearchDecoderMixin:
         coverage_penalty_weight: FloatTensorLike = 0.0,
         reorder_tensor_arrays: bool = True,
         output_all_scores: bool = False,
-        **kwargs
+        **kwargs,
     ):
         """Initialize the BeamSearchDecoderMixin.
 
@@ -795,7 +795,7 @@ class BeamSearchDecoder(BeamSearchDecoderMixin, decoder.BaseDecoder):
         length_penalty_weight: FloatTensorLike = 0.0,
         coverage_penalty_weight: FloatTensorLike = 0.0,
         reorder_tensor_arrays: bool = True,
-        **kwargs
+        **kwargs,
     ):
         """Initialize the BeamSearchDecoder.
 

--- a/tensorflow_addons/seq2seq/decoder.py
+++ b/tensorflow_addons/seq2seq/decoder.py
@@ -147,7 +147,7 @@ class BaseDecoder(tf.keras.layers.Layer):
         maximum_iterations: Optional[TensorLike] = None,
         parallel_iterations: int = 32,
         swap_memory: bool = False,
-        **kwargs
+        **kwargs,
     ):
         self.output_time_major = output_time_major
         self.impute_finished = impute_finished
@@ -267,7 +267,7 @@ def dynamic_decode(
     training: Optional[bool] = None,
     scope: Optional[str] = None,
     enable_tflite_convertible: bool = False,
-    **kwargs
+    **kwargs,
 ) -> Tuple[Any, Any, Any]:
     """Runs dynamic decoding with a decoder.
 


### PR DESCRIPTION
# Description

Since we no longer support py3.5 we can go ahead an increment the black formatting.

# Checklist:

- [x] I've properly [formatted my code according to the guidelines](https://github.com/tensorflow/addons/blob/master/CONTRIBUTING.md#coding-style)
    - [ ] By running Black + Flake8
    - [x] By running pre-commit hooks
- [ ] This PR addresses an already submitted issue for TensorFlow Addons
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] This PR contains modifications to C++ custom-ops

