### PR TITLE
Support mixed precision for WeightNormalization

### DIFF
--- a/tensorflow_addons/layers/tests/wrappers_test.py
+++ b/tensorflow_addons/layers/tests/wrappers_test.py
@@ -32,6 +32,18 @@ def test_basic():
     )
 
 
+def test_basic_mixed_precision():
+    tf.keras.mixed_precision.experimental.set_policy("mixed_float16")
+    test_utils.layer_test(
+        wrappers.WeightNormalization,
+        kwargs={"layer": tf.keras.layers.Conv2D(5, (2, 2))},
+        input_shape=(2, 4, 4, 3),
+        input_dtype="float16",
+        expected_output_dtype="float16"
+    )
+    tf.keras.mixed_precision.experimental.set_policy("float32")
+
+
 def test_no_bias():
     test_utils.layer_test(
         wrappers.WeightNormalization,

--- a/tensorflow_addons/layers/tests/wrappers_test.py
+++ b/tensorflow_addons/layers/tests/wrappers_test.py
@@ -39,7 +39,7 @@ def test_basic_mixed_precision():
         kwargs={"layer": tf.keras.layers.Conv2D(5, (2, 2))},
         input_shape=(2, 4, 4, 3),
         input_dtype="float16",
-        expected_output_dtype="float16"
+        expected_output_dtype="float16",
     )
     tf.keras.mixed_precision.experimental.set_policy("float32")
 

--- a/tensorflow_addons/layers/wrappers.py
+++ b/tensorflow_addons/layers/wrappers.py
@@ -203,7 +203,9 @@ class WeightNormalization(tf.keras.layers.Wrapper):
             # Assign data dependent init values
             g_tensor = self.g.assign(tf.cast(self.g * scale_init, self.g.true_dtype))
             if hasattr(self.layer, "bias") and self.layer.bias is not None:
-                bias_tensor = self.layer.bias.assign(tf.cast(-m_init * scale_init, self.layer.bias.true_dtype))
+                bias_tensor = self.layer.bias.assign(
+                    tf.cast(-m_init * scale_init, self.layer.bias.true_dtype)
+                )
                 return [g_tensor, bias_tensor]
             else:
                 return [g_tensor]

--- a/tensorflow_addons/layers/wrappers.py
+++ b/tensorflow_addons/layers/wrappers.py
@@ -201,9 +201,9 @@ class WeightNormalization(tf.keras.layers.Wrapper):
                 scale_init = tf.tile(scale_init, [rep])
 
             # Assign data dependent init values
-            g_tensor = self.g.assign(self.g * scale_init)
+            g_tensor = self.g.assign(tf.cast(self.g * scale_init, self.g.true_dtype))
             if hasattr(self.layer, "bias") and self.layer.bias is not None:
-                bias_tensor = self.layer.bias.assign(-m_init * scale_init)
+                bias_tensor = self.layer.bias.assign(tf.cast(-m_init * scale_init, self.layer.bias.true_dtype))
                 return [g_tensor, bias_tensor]
             else:
                 return [g_tensor]


### PR DESCRIPTION
# Description

This fixes `WeightNormalization` when `data_init=True` and mixed precision is enabled. Previously, this setup would result in dtype conflicts in a couple variables in the layer.

Fixes # (issue)

## Type of change

- [x] Bug fix
- [ ] New Tutorial
- [ ] Updated or additional documentation
- [ ] Additional Testing
- [ ] New Activation and the changes conform to the [activation contribution guidelines](https://github.com/tensorflow/addons/blob/master/tensorflow_addons/activations/README.md#contribution-guidelines)
- [ ] New Callback and the changes conform to the [callback contribution guidelines](https://github.com/tensorflow/addons/blob/master/tensorflow_addons/callbacks/README.md#contribution-guidelines)
- [ ] New Image addition and the changes conform to the [image op contribution guidelines](https://github.com/tensorflow/addons/blob/master/tensorflow_addons/image/README.md#contribution-guidelines)
- [x] New Layer and the changes conform to the [layer contribution guidelines](https://github.com/tensorflow/addons/blob/master/tensorflow_addons/layers/README.md#contribution-guidelines)
- [ ] New Loss and the changes conform to the [loss contribution guidelines](https://github.com/tensorflow/addons/blob/master/tensorflow_addons/losses/README.md#contribution-guidelines)
- [ ] New Metric and the changes conform to the [metric contribution guidelines](https://github.com/tensorflow/addons/blob/master/tensorflow_addons/metrics/README.md#contribution-guidelines)
- [ ] New Optimizer and the changes conform to the [optimizer contribution guidelines](https://github.com/tensorflow/addons/blob/master/tensorflow_addons/optimizers/README.md#contribution-guidelines)
- [ ] New RNN Cell and the changes conform to the [rnn contribution guidelines](https://github.com/tensorflow/addons/blob/master/tensorflow_addons/rnn/README.md#contribution-guidelines)
- [ ] New Seq2seq addition and the changes conform to the [seq2seq contribution guidelines](https://github.com/tensorflow/addons/blob/master/tensorflow_addons/seq2seq/README.md#contribution-guidelines)
- [ ] New Text addition and the changes conform to the [text op contribution guidelines](https://github.com/tensorflow/addons/blob/master/tensorflow_addons/text/README.md#contribution-guidelines)

# Checklist:

- [x] I've properly [formatted my code according to the guidelines](https://github.com/tensorflow/addons/blob/master/CONTRIBUTING.md#coding-style)
    - [x] By running Black + Flake8
    - [x] By running pre-commit hooks
- [ ] This PR addresses an already submitted issue for TensorFlow Addons
- [ ] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] This PR contains modifications to C++ custom-ops

# How Has This Been Tested?

If you're adding a bugfix or new feature please describe the tests that you ran to verify your changes: I added a modified version of the basic layer test that enables mixed precision (then disables it to tear down).

