### PR TITLE
Update 2.4.1

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -40,7 +40,7 @@ jobs:
       matrix:
         os: ['macos-latest', 'windows-latest', 'ubuntu-18.04']
         py-version: ['3.6', '3.7', '3.8']
-        tf-version: ['2.3.0', '2.4.0']
+        tf-version: ['2.3.0', '2.4.1']
       fail-fast: false
     steps:
       - uses: actions/github-script@0.3.0

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -81,7 +81,7 @@ jobs:
       matrix:
         os: ['macOS', 'Windows', 'Linux']
         py-version: ['3.6', '3.7', '3.8']
-        tf-version: ['2.4.0']
+        tf-version: ['2.4.1']
       fail-fast: false
     if: (github.event_name == 'push' && github.ref == 'refs/heads/master') || github.event_name == 'release'
     steps:


### PR DESCRIPTION
# Description

Typically we don't need to build against minor versions, but since 2.4.1 changes compilation settings we should align. Planning on a 0.12.1 release for TFA after these go through