### PR TITLE
fix LazyAdam resource variable ops performance issue

### DIFF
--- a/tensorflow_addons/optimizers/lazy_adam.py
+++ b/tensorflow_addons/optimizers/lazy_adam.py
@@ -119,7 +119,26 @@ class LazyAdam(tf.keras.optimizers.Adam):
         v_update_op = self._resource_scatter_update(v, indices, v_t_slice)
 
         # \\(variable += -learning_rate * m_t / (epsilon_t + sqrt(v_t))\\)
-        var_slice = -lr * m_t_slice / (tf.math.sqrt(v_t_slice) + epsilon_t)
-        var_update_op = self._resource_scatter_add(var, indices, var_slice)
+        var_slice = lr * m_t_slice / (tf.math.sqrt(v_t_slice) + epsilon_t)
+        var_update_op = self._resource_scatter_sub(var, indices, var_slice)
 
         return tf.group(*[var_update_op, m_update_op, v_update_op])
+
+    def _resource_scatter_update(self, resource, indices, update):
+        return self._resource_scatter_operate(
+            resource, indices, update, tf.raw_ops.ResourceScatterUpdate
+        )
+
+    def _resource_scatter_sub(self, resource, indices, update):
+        return self._resource_scatter_operate(
+            resource, indices, update, tf.raw_ops.ResourceScatterSub
+        )
+
+    def _resource_scatter_operate(self, resource, indices, update, resource_scatter_op):
+        resource_update_kwargs = {
+            "resource": resource.handle,
+            "indices": indices,
+            "updates": update,
+        }
+
+        return resource_scatter_op(**resource_update_kwargs)


### PR DESCRIPTION
# Description

Brief Description of the PR:
Swap calls to `OptimizerV2._resource_scatter_update` and `OptimizerV2._resource_scatter_add` with direct calls to `resource_variable_ops.resource_scatter_update` and `resource_variable_ops.resource_scatter_sub`.

The `OptimizerV2` methods are wrappers around the `resource_variable_ops`, except they extract and return the underlying `Tensor` from the op instead of returning the operation. This causes a big performance hit as outlined in issue #2273.

The returned tensor is not necessary for this "lazy" version of Adam sparse updates, since the op isn't used in subsequent computation. Thus we can avoid the extra `.value()` call in `OptimizerV2._resource_scatter_update/sub/add`

Fixes #2273 

## Type of change

- [X] Bug fix
- [ ] New Tutorial
- [ ] Updated or additional documentation
- [ ] Additional Testing
- [ ] New Activation and the changes conform to the [activation contribution guidelines](https://github.com/tensorflow/addons/blob/master/tensorflow_addons/activations/README.md#contribution-guidelines)
- [ ] New Callback and the changes conform to the [callback contribution guidelines](https://github.com/tensorflow/addons/blob/master/tensorflow_addons/callbacks/README.md#contribution-guidelines)
- [ ] New Image addition and the changes conform to the [image op contribution guidelines](https://github.com/tensorflow/addons/blob/master/tensorflow_addons/image/README.md#contribution-guidelines)
- [ ] New Layer and the changes conform to the [layer contribution guidelines](https://github.com/tensorflow/addons/blob/master/tensorflow_addons/layers/README.md#contribution-guidelines)
- [ ] New Loss and the changes conform to the [loss contribution guidelines](https://github.com/tensorflow/addons/blob/master/tensorflow_addons/losses/README.md#contribution-guidelines)
- [ ] New Metric and the changes conform to the [metric contribution guidelines](https://github.com/tensorflow/addons/blob/master/tensorflow_addons/metrics/README.md#contribution-guidelines)
- [ ] New Optimizer and the changes conform to the [optimizer contribution guidelines](https://github.com/tensorflow/addons/blob/master/tensorflow_addons/optimizers/README.md#contribution-guidelines)
- [ ] New RNN Cell and the changes conform to the [rnn contribution guidelines](https://github.com/tensorflow/addons/blob/master/tensorflow_addons/rnn/README.md#contribution-guidelines)
- [ ] New Seq2seq addition and the changes conform to the [seq2seq contribution guidelines](https://github.com/tensorflow/addons/blob/master/tensorflow_addons/seq2seq/README.md#contribution-guidelines)
- [ ] New Text addition and the changes conform to the [text op contribution guidelines](https://github.com/tensorflow/addons/blob/master/tensorflow_addons/text/README.md#contribution-guidelines)

# Checklist:

- [ X] I've properly [formatted my code according to the guidelines](https://github.com/tensorflow/addons/blob/master/CONTRIBUTING.md#coding-style)
    - [ ] By running Black + Flake8
    - [X] By running pre-commit hooks
- [X] This PR addresses an already submitted issue for TensorFlow Addons
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] This PR contains modifications to C++ custom-ops

# How Has This Been Tested?

If you're adding a bugfix or new feature please describe the tests that you ran to verify your changes:
*  Compared training with the fixed/unfixed LazyAdam optimizer in a Colab:
https://colab.research.google.com/drive/1T1X9log6pyDShHkKRxTPqkZwj0iZsowy?usp=sharing

With both the Keras and Estimator APIs. Validated model equality while observing major performance boost.
