### PR TITLE
Default compile with AVX support

### DIFF
--- a/configure.py
+++ b/configure.py
@@ -116,12 +116,12 @@ def create_build_configuration():
         write("build:windows --enable_runfiles")
         write("build:windows --copt=/experimental:preprocessor")
         write("build:windows --host_copt=/experimental:preprocessor")
-        write("build:windows --copt=/arch=AVX2")
+        write("build:windows --copt=/arch=AVX")
         write("build:windows --cxxopt=/std:c++14")
         write("build:windows --host_cxxopt=/std:c++14")
 
     if is_macos() or is_linux():
-        write("build --copt=-mavx2")
+        write("build --copt=-mavx")
         write("build --cxxopt=-std=c++14")
         write("build --host_cxxopt=-std=c++14")
 


### PR DESCRIPTION
# Description
Default compile with only AVX (not AVX2) support. We can release a 0.12.1 patch in the coming weeks

Fixes #2336
