### PR TITLE
Remove control dependency

### DIFF
--- a/tensorflow_addons/image/dense_image_warp.py
+++ b/tensorflow_addons/image/dense_image_warp.py
@@ -14,7 +14,6 @@
 # ==============================================================================
 """Image warping using per-pixel flow vectors."""
 
-import numpy as np
 import tensorflow as tf
 
 from tensorflow_addons.utils import types
@@ -64,28 +63,6 @@ def interpolate_bilinear(
                 raise ValueError("Grid height must be at least 2.")
             if grid_static_shape[2] is not None and grid_static_shape[2] < 2:
                 raise ValueError("Grid width must be at least 2.")
-        else:
-            with tf.control_dependencies(
-                [
-                    tf.debugging.assert_greater_equal(
-                        grid_shape[1], 2, message="Grid height must be at least 2."
-                    ),
-                    tf.debugging.assert_greater_equal(
-                        grid_shape[2], 2, message="Grid width must be at least 2."
-                    ),
-                    tf.debugging.assert_less_equal(
-                        tf.cast(
-                            grid_shape[0] * grid_shape[1] * grid_shape[2],
-                            dtype=tf.dtypes.float32,
-                        ),
-                        np.iinfo(np.int32).max / 8.0,
-                        message="The image size or batch size is sufficiently "
-                        "large that the linearized addresses used by "
-                        "tf.gather may exceed the int32 limit.",
-                    ),
-                ]
-            ):
-                pass
 
         # query_points shape checks
         query_static_shape = query_points.shape
@@ -96,17 +73,6 @@ def interpolate_bilinear(
             query_hw = query_static_shape[2]
             if query_hw is not None and query_hw != 2:
                 raise ValueError("Query points last dimension must be 2.")
-        else:
-            with tf.control_dependencies(
-                [
-                    tf.debugging.assert_equal(
-                        query_shape[2],
-                        2,
-                        message="Query points last dimension must be 2.",
-                    )
-                ]
-            ):
-                pass
 
         batch_size, height, width, channels = (
             grid_shape[0],

--- a/tensorflow_addons/image/tests/dense_image_warp_test.py
+++ b/tensorflow_addons/image/tests/dense_image_warp_test.py
@@ -239,10 +239,8 @@ def test_interpolation():
 def test_size_exception():
     """Make sure it throws an exception for images that are too small."""
     shape = [1, 2, 1, 1]
-    errors = (ValueError, tf.errors.InvalidArgumentError)
-    with pytest.raises(errors) as exception_raised:
+    with pytest.raises(ValueError, match="Grid width must be at least 2."):
         _check_interpolation_correctness(shape, "float32", "float32")
-    assert "Grid width must be at least 2." in str(exception_raised.value)
 
 
 @pytest.mark.usefixtures("maybe_run_functions_eagerly")

--- a/tools/testing/source_code_test.py
+++ b/tools/testing/source_code_test.py
@@ -177,7 +177,6 @@ def test_no_tf_control_dependencies():
     allowlist = [
         "tensorflow_addons/layers/wrappers.py",
         "tensorflow_addons/image/utils.py",
-        "tensorflow_addons/image/dense_image_warp.py",
         "tensorflow_addons/optimizers/average_wrapper.py",
         "tensorflow_addons/optimizers/yogi.py",
         "tensorflow_addons/optimizers/lookahead.py",


### PR DESCRIPTION
# Description

Seems that we are hostile to `control_dependencies` so this PR removed it. It also makes the behavior consistent with docstring -- raises `ValueError` instead of `tf.errors.InvalidArgumentError` for invalid inputs. Note that removal of runtime check will result in

```python
fn = foo.get_concreate_function(tf.TensorSpec(shape=None))
fn(invalid_inputs)
```

throws unexpected errors.

## Type of change

- [ ] Bug fix
- [ ] New Tutorial
- [ ] Updated or additional documentation
- [ ] Additional Testing
- [ ] New Activation and the changes conform to the [activation contribution guidelines](https://github.com/tensorflow/addons/blob/master/tensorflow_addons/activations/README.md#contribution-guidelines)
- [ ] New Callback and the changes conform to the [callback contribution guidelines](https://github.com/tensorflow/addons/blob/master/tensorflow_addons/callbacks/README.md#contribution-guidelines)
- [ ] New Image addition and the changes conform to the [image op contribution guidelines](https://github.com/tensorflow/addons/blob/master/tensorflow_addons/image/README.md#contribution-guidelines)
- [ ] New Layer and the changes conform to the [layer contribution guidelines](https://github.com/tensorflow/addons/blob/master/tensorflow_addons/layers/README.md#contribution-guidelines)
- [ ] New Loss and the changes conform to the [loss contribution guidelines](https://github.com/tensorflow/addons/blob/master/tensorflow_addons/losses/README.md#contribution-guidelines)
- [ ] New Metric and the changes conform to the [metric contribution guidelines](https://github.com/tensorflow/addons/blob/master/tensorflow_addons/metrics/README.md#contribution-guidelines)
- [ ] New Optimizer and the changes conform to the [optimizer contribution guidelines](https://github.com/tensorflow/addons/blob/master/tensorflow_addons/optimizers/README.md#contribution-guidelines)
- [ ] New RNN Cell and the changes conform to the [rnn contribution guidelines](https://github.com/tensorflow/addons/blob/master/tensorflow_addons/rnn/README.md#contribution-guidelines)
- [ ] New Seq2seq addition and the changes conform to the [seq2seq contribution guidelines](https://github.com/tensorflow/addons/blob/master/tensorflow_addons/seq2seq/README.md#contribution-guidelines)
- [ ] New Text addition and the changes conform to the [text op contribution guidelines](https://github.com/tensorflow/addons/blob/master/tensorflow_addons/text/README.md#contribution-guidelines)

# Checklist:

- [x] I've properly [formatted my code according to the guidelines](https://github.com/tensorflow/addons/blob/master/CONTRIBUTING.md#coding-style)
    - [ ] By running Black + Flake8
    - [ ] By running pre-commit hooks
- [ ] This PR addresses an already submitted issue for TensorFlow Addons
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] This PR contains modifications to C++ custom-ops

# How Has This Been Tested?

Passes existing tests.