### PR TITLE
[*.py] Rename "Arguments:" to "Args:"

### DIFF
--- a/tensorflow_addons/callbacks/tqdm_progress_bar.py
+++ b/tensorflow_addons/callbacks/tqdm_progress_bar.py
@@ -223,7 +223,7 @@ class TQDMProgressBar(Callback):
     def format_metrics(self, logs={}, factor=1):
         """Format metrics in logs into a string.
 
-        Arguments:
+        Args:
             logs: dictionary of metrics and their values. Defaults to
                 empty dictionary.
             factor (int): The factor we want to divide the metrics in logs

--- a/tensorflow_addons/layers/adaptive_pooling.py
+++ b/tensorflow_addons/layers/adaptive_pooling.py
@@ -26,7 +26,7 @@ class AdaptivePooling1D(tf.keras.layers.Layer):
 
     This class only exists for code reuse. It will never be an exposed API.
 
-    Arguments:
+    Args:
       reduce_function: The reduction method to apply, e.g. `tf.reduce_max`.
       output_size: An integer or tuple/list of a single integer, specifying pooled_features.
         The new size of output channels.
@@ -90,7 +90,7 @@ class AdaptivePooling1D(tf.keras.layers.Layer):
 class AdaptiveAveragePooling1D(AdaptivePooling1D):
     """Average Pooling with adaptive kernel size.
 
-    Arguments:
+    Args:
       output_size: An integer or tuple/list of a single integer, specifying pooled_features.
         The new size of output channels.
       data_format: A string,
@@ -124,7 +124,7 @@ class AdaptiveAveragePooling1D(AdaptivePooling1D):
 class AdaptiveMaxPooling1D(AdaptivePooling1D):
     """Max Pooling with adaptive kernel size.
 
-    Arguments:
+    Args:
       output_size: An integer or tuple/list of a single integer, specifying pooled_features.
         The new size of output channels.
       data_format: A string,
@@ -159,7 +159,7 @@ class AdaptivePooling2D(tf.keras.layers.Layer):
 
     This class only exists for code reuse. It will never be an exposed API.
 
-    Arguments:
+    Args:
       reduce_function: The reduction method to apply, e.g. `tf.reduce_max`.
       output_size: An integer or tuple/list of 2 integers specifying (pooled_rows, pooled_cols).
         The new size of output channels.
@@ -238,7 +238,7 @@ class AdaptivePooling2D(tf.keras.layers.Layer):
 class AdaptiveAveragePooling2D(AdaptivePooling2D):
     """Average Pooling with adaptive kernel size.
 
-    Arguments:
+    Args:
       output_size: Tuple of integers specifying (pooled_rows, pooled_cols).
         The new size of output channels.
       data_format: A string,
@@ -272,7 +272,7 @@ class AdaptiveAveragePooling2D(AdaptivePooling2D):
 class AdaptiveMaxPooling2D(AdaptivePooling2D):
     """Max Pooling with adaptive kernel size.
 
-    Arguments:
+    Args:
       output_size: Tuple of integers specifying (pooled_rows, pooled_cols).
         The new size of output channels.
       data_format: A string,
@@ -307,7 +307,7 @@ class AdaptivePooling3D(tf.keras.layers.Layer):
 
     This class only exists for code reuse. It will never be an exposed API.
 
-    Arguments:
+    Args:
       reduce_function: The reduction method to apply, e.g. `tf.reduce_max`.
       output_size: An integer or tuple/list of 3 integers specifying (pooled_dim1, pooled_dim2, pooled_dim3).
         The new size of output channels.
@@ -393,7 +393,7 @@ class AdaptivePooling3D(tf.keras.layers.Layer):
 class AdaptiveAveragePooling3D(AdaptivePooling3D):
     """Average Pooling with adaptive kernel size.
 
-    Arguments:
+    Args:
       output_size: An integer or tuple/list of 3 integers specifying (pooled_depth, pooled_height, pooled_width).
         The new size of output channels.
       data_format: A string,
