### PR TITLE
variable histogram bins added

### DIFF
--- a/tensorflow_addons/image/color_ops.py
+++ b/tensorflow_addons/image/color_ops.py
@@ -31,7 +31,6 @@ def _scale_channel(
     image: TensorLike, channel: int, bins: Optional[int] = 256
 ) -> tf.Tensor:
     """Scale the data in the channel to implement equalize."""
-    assert bins >= 256, "Number of histogram bins should be at least 256"
     image_dtype = image.dtype
     image = tf.cast(image[:, :, channel], tf.int32)
 

--- a/tensorflow_addons/image/color_ops.py
+++ b/tensorflow_addons/image/color_ops.py
@@ -28,7 +28,7 @@ from functools import partial
 
 
 def _scale_channel(
-    image: TensorLike, channel: int, bins: Optional[int] = 256
+    image: TensorLike, channel: int, bins: int = 256
 ) -> tf.Tensor:
     """Scale the data in the channel to implement equalize."""
     image_dtype = image.dtype
@@ -53,7 +53,7 @@ def _scale_channel(
     return tf.cast(result, image_dtype)
 
 
-def _equalize_image(image: TensorLike, bins: Optional[int] = 256) -> tf.Tensor:
+def _equalize_image(image: TensorLike, bins: int = 256) -> tf.Tensor:
     """Implements Equalize function from PIL using TF ops."""
     image = tf.stack(
         [_scale_channel(image, c, bins) for c in range(image.shape[-1])], -1
@@ -63,7 +63,7 @@ def _equalize_image(image: TensorLike, bins: Optional[int] = 256) -> tf.Tensor:
 
 @tf.function
 def equalize(
-    image: TensorLike, bins: Optional[int] = 256, name: Optional[str] = None
+    image: TensorLike, bins: int = 256, name: Optional[str] = None
 ) -> tf.Tensor:
     """Equalize image(s)
 

--- a/tensorflow_addons/image/color_ops.py
+++ b/tensorflow_addons/image/color_ops.py
@@ -39,7 +39,10 @@ def _scale_channel(
 
     # For the purposes of computing the step, filter out the nonzeros.
     nonzero_histo = tf.boolean_mask(histo, histo != 0)
-    step = (tf.reduce_sum(nonzero_histo) - nonzero_histo[-1]) // bins - 1
+    if (bins - 1) == 0:
+        step = tf.reduce_sum(nonzero_histo) - nonzero_histo[-1]
+    else:
+        step = (tf.reduce_sum(nonzero_histo) - nonzero_histo[-1]) // bins - 1
 
     # If step is zero, return the original image.  Otherwise, build
     # lut from the full histogram and step and then index from it.

--- a/tensorflow_addons/image/color_ops.py
+++ b/tensorflow_addons/image/color_ops.py
@@ -31,6 +31,7 @@ def _scale_channel(
     image: TensorLike, channel: int, bins: Optional[int] = 256
 ) -> tf.Tensor:
     """Scale the data in the channel to implement equalize."""
+    assert bins >= 256, "Number of histogram bins should be at least 256"
     image_dtype = image.dtype
     image = tf.cast(image[:, :, channel], tf.int32)
 
@@ -39,10 +40,7 @@ def _scale_channel(
 
     # For the purposes of computing the step, filter out the nonzeros.
     nonzero_histo = tf.boolean_mask(histo, histo != 0)
-    if (bins - 1) == 0:
-        step = tf.reduce_sum(nonzero_histo) - nonzero_histo[-1]
-    else:
-        step = (tf.reduce_sum(nonzero_histo) - nonzero_histo[-1]) // (bins - 1)
+    step = (tf.reduce_sum(nonzero_histo) - nonzero_histo[-1]) // (bins - 1)
 
     # If step is zero, return the original image.  Otherwise, build
     # lut from the full histogram and step and then index from it.

--- a/tensorflow_addons/image/color_ops.py
+++ b/tensorflow_addons/image/color_ops.py
@@ -27,17 +27,17 @@ from typing import Optional
 from functools import partial
 
 
-def _scale_channel(image: TensorLike, channel: int) -> tf.Tensor:
+def _scale_channel(image: TensorLike, channel: int, bins: Optional[int] = 256) -> tf.Tensor:
     """Scale the data in the channel to implement equalize."""
     image_dtype = image.dtype
     image = tf.cast(image[:, :, channel], tf.int32)
 
     # Compute the histogram of the image channel.
-    histo = tf.histogram_fixed_width(image, [0, 255], nbins=256)
+    histo = tf.histogram_fixed_width(image, [0, bins-1], nbins=bins)
 
     # For the purposes of computing the step, filter out the nonzeros.
     nonzero_histo = tf.boolean_mask(histo, histo != 0)
-    step = (tf.reduce_sum(nonzero_histo) - nonzero_histo[-1]) // 255
+    step = (tf.reduce_sum(nonzero_histo) - nonzero_histo[-1]) // bins-1
 
     # If step is zero, return the original image.  Otherwise, build
     # lut from the full histogram and step and then index from it.
@@ -45,20 +45,20 @@ def _scale_channel(image: TensorLike, channel: int) -> tf.Tensor:
         result = image
     else:
         lut_values = (tf.cumsum(histo, exclusive=True) + (step // 2)) // step
-        lut_values = tf.clip_by_value(lut_values, 0, 255)
+        lut_values = tf.clip_by_value(lut_values, 0, bins-1)
         result = tf.gather(lut_values, image)
 
     return tf.cast(result, image_dtype)
 
 
-def _equalize_image(image: TensorLike) -> tf.Tensor:
+def _equalize_image(image: TensorLike, bins: Optional[int] = 256) -> tf.Tensor:
     """Implements Equalize function from PIL using TF ops."""
-    image = tf.stack([_scale_channel(image, c) for c in range(image.shape[-1])], -1)
+    image = tf.stack([_scale_channel(image, c, bins) for c in range(image.shape[-1])], -1)
     return image
 
 
 @tf.function
-def equalize(image: TensorLike, name: Optional[str] = None) -> tf.Tensor:
+def equalize(image: TensorLike, bins: Optional[int] = 256, name: Optional[str] = None) -> tf.Tensor:
     """Equalize image(s)
 
     Args:
@@ -67,6 +67,7 @@ def equalize(image: TensorLike, name: Optional[str] = None) -> tf.Tensor:
           `(num_rows, num_columns, num_channels)` (HWC), or
           `(num_rows, num_columns)` (HW). The rank must be statically known (the
           shape is not `TensorShape(None)`).
+      bins: The number of bins in the histogram.
       name: The name of the op.
     Returns:
       Image(s) with the same type and shape as `images`, equalized.
@@ -75,7 +76,7 @@ def equalize(image: TensorLike, name: Optional[str] = None) -> tf.Tensor:
         image_dims = tf.rank(image)
         image = to_4D_image(image)
         fn = partial(_equalize_image)
-        image = tf.map_fn(fn, image)
+        image = tf.map_fn(lambda x: fn(x, bins), image)
         return from_4D_image(image, image_dims)
 
 

--- a/tensorflow_addons/image/color_ops.py
+++ b/tensorflow_addons/image/color_ops.py
@@ -27,7 +27,9 @@ from typing import Optional
 from functools import partial
 
 
-def _scale_channel(image: TensorLike, channel: int, bins: Optional[int] = 256) -> tf.Tensor:
+def _scale_channel(image: TensorLike,
+                   channel: int,
+                   bins: Optional[int] = 256) -> tf.Tensor:
     """Scale the data in the channel to implement equalize."""
     image_dtype = image.dtype
     image = tf.cast(image[:, :, channel], tf.int32)
@@ -51,14 +53,17 @@ def _scale_channel(image: TensorLike, channel: int, bins: Optional[int] = 256) -
     return tf.cast(result, image_dtype)
 
 
-def _equalize_image(image: TensorLike, bins: Optional[int] = 256) -> tf.Tensor:
+def _equalize_image(image: TensorLike,
+                    bins: Optional[int] = 256) -> tf.Tensor:
     """Implements Equalize function from PIL using TF ops."""
     image = tf.stack([_scale_channel(image, c, bins) for c in range(image.shape[-1])], -1)
     return image
 
 
 @tf.function
-def equalize(image: TensorLike, bins: Optional[int] = 256, name: Optional[str] = None) -> tf.Tensor:
+def equalize(image: TensorLike,
+             bins: Optional[int] = 256,
+             name: Optional[str] = None) -> tf.Tensor:
     """Equalize image(s)
 
     Args:

--- a/tensorflow_addons/image/color_ops.py
+++ b/tensorflow_addons/image/color_ops.py
@@ -42,7 +42,7 @@ def _scale_channel(
     if (bins - 1) == 0:
         step = tf.reduce_sum(nonzero_histo) - nonzero_histo[-1]
     else:
-        step = (tf.reduce_sum(nonzero_histo) - nonzero_histo[-1]) // bins - 1
+        step = (tf.reduce_sum(nonzero_histo) - nonzero_histo[-1]) // (bins - 1)
 
     # If step is zero, return the original image.  Otherwise, build
     # lut from the full histogram and step and then index from it.

--- a/tensorflow_addons/image/color_ops.py
+++ b/tensorflow_addons/image/color_ops.py
@@ -27,9 +27,7 @@ from typing import Optional
 from functools import partial
 
 
-def _scale_channel(
-    image: TensorLike, channel: int, bins: int = 256
-) -> tf.Tensor:
+def _scale_channel(image: TensorLike, channel: int, bins: int = 256) -> tf.Tensor:
     """Scale the data in the channel to implement equalize."""
     image_dtype = image.dtype
     image = tf.cast(image[:, :, channel], tf.int32)

--- a/tensorflow_addons/image/tests/color_ops_test.py
+++ b/tensorflow_addons/image/tests/color_ops_test.py
@@ -54,12 +54,12 @@ def test_equalize_with_PIL():
 @pytest.mark.usefixtures("maybe_run_functions_eagerly")
 def test_equalize_with_skimage():
     np.random.seed(0)
-    image = np.random.randint(low=0, high=256, size=(4, 3, 3, 3), dtype=np.uint8)
+    image = np.random.randint(low=0, high=256, size=(10, 10, 3, 3), dtype=np.uint8)
     bins = np.random.randint(low=256, dtype=np.int32)
     equalized = tf.cast(color_ops.equalize(tf.constant(image), bins), np.float16)
-    normal_equalized = tf.math.divide(equalized, 255)
     skiequalized = equalize_hist(image, bins)
-    np.testing.assert_allclose(normal_equalized, skiequalized, rtol=0.05, atol=0.10)
+    skiequalized = tf.math.multiply(skiequalized, 255)
+    np.testing.assert_allclose(equalized, skiequalized, rtol=0.05, atol=1)
 
 
 @pytest.mark.parametrize("dtype", _DTYPES)

--- a/tensorflow_addons/image/tests/color_ops_test.py
+++ b/tensorflow_addons/image/tests/color_ops_test.py
@@ -54,12 +54,17 @@ def test_equalize_with_PIL():
 @pytest.mark.usefixtures("maybe_run_functions_eagerly")
 def test_equalize_with_skimage():
     np.random.seed(0)
-    image = np.random.randint(low=0, high=256, size=(10, 10, 3, 3), dtype=np.uint8)
+    image = np.random.randint(low=0, high=256, size=(5, 5, 3, 3), dtype=np.uint8)
     bins = np.random.randint(low=256, dtype=np.int32)
     equalized = tf.cast(color_ops.equalize(tf.constant(image), bins), np.float16)
+    equalized = tf.math.divide(equalized, 255)
     skiequalized = equalize_hist(image, bins)
-    skiequalized = tf.math.multiply(skiequalized, 255)
-    np.testing.assert_allclose(equalized, skiequalized, rtol=0.05, atol=1)
+    assert (
+        tf.reduce_mean(
+            tf.math.abs(tf.reshape(tf.math.subtract(equalized, skiequalized), [-1]))
+        )
+        <= 0.015
+    ), "Greater than 1.5% difference in arrays"
 
 
 @pytest.mark.parametrize("dtype", _DTYPES)

--- a/tensorflow_addons/image/tests/color_ops_test.py
+++ b/tensorflow_addons/image/tests/color_ops_test.py
@@ -52,10 +52,10 @@ def test_equalize_with_PIL():
 
 
 @pytest.mark.usefixtures("maybe_run_functions_eagerly")
-def test_equalize_with_skimage():
+@pytest.mark.parametrize("bins", [256, 65536])
+def test_equalize_with_skimage(bins):
     np.random.seed(0)
     image = np.random.randint(low=0, high=256, size=(5, 5, 3, 3), dtype=np.uint8)
-    bins = np.random.randint(low=256, dtype=np.int32)
     equalized = tf.cast(color_ops.equalize(tf.constant(image), bins), np.float16)
     equalized = tf.math.divide(equalized, 255)
     skiequalized = equalize_hist(image, bins)

--- a/tensorflow_addons/image/tests/color_ops_test.py
+++ b/tensorflow_addons/image/tests/color_ops_test.py
@@ -64,7 +64,12 @@ def test_equalize_with_skimage(bins):
             tf.math.abs(tf.reshape(tf.math.subtract(equalized, skiequalized), [-1]))
         )
         <= 0.015
-    ), "Greater than 1.5% difference in arrays"
+    ), "Greater than 0.015 mean absolute difference in arrays"
+    # Test asserts a tolerance of at least 0.015 mean difference between the two
+    # arrays due to the difference in implementation between PIL and skimage.
+    # PIL's and skimage's equalized arrays can have a mean difference ranging
+    # from 0.006-0.036 according showcase done in
+    # https://github.com/tensorflow/addons/pull/2381
 
 
 @pytest.mark.parametrize("dtype", _DTYPES)

--- a/tensorflow_addons/image/tests/color_ops_test.py
+++ b/tensorflow_addons/image/tests/color_ops_test.py
@@ -20,6 +20,7 @@ import numpy as np
 
 from tensorflow_addons.image import color_ops
 from PIL import Image, ImageOps, ImageEnhance
+from skimage.exposure import equalize_hist
 
 _DTYPES = {
     np.uint8,
@@ -48,6 +49,17 @@ def test_equalize_with_PIL():
     image = np.random.randint(low=0, high=255, size=(4, 3, 3, 3), dtype=np.uint8)
     equalized = np.stack([ImageOps.equalize(Image.fromarray(i)) for i in image])
     np.testing.assert_equal(color_ops.equalize(tf.constant(image)).numpy(), equalized)
+
+
+@pytest.mark.usefixtures("maybe_run_functions_eagerly")
+def test_equalize_with_skimage():
+    np.random.seed(0)
+    image = np.random.randint(low=0, high=256, size=(4, 3, 3, 3), dtype=np.uint8)
+    bins = np.random.randint(low=256, dtype=np.int32)
+    equalized = tf.cast(color_ops.equalize(tf.constant(image), bins), np.float16)
+    normal_equalized = tf.math.divide(equalized, 255)
+    skiequalized = equalize_hist(image, bins)
+    np.testing.assert_allclose(normal_equalized, skiequalized, rtol=0.05, atol=0.10)
 
 
 @pytest.mark.parametrize("dtype", _DTYPES)


### PR DESCRIPTION
# Description

Changes the equalization method in color_ops.py to take in a variable number of histogram bins.

Fixes #2379

## Type of change

- [x] Bug fix
- [x] Updated or additional documentation

# Checklist:

- [x] I've properly [formatted my code according to the guidelines](https://github.com/tensorflow/addons/blob/master/CONTRIBUTING.md#coding-style)
    - [x] By running Black + Flake8
    - [ ] By running pre-commit hooks
- [x] This PR addresses an already submitted issue for TensorFlow Addons
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] This PR contains modifications to C++ custom-ops

# How Has This Been Tested?

Function has been sanity tested to be the same as the old equalize_image and past tests should still pass. This PR adds `bins` as an optional `int` parameter which defaults to `256` to ensure backwards compatibility. The expected use case of this parameter is for imaging data which has greater dynamic range than 8-bit.