### PR TITLE
Rodert fix image random cutout 2276

### DIFF
--- a/tensorflow_addons/image/cutout_ops.py
+++ b/tensorflow_addons/image/cutout_ops.py
@@ -81,10 +81,18 @@ def random_cutout(
     half_mask_width = mask_size[1] // 2
 
     cutout_center_height = tf.random.uniform(
-        shape=[batch_size], minval=half_mask_height, maxval=image_height-half_mask_height, dtype=tf.int32, seed=seed
+        shape=[batch_size],
+        minval=half_mask_height,
+        maxval=image_height - half_mask_height,
+        dtype=tf.int32,
+        seed=seed,
     )
     cutout_center_width = tf.random.uniform(
-        shape=[batch_size], minval=half_mask_width, maxval=image_width-half_mask_width, dtype=tf.int32, seed=seed
+        shape=[batch_size],
+        minval=half_mask_width,
+        maxval=image_width - half_mask_width,
+        dtype=tf.int32,
+        seed=seed,
     )
 
     offset = tf.transpose([cutout_center_height, cutout_center_width], [1, 0])

--- a/tensorflow_addons/image/cutout_ops.py
+++ b/tensorflow_addons/image/cutout_ops.py
@@ -77,11 +77,14 @@ def random_cutout(
     batch_size = tf.shape(images)[0]
     mask_size, data_format, image_height, image_width = _norm_params(images, mask_size)
 
+    half_mask_height = mask_size[0] // 2
+    half_mask_width = mask_size[1] // 2
+
     cutout_center_height = tf.random.uniform(
-        shape=[batch_size], minval=0, maxval=image_height, dtype=tf.int32, seed=seed
+        shape=[batch_size], minval=half_mask_height, maxval=image_height-half_mask_height, dtype=tf.int32, seed=seed
     )
     cutout_center_width = tf.random.uniform(
-        shape=[batch_size], minval=0, maxval=image_width, dtype=tf.int32, seed=seed
+        shape=[batch_size], minval=half_mask_width, maxval=image_width-half_mask_width, dtype=tf.int32, seed=seed
     )
 
     offset = tf.transpose([cutout_center_height, cutout_center_width], [1, 0])

--- a/tensorflow_addons/image/tests/cutout_ops_test.py
+++ b/tensorflow_addons/image/tests/cutout_ops_test.py
@@ -59,3 +59,13 @@ def test_with_tf_function():
     cutout_area = tf.pad(cutout_area, ((0, 36), (0, 36)), constant_values=1)
     expect_image = to_4D_image(cutout_area)
     np.testing.assert_equal(result_image.shape, expect_image.shape)
+
+
+def test_mask_applied():
+    test_image = tf.ones([10, 40, 40, 1], dtype=np.uint8)
+    result_image = random_cutout(test_image, 20, seed=1234)
+    total_expected_masked_count = 20 * 20 * test_image.shape[0]
+
+    np.testing.assert_equal(
+        np.sum(result_image) + total_expected_masked_count, np.sum(test_image)
+    )


### PR DESCRIPTION
# Description

Brief Description of the PR: Bugfix for random_cutout mask which is not fully applied when randomly chosen mask location is chosen too close to the image boundary. 

Fixes # (2276)

## Type of change

- [x] Bug fix
- [ ] New Tutorial
- [ ] Updated or additional documentation
- [x] Additional Testing
- [ ] New Activation and the changes conform to the [activation contribution guidelines](https://github.com/tensorflow/addons/blob/master/tensorflow_addons/activations/README.md#contribution-guidelines)
- [ ] New Callback and the changes conform to the [callback contribution guidelines](https://github.com/tensorflow/addons/blob/master/tensorflow_addons/callbacks/README.md#contribution-guidelines)
- [ ] New Image addition and the changes conform to the [image op contribution guidelines](https://github.com/tensorflow/addons/blob/master/tensorflow_addons/image/README.md#contribution-guidelines)
- [ ] New Layer and the changes conform to the [layer contribution guidelines](https://github.com/tensorflow/addons/blob/master/tensorflow_addons/layers/README.md#contribution-guidelines)
- [ ] New Loss and the changes conform to the [loss contribution guidelines](https://github.com/tensorflow/addons/blob/master/tensorflow_addons/losses/README.md#contribution-guidelines)
- [ ] New Metric and the changes conform to the [metric contribution guidelines](https://github.com/tensorflow/addons/blob/master/tensorflow_addons/metrics/README.md#contribution-guidelines)
- [ ] New Optimizer and the changes conform to the [optimizer contribution guidelines](https://github.com/tensorflow/addons/blob/master/tensorflow_addons/optimizers/README.md#contribution-guidelines)
- [ ] New RNN Cell and the changes conform to the [rnn contribution guidelines](https://github.com/tensorflow/addons/blob/master/tensorflow_addons/rnn/README.md#contribution-guidelines)
- [ ] New Seq2seq addition and the changes conform to the [seq2seq contribution guidelines](https://github.com/tensorflow/addons/blob/master/tensorflow_addons/seq2seq/README.md#contribution-guidelines)
- [ ] New Text addition and the changes conform to the [text op contribution guidelines](https://github.com/tensorflow/addons/blob/master/tensorflow_addons/text/README.md#contribution-guidelines)

# Checklist:

- [x] I've properly [formatted my code according to the guidelines](https://github.com/tensorflow/addons/blob/master/CONTRIBUTING.md#coding-style)
    - [x] By running Black + Flake8
    - [ ] By running pre-commit hooks
- [x] This PR addresses an already submitted issue for TensorFlow Addons
- [ ] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] This PR contains modifications to C++ custom-ops

# How Has This Been Tested?
Additional unit test

*  Bugfix for random_cutout mask which is not fully applied when randomly chosen mask location is chosen too close to the image boundary. Unit test applies a zero mask to 10 images of ones, and verifies the total expected sum over all images is correct. i.e. all of the zeros have been applied.

![cutout_bug_fix](https://user-images.githubusercontent.com/72381446/101898957-e950e400-3ba4-11eb-8783-ffd5bf0750c2.png)

