### PR TITLE
Add experimental_implements attribute to dense_image_warp

### DIFF
--- a/tensorflow_addons/image/dense_image_warp.py
+++ b/tensorflow_addons/image/dense_image_warp.py
@@ -158,7 +158,7 @@ def _get_dim(x, idx):
     return x.shape[idx] or tf.shape(x)[idx]
 
 
-@tf.function(experimental_implements="addons:DenseImageWarp")
+@tf.function
 def dense_image_warp(
     image: types.TensorLike, flow: types.TensorLike, name: Optional[str] = None
 ) -> tf.Tensor:
@@ -222,3 +222,18 @@ def dense_image_warp(
         interpolated = interpolate_bilinear(image, query_points_flattened)
         interpolated = tf.reshape(interpolated, [batch_size, height, width, channels])
         return interpolated
+
+
+@tf.function(experimental_implements="addons:DenseImageWarp")
+def dense_image_warp_annotated(
+    image: types.TensorLike, flow: types.TensorLike, name: Optional[str] = None
+) -> tf.Tensor:
+    """Similar to dense_image_warp but annotated with experimental_implements.
+
+    This annotation make the serialized function detectable by the TFLite MLIR
+    converter and allow the converter to convert it to corresponding TFLite op.
+
+    However, with the annotation, this function cannot be used with backprop
+    under `tf.GradientTape` objects.
+    """
+    return dense_image_warp(image, flow, name)

--- a/tensorflow_addons/image/dense_image_warp.py
+++ b/tensorflow_addons/image/dense_image_warp.py
@@ -158,7 +158,7 @@ def _get_dim(x, idx):
     return x.shape[idx] or tf.shape(x)[idx]
 
 
-@tf.function
+@tf.function(experimental_implements="addons:DenseImageWarp")
 def dense_image_warp(
     image: types.TensorLike, flow: types.TensorLike, name: Optional[str] = None
 ) -> tf.Tensor:

--- a/tools/testing/source_code_test.py
+++ b/tools/testing/source_code_test.py
@@ -149,6 +149,7 @@ def test_no_experimental_api():
     allowlist = [
         "tensorflow_addons/optimizers/weight_decay_optimizers.py",
         "tensorflow_addons/layers/max_unpooling_2d.py",
+        "tensorflow_addons/image/dense_image_warp.py",
     ]
     for file_path, line_idx, line in get_lines_of_source_code(allowlist):
 


### PR DESCRIPTION
This attribute will help the TFLite conversion convert the whole block to a single TFLite custom op, significantly reduce the runtime.

# Description

Add experimental_implements attribute to dense_image_warp

## Type of change

- [ ] Bug fix
- [ ] New Tutorial
- [ ] Updated or additional documentation
- [ ] Additional Testing
- [ ] New Activation and the changes conform to the [activation contribution guidelines](https://github.com/tensorflow/addons/blob/master/tensorflow_addons/activations/README.md#contribution-guidelines)
- [ ] New Callback and the changes conform to the [callback contribution guidelines](https://github.com/tensorflow/addons/blob/master/tensorflow_addons/callbacks/README.md#contribution-guidelines)
- [x] New Image addition and the changes conform to the [image op contribution guidelines](https://github.com/tensorflow/addons/blob/master/tensorflow_addons/image/README.md#contribution-guidelines)
- [ ] New Layer and the changes conform to the [layer contribution guidelines](https://github.com/tensorflow/addons/blob/master/tensorflow_addons/layers/README.md#contribution-guidelines)
- [ ] New Loss and the changes conform to the [loss contribution guidelines](https://github.com/tensorflow/addons/blob/master/tensorflow_addons/losses/README.md#contribution-guidelines)
- [ ] New Metric and the changes conform to the [metric contribution guidelines](https://github.com/tensorflow/addons/blob/master/tensorflow_addons/metrics/README.md#contribution-guidelines)
- [ ] New Optimizer and the changes conform to the [optimizer contribution guidelines](https://github.com/tensorflow/addons/blob/master/tensorflow_addons/optimizers/README.md#contribution-guidelines)
- [ ] New RNN Cell and the changes conform to the [rnn contribution guidelines](https://github.com/tensorflow/addons/blob/master/tensorflow_addons/rnn/README.md#contribution-guidelines)
- [ ] New Seq2seq addition and the changes conform to the [seq2seq contribution guidelines](https://github.com/tensorflow/addons/blob/master/tensorflow_addons/seq2seq/README.md#contribution-guidelines)
- [ ] New Text addition and the changes conform to the [text op contribution guidelines](https://github.com/tensorflow/addons/blob/master/tensorflow_addons/text/README.md#contribution-guidelines)

# Checklist:

- [x] I've properly [formatted my code according to the guidelines](https://github.com/tensorflow/addons/blob/master/CONTRIBUTING.md#coding-style)
    - [x] By running Black + Flake8
    - [ ] By running pre-commit hooks
- [ ] This PR addresses an already submitted issue for TensorFlow Addons
- [ ] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] This PR contains modifications to C++ custom-ops

# How Has This Been Tested?

