### PR TITLE
Move enable_runfiles flag to configure.py

### DIFF
--- a/.github/workflows/make_wheel_Windows.sh
+++ b/.github/workflows/make_wheel_Windows.sh
@@ -9,7 +9,6 @@ bash ./tools/testing/build_and_run_tests.sh
 python configure.py
 
 bazel.exe build \
-  --enable_runfiles \
   --noshow_progress \
   --noshow_loading_progress \
   --verbose_failures \

--- a/README.md
+++ b/README.md
@@ -139,7 +139,7 @@ cd addons
 # This script links project with TensorFlow dependency
 python3 ./configure.py
 
-bazel build --enable_runfiles build_pip_pkg
+bazel build build_pip_pkg
 bazel-bin/build_pip_pkg artifacts
 
 pip install artifacts/tensorflow_addons-*.whl
@@ -161,7 +161,7 @@ export CUDNN_INSTALL_PATH="/usr/lib/x86_64-linux-gnu"
 # This script links project with TensorFlow dependency
 python3 ./configure.py
 
-bazel build --enable_runfiles build_pip_pkg
+bazel build build_pip_pkg
 bazel-bin/build_pip_pkg artifacts
 
 pip install artifacts/tensorflow_addons-*.whl

--- a/configure.py
+++ b/configure.py
@@ -113,6 +113,7 @@ def create_build_configuration():
 
     if is_windows():
         write("build --config=windows")
+        write("build:windows --enable_runfiles")
         write("build:windows --copt=/experimental:preprocessor")
         write("build:windows --host_copt=/experimental:preprocessor")
         write("build:windows --copt=/arch=AVX2")


### PR DESCRIPTION
# Description

Cleanup where `--enable_runfiles` flag is set. Previously we just put this in the documentation for all OS since it didn't hurt but now configure will handle it and users don't need to worry about it.