### PR TITLE
Update ABI compatibility on r0.12

### DIFF
--- a/tensorflow_addons/utils/resource_loader.py
+++ b/tensorflow_addons/utils/resource_loader.py
@@ -20,8 +20,8 @@ import warnings
 
 import tensorflow as tf
 
-MIN_TF_VERSION_FOR_ABI_COMPATIBILITY = "2.3.0"
-MAX_TF_VERSION_FOR_ABI_COMPATIBILITY = "2.4.0"
+MIN_TF_VERSION_FOR_ABI_COMPATIBILITY = "2.4.0"
+MAX_TF_VERSION_FOR_ABI_COMPATIBILITY = "2.5.0"
 abi_warning_already_raised = False
 SKIP_CUSTOM_OPS = False
 


### PR DESCRIPTION
# Description
The backport failed:
https://github.com/tensorflow/addons/pull/2306#issuecomment-748403736