### PR TITLE
Refactor sharpness

### DIFF
--- a/tensorflow_addons/image/color_ops.py
+++ b/tensorflow_addons/image/color_ops.py
@@ -96,7 +96,6 @@ def _sharpness_image(image: TensorLike, factor: Number) -> tf.Tensor:
     kernel = tf.tile(kernel, [1, 1, image_channels, 1])
 
     # Apply kernel channel-wise.
-    # TODO: Use tf.nn.conv2d as soon as grouped convolutions have CPU support.
     degenerate = tf.nn.depthwise_conv2d(
         image, kernel, strides=[1, 1, 1, 1], padding="VALID", dilations=[1, 1]
     )

--- a/tensorflow_addons/image/tests/color_ops_test.py
+++ b/tensorflow_addons/image/tests/color_ops_test.py
@@ -30,9 +30,11 @@ _DTYPES = {
     np.float64,
 }
 
+_SHAPES = {(5, 5), (5, 5, 1), (5, 5, 3), (4, 5, 5), (4, 5, 5, 1), (4, 5, 5, 3)}
+
 
 @pytest.mark.parametrize("dtype", _DTYPES)
-@pytest.mark.parametrize("shape", [(7, 7), (5, 5, 1), (5, 5, 3), (5, 7, 7, 3)])
+@pytest.mark.parametrize("shape", _SHAPES)
 def test_equalize_dtype_shape(dtype, shape):
     image = np.ones(shape=shape, dtype=dtype)
     equalized = color_ops.equalize(tf.constant(image)).numpy()
@@ -48,15 +50,8 @@ def test_equalize_with_PIL():
     np.testing.assert_equal(color_ops.equalize(tf.constant(image)).numpy(), equalized)
 
 
-@pytest.mark.parametrize("shape", [(1, 5, 5), (3, 5, 5), (10, 3, 7, 7)])
-def test_equalize_channel_first(shape):
-    image = tf.ones(shape=shape, dtype=tf.uint8)
-    equalized = color_ops.equalize(image, "channels_first")
-    np.testing.assert_equal(equalized.numpy(), image.numpy())
-
-
 @pytest.mark.parametrize("dtype", _DTYPES)
-@pytest.mark.parametrize("shape", [(5, 5, 3), (10, 5, 5, 3)])
+@pytest.mark.parametrize("shape", _SHAPES)
 def test_sharpness_dtype_shape(dtype, shape):
     image = np.ones(shape=shape, dtype=dtype)
     sharp = color_ops.sharpness(tf.constant(image), 0).numpy()


### PR DESCRIPTION
Part of #2279.

Changes:
1. Made `sharpness_image` private (`_sharpness_image` now), as `sharpness` already handles single images and `_equalize_image` is private as well.
2. Made `sharpness` compatible with grayscale images (previously only worked with RGB).
3. Added the `name` argument and applied a `tf.name_scope`.
4. Decorated with `@tf.function`. **Now runs ~60% faster.** ([colab](https://colab.research.google.com/drive/1uZzz4G-Bfme1-9jaBsMPYTzykA25GsTu#scrollTo=mFA_HXxMmvhd))
5. Removed the `clip_by_value` invocation since the sharpening kernel is already normalized.
6. Refactored the tests. `sharpness` and `equalize` now both handle all input shapes.

Also removed a faulty test for `equalize`. That test was for the now unsupported `channels_first` and was passing because it was just renaming the `name_scope` to `channels_first` :D.