### PR TITLE
Calcuate decay once per step instead once per variable #moving_average

### DIFF
--- a/tensorflow_addons/optimizers/average_wrapper.py
+++ b/tensorflow_addons/optimizers/average_wrapper.py
@@ -48,36 +48,59 @@ class AveragedOptimizerWrapper(tf.keras.optimizers.Optimizer, metaclass=abc.ABCM
     def _create_hypers(self):
         self._optimizer._create_hypers()
 
-    def _prepare(self, var_list):
-        return self._optimizer._prepare(var_list=var_list)
+    def _prepare_local(self, var_device, var_dtype, apply_state):
+        return self._optimizer._prepare_local(var_device, var_dtype, apply_state)
 
     def apply_gradients(self, grads_and_vars, name=None, **kwargs):
         self._optimizer._iterations = self.iterations
         return super().apply_gradients(grads_and_vars, name, **kwargs)
 
     @abc.abstractmethod
-    def average_op(self, var, average_var):
+    def average_op(self, var, average_var, local_apply_state):
         raise NotImplementedError
 
-    def _apply_average_op(self, train_op, var):
+    def _apply_average_op(self, train_op, var, apply_state):
+        apply_state = apply_state or {}
+        local_apply_state = apply_state.get((var.device, var.dtype.base_dtype))
+        if local_apply_state is None:
+            local_apply_state = self._fallback_apply_state(
+                var.device, var.dtype.base_dtype
+            )
         average_var = self.get_slot(var, "average")
-        return self.average_op(var, average_var)
+        return self.average_op(var, average_var, local_apply_state)
 
-    def _resource_apply_dense(self, grad, var):
-        train_op = self._optimizer._resource_apply_dense(grad, var)
-        average_op = self._apply_average_op(train_op, var)
+    def _resource_apply_dense(self, grad, var, apply_state=None):
+        if "apply_state" in self._optimizer._dense_apply_args:
+            train_op = self._optimizer._resource_apply_dense(
+                grad, var, apply_state=apply_state
+            )
+        else:
+            train_op = self._optimizer._resource_apply_dense(grad, var)
+        average_op = self._apply_average_op(train_op, var, apply_state)
         return tf.group(train_op, average_op)
 
-    def _resource_apply_sparse(self, grad, var, indices):
-        train_op = self._optimizer._resource_apply_sparse(grad, var, indices)
-        average_op = self._apply_average_op(train_op, var)
+    def _resource_apply_sparse(self, grad, var, indices, apply_state=None):
+        if "apply_state" in self._optimizer._sparse_apply_args:
+            train_op = self._optimizer._resource_apply_sparse(
+                grad, var, indices, apply_state=apply_state
+            )
+        else:
+            train_op = self._optimizer._resource_apply_sparse(grad, var, indices)
+        average_op = self._apply_average_op(train_op, var, apply_state)
         return tf.group(train_op, average_op)
 
-    def _resource_apply_sparse_duplicate_indices(self, grad, var, indices):
-        train_op = self._optimizer._resource_apply_sparse_duplicate_indices(
-            grad, var, indices
-        )
-        average_op = self._apply_average_op(train_op, var)
+    def _resource_apply_sparse_duplicate_indices(
+        self, grad, var, indices, apply_state=None
+    ):
+        if "apply_state" in self._optimizer._sparse_apply_args:
+            train_op = self._optimizer._resource_apply_sparse_duplicate_indices(
+                grad, var, indices, apply_state=apply_state
+            )
+        else:
+            train_op = self._optimizer._resource_apply_sparse_duplicate_indices(
+                grad, var, indices
+            )
+        average_op = self._apply_average_op(train_op, var, apply_state)
         return tf.group(train_op, average_op)
 
     def assign_average_vars(self, var_list):

--- a/tensorflow_addons/optimizers/moving_average.py
+++ b/tensorflow_addons/optimizers/moving_average.py
@@ -107,9 +107,16 @@ class MovingAverage(AveragedOptimizerWrapper):
         else:
             return average_decay
 
-    def average_op(self, var, average_var):
-        decay = self._get_decay(self._optimizer.iterations)
-        return tf.keras.backend.moving_average_update(average_var, var, decay)
+    def _prepare_local(self, var_device, var_dtype, apply_state):
+        super()._prepare_local(var_device, var_dtype, apply_state)
+        apply_state[(var_device, var_dtype)]["tfa_ma_decay"] = self._get_decay(
+            self._optimizer.iterations
+        )
+
+    def average_op(self, var, average_var, local_apply_state):
+        return tf.keras.backend.moving_average_update(
+            average_var, var, local_apply_state["tfa_ma_decay"]
+        )
 
     def get_config(self):
         config = {

--- a/tensorflow_addons/optimizers/stochastic_weight_averaging.py
+++ b/tensorflow_addons/optimizers/stochastic_weight_averaging.py
@@ -113,7 +113,7 @@ class SWA(AveragedOptimizerWrapper):
         self._set_hyper("start_averaging", start_averaging)
 
     @tf.function
-    def average_op(self, var, average_var):
+    def average_op(self, var, average_var, local_apply_state):
         average_period = self._get_hyper("average_period", tf.dtypes.int64)
         start_averaging = self._get_hyper("start_averaging", tf.dtypes.int64)
         # number of times snapshots of weights have been taken (using max to


### PR DESCRIPTION
Calling _get_decay once per variable can greatly slow down kernel
launches as it contains control flows. By putting decay into apply state
we only need to calcuate it once per step. The same optimization
technicle is applied in keras optimizer for learning rate scheduler.

# Description

Brief Description of the PR:

Fixes # (issue)

## Type of change

- [x] Bug fix
- [ ] New Tutorial
- [ ] Updated or additional documentation
- [ ] Additional Testing
- [ ] New Activation and the changes conform to the [activation contribution guidelines](https://github.com/tensorflow/addons/blob/master/tensorflow_addons/activations/README.md#contribution-guidelines)
- [ ] New Callback and the changes conform to the [callback contribution guidelines](https://github.com/tensorflow/addons/blob/master/tensorflow_addons/callbacks/README.md#contribution-guidelines)
- [ ] New Image addition and the changes conform to the [image op contribution guidelines](https://github.com/tensorflow/addons/blob/master/tensorflow_addons/image/README.md#contribution-guidelines)
- [ ] New Layer and the changes conform to the [layer contribution guidelines](https://github.com/tensorflow/addons/blob/master/tensorflow_addons/layers/README.md#contribution-guidelines)
- [ ] New Loss and the changes conform to the [loss contribution guidelines](https://github.com/tensorflow/addons/blob/master/tensorflow_addons/losses/README.md#contribution-guidelines)
- [ ] New Metric and the changes conform to the [metric contribution guidelines](https://github.com/tensorflow/addons/blob/master/tensorflow_addons/metrics/README.md#contribution-guidelines)
- [ ] New Optimizer and the changes conform to the [optimizer contribution guidelines](https://github.com/tensorflow/addons/blob/master/tensorflow_addons/optimizers/README.md#contribution-guidelines)
- [ ] New RNN Cell and the changes conform to the [rnn contribution guidelines](https://github.com/tensorflow/addons/blob/master/tensorflow_addons/rnn/README.md#contribution-guidelines)
- [ ] New Seq2seq addition and the changes conform to the [seq2seq contribution guidelines](https://github.com/tensorflow/addons/blob/master/tensorflow_addons/seq2seq/README.md#contribution-guidelines)
- [ ] New Text addition and the changes conform to the [text op contribution guidelines](https://github.com/tensorflow/addons/blob/master/tensorflow_addons/text/README.md#contribution-guidelines)

# Checklist:

- [x] I've properly [formatted my code according to the guidelines](https://github.com/tensorflow/addons/blob/master/CONTRIBUTING.md#coding-style)
    - [ ] By running Black + Flake8
    - [x] By running pre-commit hooks
- [ ] This PR addresses an already submitted issue for TensorFlow Addons
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] This PR contains modifications to C++ custom-ops

# How Has This Been Tested?

python3 -m pytest tensorflow_addons/optimizers/tests/moving_average_test.py

If you're adding a bugfix or new feature please describe the tests that you ran to verify your changes:
*

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tensorflow/addons/2342)
<!-- Reviewable:end -->
