### PR TITLE
feature/1cycle_super_convergence

### DIFF
--- a/tensorflow_addons/optimizers/tests/cyclical_learning_rate_test.py
+++ b/tensorflow_addons/optimizers/tests/cyclical_learning_rate_test.py
@@ -54,6 +54,35 @@ def test_triangular_cyclical_learning_rate(serialize):
 
 
 @pytest.mark.parametrize("serialize", [True, False])
+def test_1cycle_cyclical_learning_rate(serialize):
+    initial_learning_rate = 0.1
+    max_learning_rate = 1
+    step_size = 40
+    cyclical_lr = cyclical_learning_rate.CyclicalLearningRate(
+        initial_learning_rate=initial_learning_rate,
+        maximal_learning_rate=max_learning_rate,
+        step_size=step_size,
+        scale_fn=lambda x: 1,
+        is_1cycle=True,
+    )
+    cyclical_lr = _maybe_serialized(cyclical_lr, serialize)
+
+    expected = np.concatenate(
+        [
+            np.linspace(initial_learning_rate, max_learning_rate, num=step_size + 1),
+            np.linspace(max_learning_rate, initial_learning_rate, num=step_size + 1)[
+                1:
+            ][: step_size - 1],
+            np.full(2 * step_size, initial_learning_rate / 1e3),
+        ]
+    )
+
+    for step, expected_value in enumerate(expected):
+        print("expected: {}, clr: {}".format(expected_value, cyclical_lr(step)))
+        np.testing.assert_allclose(cyclical_lr(step), expected_value, 1e-6)
+
+
+@pytest.mark.parametrize("serialize", [True, False])
 def test_triangular2_cyclical_learning_rate(serialize):
     initial_lr = 0.1
     maximal_lr = 1


### PR DESCRIPTION
# Description

Brief Description of the PR:

Hi team, added configuration for a 1cycle learning policy. This is an extension of the Leslie Smith's cyclical learning rates (CLR) that attempts to achieve superconvergence. This pull request is also an extension of previously implemented CLR schedules.

1. [Super-Convergence: Very Fast Training of Neural Networks Using Large Learning Rates](https://arxiv.org/abs/1708.07120)
2. [A disciplined approach to neural network hyper-parameters: Part 1 -- learning rate, batch size, momentum, and weight decay](https://arxiv.org/abs/1803.09820)

Wanted to get the TF team's/communities thoughts on these changes.
Thanks,
Iain

Fixes # (issue)

N/A

## Type of change

- [ ] Bug fix
- [ ] New Tutorial
- [ ] Updated or additional documentation
- [ ] Additional Testing
- [ ] New Activation and the changes conform to the [activation contribution guidelines](https://github.com/tensorflow/addons/blob/master/tensorflow_addons/activations/README.md#contribution-guidelines)
- [ ] New Callback and the changes conform to the [callback contribution guidelines](https://github.com/tensorflow/addons/blob/master/tensorflow_addons/callbacks/README.md#contribution-guidelines)
- [ ] New Image addition and the changes conform to the [image op contribution guidelines](https://github.com/tensorflow/addons/blob/master/tensorflow_addons/image/README.md#contribution-guidelines)
- [ ] New Layer and the changes conform to the [layer contribution guidelines](https://github.com/tensorflow/addons/blob/master/tensorflow_addons/layers/README.md#contribution-guidelines)
- [ ] New Loss and the changes conform to the [loss contribution guidelines](https://github.com/tensorflow/addons/blob/master/tensorflow_addons/losses/README.md#contribution-guidelines)
- [ ] New Metric and the changes conform to the [metric contribution guidelines](https://github.com/tensorflow/addons/blob/master/tensorflow_addons/metrics/README.md#contribution-guidelines)
- [x] New Optimizer and the changes conform to the [optimizer contribution guidelines](https://github.com/tensorflow/addons/blob/master/tensorflow_addons/optimizers/README.md#contribution-guidelines)
- [ ] New RNN Cell and the changes conform to the [rnn contribution guidelines](https://github.com/tensorflow/addons/blob/master/tensorflow_addons/rnn/README.md#contribution-guidelines)
- [ ] New Seq2seq addition and the changes conform to the [seq2seq contribution guidelines](https://github.com/tensorflow/addons/blob/master/tensorflow_addons/seq2seq/README.md#contribution-guidelines)
- [ ] New Text addition and the changes conform to the [text op contribution guidelines](https://github.com/tensorflow/addons/blob/master/tensorflow_addons/text/README.md#contribution-guidelines)

# Checklist:

- [x] I've properly [formatted my code according to the guidelines](https://github.com/tensorflow/addons/blob/master/CONTRIBUTING.md#coding-style)
    - [x] By running Black + Flake8
    - [x] By running pre-commit hooks
- [ ] This PR addresses an already submitted issue for TensorFlow Addons
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] This PR contains modifications to C++ custom-ops

# How Has This Been Tested?

If you're adding a bugfix or new feature please describe the tests that you ran to verify your changes:
*  added test: "test_1cycle_cyclical_learning_rate" in tensorflow_addons/optimizers/test/cyclical_learning_rate_test.py
    * validates the learning rate schedule returns a fraction of the intial learning after the first cycle, whilst maintaining the original stepping behaviour within the first cycle
