### PR TITLE
Handle the case when mask size is larger than the image size in

### DIFF
--- a/tensorflow_addons/image/cutout_ops.py
+++ b/tensorflow_addons/image/cutout_ops.py
@@ -32,6 +32,20 @@ def _norm_params(mask_size, offset=None):
     return mask_size, offset
 
 
+@tf.function
+def _random_center(mask_dim_length, image_dim_length, batch_size, seed):
+    if mask_dim_length >= image_dim_length:
+        return tf.tile([image_dim_length // 2], [batch_size])
+    half_mask_dim_length = mask_dim_length // 2
+    return tf.random.uniform(
+        shape=[batch_size],
+        minval=half_mask_dim_length,
+        maxval=image_dim_length - half_mask_dim_length,
+        dtype=tf.int32,
+        seed=seed,
+    )
+
+
 def random_cutout(
     images: TensorLike,
     mask_size: TensorLike,
@@ -71,23 +85,8 @@ def random_cutout(
 
     mask_size, _ = _norm_params(mask_size, offset=None)
 
-    half_mask_height = mask_size[0] // 2
-    half_mask_width = mask_size[1] // 2
-
-    cutout_center_height = tf.random.uniform(
-        shape=[batch_size],
-        minval=half_mask_height,
-        maxval=image_height - half_mask_height,
-        dtype=tf.int32,
-        seed=seed,
-    )
-    cutout_center_width = tf.random.uniform(
-        shape=[batch_size],
-        minval=half_mask_width,
-        maxval=image_width - half_mask_width,
-        dtype=tf.int32,
-        seed=seed,
-    )
+    cutout_center_height = _random_center(mask_size[0], image_height, batch_size, seed)
+    cutout_center_width = _random_center(mask_size[1], image_width, batch_size, seed)
 
     offset = tf.transpose([cutout_center_height, cutout_center_width], [1, 0])
     return cutout(images, mask_size, offset, constant_values)

--- a/tensorflow_addons/image/tests/cutout_ops_test.py
+++ b/tensorflow_addons/image/tests/cutout_ops_test.py
@@ -71,6 +71,12 @@ def test_mask_applied():
     )
 
 
+def test_mask_larger_than_image():
+    test_image = tf.ones([10, 40, 40, 1], dtype=np.uint8)
+    result_image = random_cutout(test_image, 60, seed=1234)
+    np.testing.assert_equal(np.sum(result_image), 0)
+
+
 def test_keras_layer():
     inputs = tf.keras.Input(shape=(40, 40, 1), dtype=tf.uint8)
     outputs = tf.keras.layers.Lambda(lambda x: cutout(x, 4, [2, 2]))(inputs)


### PR DESCRIPTION
random_cutoff

tf.random.uniform requires that minval is smaller than maxval.

# Description

Brief Description of the PR:

Fixes # (issue)

## Type of change

- [x] Bug fix
- [ ] New Tutorial
- [ ] Updated or additional documentation
- [x] Additional Testing
- [ ] New Activation and the changes conform to the [activation contribution guidelines](https://github.com/tensorflow/addons/blob/master/tensorflow_addons/activations/README.md#contribution-guidelines)
- [ ] New Callback and the changes conform to the [callback contribution guidelines](https://github.com/tensorflow/addons/blob/master/tensorflow_addons/callbacks/README.md#contribution-guidelines)
- [ ] New Image addition and the changes conform to the [image op contribution guidelines](https://github.com/tensorflow/addons/blob/master/tensorflow_addons/image/README.md#contribution-guidelines)
- [ ] New Layer and the changes conform to the [layer contribution guidelines](https://github.com/tensorflow/addons/blob/master/tensorflow_addons/layers/README.md#contribution-guidelines)
- [ ] New Loss and the changes conform to the [loss contribution guidelines](https://github.com/tensorflow/addons/blob/master/tensorflow_addons/losses/README.md#contribution-guidelines)
- [ ] New Metric and the changes conform to the [metric contribution guidelines](https://github.com/tensorflow/addons/blob/master/tensorflow_addons/metrics/README.md#contribution-guidelines)
- [ ] New Optimizer and the changes conform to the [optimizer contribution guidelines](https://github.com/tensorflow/addons/blob/master/tensorflow_addons/optimizers/README.md#contribution-guidelines)
- [ ] New RNN Cell and the changes conform to the [rnn contribution guidelines](https://github.com/tensorflow/addons/blob/master/tensorflow_addons/rnn/README.md#contribution-guidelines)
- [ ] New Seq2seq addition and the changes conform to the [seq2seq contribution guidelines](https://github.com/tensorflow/addons/blob/master/tensorflow_addons/seq2seq/README.md#contribution-guidelines)
- [ ] New Text addition and the changes conform to the [text op contribution guidelines](https://github.com/tensorflow/addons/blob/master/tensorflow_addons/text/README.md#contribution-guidelines)

# Checklist:

- [x] I've properly [formatted my code according to the guidelines](https://github.com/tensorflow/addons/blob/master/CONTRIBUTING.md#coding-style)
    - [ ] By running Black + Flake8
    - [x] By running pre-commit hooks
- [ ] This PR addresses an already submitted issue for TensorFlow Addons
- [ ] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] This PR contains modifications to C++ custom-ops

# How Has This Been Tested?

If you're adding a bugfix or new feature please describe the tests that you ran to verify your changes:
*

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tensorflow/addons/2348)
<!-- Reviewable:end -->