@@ -427,7 +427,7 @@ class AdaptiveAveragePooling3D(AdaptivePooling3D):
 class AdaptiveMaxPooling3D(AdaptivePooling3D):
     """Max Pooling with adaptive kernel size.
 
-    Arguments:
+    Args:
       output_size: An integer or tuple/list of 3 integers specifying (pooled_depth, pooled_height, pooled_width).
         The new size of output channels.
       data_format: A string,

--- a/tensorflow_addons/layers/crf.py
+++ b/tensorflow_addons/layers/crf.py
@@ -46,13 +46,13 @@ class CRF(tf.keras.layers.Layer):
     >>> chain_kernel.shape
     TensorShape([4, 4])
 
-    Arguments:
+    Args:
         units: Positive integer, dimensionality of the reservoir.
         chain_initializer: Orthogonal matrix. Default to `orthogonal`.
         use_boundary: `Boolean`, whether the layer uses a boundary vector. Default to `True`.
         boundary_initializer: Tensors initialized to 0. Default to `zeros`.
         use_kernel: `Boolean`, whether the layer uses a kernel weights. Default to `True`.
-    Call Arguments:
+    Call Args:
         inputs: Positive integer, dimensionality of the output space.
         mask: A boolean `Tensor` of shape `[batch_size, sequence_length]`
             or `None`. Default to `None`.

--- a/tensorflow_addons/layers/esn.py
+++ b/tensorflow_addons/layers/esn.py
@@ -38,7 +38,7 @@ class ESN(tf.keras.layers.RNN):
         (https://www.researchgate.net/publication/215385037).
         GMD Report148, German National Research Center for Information Technology, 2001.
 
-    Arguments:
+    Args:
         units: Positive integer, dimensionality of the reservoir.
         connectivity: Float between 0 and 1.
             Connection probability between two reservoir units.

--- a/tensorflow_addons/layers/maxout.py
+++ b/tensorflow_addons/layers/maxout.py
@@ -28,7 +28,7 @@ class Maxout(tf.keras.layers.Layer):
     Usually the operation is performed in the filter/channel dimension. This
     can also be used after Dense layers to reduce number of features.
 
-    Arguments:
+    Args:
       num_units: Specifies how many features will remain after maxout
         in the `axis` dimension (usually channel).
         This must be a factor of number of features.

--- a/tensorflow_addons/layers/multihead_attention.py
+++ b/tensorflow_addons/layers/multihead_attention.py
@@ -45,7 +45,7 @@ class MultiHeadAttention(tf.keras.layers.Layer):
     >>> attention.shape
     TensorShape([3, 5, 10])
 
-    Arguments:
+    Args:
         head_size: int, dimensionality of the `query`, `key` and `value` tensors
             after the linear transformation.
         num_heads: int, number of attention heads.
@@ -66,7 +66,7 @@ class MultiHeadAttention(tf.keras.layers.Layer):
         bias_regularizer: regularizer, regularizer for the bias weights.
         bias_constraint: constraint, constraint for the bias weights.
 
-    Call Arguments:
+    Call Args:
         inputs:  List of `[query, key, value]` where
             * `query`: Tensor of shape `(..., query_elements, query_depth)`
             * `key`: `Tensor of shape '(..., key_elements, key_depth)`

--- a/tensorflow_addons/layers/netvlad.py
+++ b/tensorflow_addons/layers/netvlad.py
@@ -29,7 +29,7 @@ class NetVLAD(tf.keras.layers.Layer):
     See [NetVLAD: CNN architecture for weakly supervised place recognition](https://arxiv.org/abs/1511.07247), and.
     [Towards Learning a Universal Non-Semantic Representation of Speech](https://arxiv.org/abs/2002.12764)
 
-    Arguments:
+    Args:
         num_clusters: The number of clusters to use.
     Input shape:
         3D tensor with shape: `(batch_size, time, feature_dim)`.

--- a/tensorflow_addons/layers/noisy_dense.py
+++ b/tensorflow_addons/layers/noisy_dense.py
@@ -66,7 +66,7 @@ class NoisyDense(tf.keras.layers.Dense):
     >>> model.output_shape
     (None, 32)
 
-    Arguments:
+    Args:
       units: Positive integer, dimensionality of the output space.
       sigma: A float between 0-1 used as a standard deviation figure and is
         applied to the gaussian noise layer (`sigma_kernel` and `sigma_bias`).

--- a/tensorflow_addons/layers/normalizations.py
+++ b/tensorflow_addons/layers/normalizations.py
@@ -45,7 +45,7 @@ class GroupNormalization(tf.keras.layers.Layer):
     to number of channels), then this operation becomes
     identical to Instance Normalization.
 
-    Arguments:
+    Args:
         groups: Integer, the number of groups for Group Normalization.
             Can be in the range [1, N] where N is the input dimension.
             The input dimension must be divisible by the number of groups.

--- a/tensorflow_addons/layers/poincare.py
+++ b/tensorflow_addons/layers/poincare.py
@@ -35,7 +35,7 @@ class PoincareNormalize(tf.keras.layers.Layer):
     For `x` with more dimensions, independently normalizes each 1-D slice along
     dimension `axis`.
 
-    Arguments:
+    Args:
       axis: Axis along which to normalize.  A scalar or a vector of integers.
       epsilon: A small deviation from the edge of the unit sphere for
         numerical stability.

--- a/tensorflow_addons/layers/polynomial.py
+++ b/tensorflow_addons/layers/polynomial.py
@@ -47,7 +47,7 @@ class PolynomialCrossing(tf.keras.layers.Layer):
     >>> logits = tf.keras.layers.Dense(units=10)(x2)
     >>> model = tf.keras.Model(logits)
 
-    Arguments:
+    Args:
         projection_dim: project dimension to reduce the computational cost.
           Default is `None` such that a full (`input_dim` by `input_dim`)
           matrix W is used. If enabled, a low-rank matrix W = U*V will be used,

--- a/tensorflow_addons/layers/snake.py
+++ b/tensorflow_addons/layers/snake.py
@@ -28,7 +28,7 @@ class Snake(tf.keras.layers.Layer):
 
     See [Neural Networks Fail to Learn Periodic Functions and How to Fix It](https://arxiv.org/abs/2006.08195).
 
-    Arguments:
+    Args:
         frequency_initializer: Initializer for the `frequency` scalar.
     """
 

