### PR TITLE
 Use full length SHA per GitHub guidelines

### DIFF
--- a/.github/workflows/backport.yml
+++ b/.github/workflows/backport.yml
@@ -12,7 +12,7 @@ jobs:
     steps:
       - name: Backport Bot
         if: github.event.pull_request.merged && ( ( github.event.action == 'closed' && contains( join( github.event.pull_request.labels.*.name ), 'backport') ) || contains( github.event.label.name, 'backport' ) )
-        uses: Gaurav0/backport@d69fd1d # Version 1.0.24
+        uses: Gaurav0/backport@d69fd1d2469762a7b4007f671857e4f94deed0af # Version 1.0.24
         with:
           bot_username: bot-of-gabrieldemarmiesse
           bot_token: 1353d990cdb8b8ceb1b73d301dce83cc0da3db29

--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -10,7 +10,7 @@ jobs:
   update_release_draft:
     runs-on: ubuntu-latest
     steps:
-      - uses: release-drafter/release-drafter@74e7c42 # Version 5.7.0
+      - uses: release-drafter/release-drafter@74e7c423dafbb406c9c18b1638334f67a7c891c3 # Version 5.7.0
         with:
           config-name: release-template.yml
         env:


### PR DESCRIPTION
# Description
GitHub will be dropping support for shortened hashes in Actions on Feb 15th:
https://docs.github.com/en/actions/learn-github-actions/security-hardening-for-github-actions#using-third-party-actions
![image](https://user-images.githubusercontent.com/18154355/106359752-75d87280-62c9-11eb-9505-1a40dcf40f04.png)