--- a/tensorflow_addons/layers/sparsemax.py
+++ b/tensorflow_addons/layers/sparsemax.py
@@ -26,7 +26,7 @@ class Sparsemax(tf.keras.layers.Layer):
 
     See [From Softmax to Sparsemax: A Sparse Model of Attention and Multi-Label Classification](https://arxiv.org/abs/1602.02068).
 
-    Arguments:
+    Args:
         axis: Integer, axis along which the sparsemax normalization is applied.
     """
 

--- a/tensorflow_addons/layers/spatial_pyramid_pooling.py
+++ b/tensorflow_addons/layers/spatial_pyramid_pooling.py
@@ -32,7 +32,7 @@ class SpatialPyramidPooling2D(tf.keras.layers.Layer):
     regardless of input size/scale. It is typically used before a layer
     that requires a constant input shape, for example before a Dense Layer.
 
-    Arguments:
+    Args:
       bins: Either a collection of integers or a collection of collections of 2 integers.
         Each element in the inner collection must contain 2 integers, (pooled_rows, pooled_cols)
         For example, providing [1, 3, 5] or [[1, 1], [3, 3], [5, 5]] preforms pooling

--- a/tensorflow_addons/layers/spectral_normalization.py
+++ b/tensorflow_addons/layers/spectral_normalization.py
@@ -42,7 +42,7 @@ class SpectralNormalization(tf.keras.layers.Wrapper):
     >>> y.shape
     TensorShape([1, 10, 10, 10])
 
-    Arguments:
+    Args:
       layer: A `tf.keras.layers.Layer` instance that
         has either `kernel` or `embeddings` attribute.
       power_iterations: `int`, the number of iterations during normalization.

--- a/tensorflow_addons/layers/stochastic_depth.py
+++ b/tensorflow_addons/layers/stochastic_depth.py
@@ -42,10 +42,10 @@ class StochasticDepth(tf.keras.layers.Layer):
     x[0] + p_l * x[1]
     $$
 
-    Arguments:
+    Args:
         survival_probability: float, the probability of the residual branch being kept.
 
-    Call Arguments:
+    Call Args:
         inputs:  List of `[shortcut, residual]` where `shortcut`, and `residual` are tensors of equal shape.
 
     Output shape:

--- a/tensorflow_addons/layers/tlu.py
+++ b/tensorflow_addons/layers/tlu.py
@@ -36,7 +36,7 @@ class TLU(tf.keras.layers.Layer):
     Output shape:
         Same shape as the input.
 
-    Arguments:
+    Args:
         affine: `bool`. Whether to make it TLU-Affine or not
             which has the form $\max(x, \alpha*x + \tau)$`
     """

--- a/tensorflow_addons/layers/wrappers.py
+++ b/tensorflow_addons/layers/wrappers.py
@@ -46,7 +46,7 @@ class WeightNormalization(tf.keras.layers.Wrapper):
     >>> y.shape
     TensorShape([1, 10, 10, 10])
 
-    Arguments:
+    Args:
       layer: A `tf.keras.layers.Layer` instance.
       data_init: If `True` use data dependent variable initialization.
     Raises:

--- a/tensorflow_addons/rnn/esn_cell.py
+++ b/tensorflow_addons/rnn/esn_cell.py
@@ -44,7 +44,7 @@ class ESNCell(keras.layers.AbstractRNNCell):
     >>> memory_state.shape
     TensorShape([30, 4])
 
-    Arguments:
+    Args:
         units: Positive integer, dimensionality in the reservoir.
         connectivity: Float between 0 and 1.
             Connection probability between two reservoir units.

--- a/tensorflow_addons/rnn/layer_norm_simple_rnn_cell.py
+++ b/tensorflow_addons/rnn/layer_norm_simple_rnn_cell.py
@@ -48,7 +48,7 @@ class LayerNormSimpleRNNCell(keras.layers.SimpleRNNCell):
     >>> memory_state.shape
     TensorShape([30, 4])
 
-    Arguments:
+    Args:
       units: Positive integer, dimensionality of the output space.
       activation: Activation function to use.
         Default: hyperbolic tangent (`tanh`).

--- a/tensorflow_addons/utils/keras_utils.py
+++ b/tensorflow_addons/utils/keras_utils.py
@@ -85,7 +85,7 @@ def normalize_tuple(value, n, name):
 
     A copy of tensorflow.python.keras.util.
 
-    Arguments:
+    Args:
       value: The value to validate and convert. Could an int, or any iterable
         of ints.
       n: The size of the tuple to be returned.


### PR DESCRIPTION
I've written custom parsers and emitters for everything from docstrings to classes and functions. However, I recently came across an issue with the TensorFlow codebase: inconsistent use of `Args:` and `Arguments:` in its docstrings. It is easy enough to extend my parsers to support both variants, howevever it looks like `Arguments:` is wrong anyway, as per:

  - https://google.github.io/styleguide/pyguide.html#doc-function-args @ [`ddccc0f`](https://github.com/google/styleguide/blob/ddccc0f/pyguide.md)

  - https://chromium.googlesource.com/chromiumos/docs/+/master/styleguide/python.md#describing-arguments-in-docstrings @ [`9fc0fc0`](https://chromium.googlesource.com/chromiumos/docs/+/9fc0fc0/styleguide/python.md)

  - https://sphinxcontrib-napoleon.readthedocs.io/en/latest/example_google.html @ [`c0ae8e3`](https://github.com/sphinx-contrib/napoleon/blob/c0ae8e3/docs/source/example_google.rst)

 

Therefore, only `Args:` is valid. This PR replaces them throughout the TensorFlow Addons codebase.

PS: For related PRs, see tensorflow/tensorflow/pull/45420