### PR TITLE
Add python fallback for adjust_hsv_in_yiq

### DIFF
--- a/tensorflow_addons/image/distort_image_ops.py
+++ b/tensorflow_addons/image/distort_image_ops.py
@@ -14,11 +14,14 @@
 # ==============================================================================
 """Python layer for distort_image_ops."""
 
+from typing import Optional
+import warnings
+
 import tensorflow as tf
+
+from tensorflow_addons import options
 from tensorflow_addons.utils.resource_loader import LazySO
 from tensorflow_addons.utils.types import Number, TensorLike
-
-from typing import Optional
 
 _distort_image_so = LazySO("custom_ops/image/_distort_image_ops.so")
 
@@ -99,6 +102,43 @@ def random_hsv_in_yiq(
         )
 
 
+def _adjust_hsv_in_yiq(
+    image,
+    delta_hue,
+    scale_saturation,
+    scale_value,
+):
+    if image.shape.rank is not None and image.shape.rank < 3:
+        raise ValueError("input must be at least 3-D.")
+    if image.shape[-1] is not None and image.shape[-1] != 3:
+        raise ValueError(
+            "input must have 3 channels but instead has {}.".format(image.shape[-1])
+        )
+    # Construct hsv linear transformation matrix in YIQ space.
+    # https://beesbuzz.biz/code/hsv_color_transforms.php
+    yiq = tf.constant(
+        [[0.299, 0.596, 0.211], [0.587, -0.274, -0.523], [0.114, -0.322, 0.312]],
+        dtype=tf.float32,
+    )
+    yiq_inverse = tf.constant(
+        [
+            [1.0, 1.0, 1.0],
+            [0.95617069, -0.2726886, -1.103744],
+            [0.62143257, -0.64681324, 1.70062309],
+        ],
+        dtype=tf.float32,
+    )
+    vsu = scale_value * scale_saturation * tf.math.cos(delta_hue)
+    vsw = scale_value * scale_saturation * tf.math.sin(delta_hue)
+    hsv_transform = tf.convert_to_tensor(
+        [[scale_value, 0, 0], [0, vsu, vsw], [0, -vsw, vsu]], dtype=tf.float32
+    )
+    transform_matrix = yiq @ hsv_transform @ yiq_inverse
+
+    image = image @ transform_matrix
+    return image
+
+
 def adjust_hsv_in_yiq(
     image: TensorLike,
     delta_hue: Number = 0,
@@ -132,13 +172,31 @@ def adjust_hsv_in_yiq(
     """
     with tf.name_scope(name or "adjust_hsv_in_yiq"):
         image = tf.convert_to_tensor(image, name="image")
+        delta_hue = tf.cast(delta_hue, dtype=tf.float32, name="delta_hue")
+        scale_saturation = tf.cast(
+            scale_saturation, dtype=tf.float32, name="scale_saturation"
+        )
+        scale_value = tf.cast(scale_value, dtype=tf.float32, name="scale_value")
 
         # Remember original dtype to so we can convert back if needed
         orig_dtype = image.dtype
-        flt_image = tf.image.convert_image_dtype(image, tf.dtypes.float32)
+        image = tf.image.convert_image_dtype(image, tf.float32)
 
-        rgb_altered = _distort_image_so.ops.addons_adjust_hsv_in_yiq(
-            flt_image, delta_hue, scale_saturation, scale_value
-        )
+        if not options.TF_ADDONS_PY_OPS:
+            warnings.warn(
+                "C++/CUDA kernel of `adjust_hsv_in_yiq` will be removed in Addons `0.13`.",
+                DeprecationWarning,
+            )
+            try:
+                image = _distort_image_so.ops.addons_adjust_hsv_in_yiq(
+                    image, delta_hue, scale_saturation, scale_value
+                )
+            except tf.errors.NotFoundError:
+                options.warn_fallback("adjust_hsv_in_yiq")
+                image = _adjust_hsv_in_yiq(
+                    image, delta_hue, scale_saturation, scale_value
+                )
+        else:
+            image = _adjust_hsv_in_yiq(image, delta_hue, scale_saturation, scale_value)
 
-        return tf.image.convert_image_dtype(rgb_altered, orig_dtype)
+        return tf.image.convert_image_dtype(image, orig_dtype)

--- a/tensorflow_addons/image/tests/distort_image_ops_test.py
+++ b/tensorflow_addons/image/tests/distort_image_ops_test.py
@@ -101,7 +101,7 @@ def test_invalid_rank_hsv():
     x_np = np.random.rand(2, 3) * 255.0
     delta_h = np.random.rand() * 2.0 - 1.0
     with pytest.raises(
-        tf.errors.InvalidArgumentError, match="input must be at least 3-D"
+        (tf.errors.InvalidArgumentError, ValueError), match="input must be at least 3-D"
     ):
         _adjust_hue_in_yiq_tf(x_np, delta_h)
 
@@ -111,7 +111,7 @@ def test_invalid_channels_hsv():
     x_np = np.random.rand(4, 2, 4) * 255.0
     delta_h = np.random.rand() * 2.0 - 1.0
     with pytest.raises(
-        tf.errors.InvalidArgumentError,
+        (tf.errors.InvalidArgumentError, ValueError),
         match="input must have 3 channels but instead has 4",
     ):
         _adjust_hue_in_yiq_tf(x_np, delta_h)
@@ -190,7 +190,8 @@ def test_invalid_rank_value():
     scale = np.random.rand() * 2.0 - 1.0
     if tf.executing_eagerly():
         with pytest.raises(
-            tf.errors.InvalidArgumentError, match="input must be at least 3-D"
+            (tf.errors.InvalidArgumentError, ValueError),
+            match="input must be at least 3-D",
         ):
             _adjust_value_in_yiq_tf(x_np, scale)
     else:
@@ -205,7 +206,7 @@ def test_invalid_channels_value():
     scale = np.random.rand() * 2.0 - 1.0
     if tf.executing_eagerly():
         with pytest.raises(
-            tf.errors.InvalidArgumentError,
+            (tf.errors.InvalidArgumentError, ValueError),
             match="input must have 3 channels but instead has 4",
         ):
             _adjust_value_in_yiq_tf(x_np, scale)
@@ -270,13 +271,13 @@ def test_invalid_rank():
     scale = np.random.rand() * 2.0 - 1.0
 
     msg = "input must be at least 3-D"
-    with pytest.raises(tf.errors.InvalidArgumentError, match=msg):
+    with pytest.raises((tf.errors.InvalidArgumentError, ValueError), match=msg):
         _adjust_saturation_in_yiq_tf(x_np, scale).numpy()
 
 
 def test_invalid_channels():
     x_np = np.random.rand(4, 2, 4) * 255.0
     scale = np.random.rand() * 2.0 - 1.0
-    msg = "input must have 3 channels but instead has 4 "
-    with pytest.raises(tf.errors.InvalidArgumentError, match=msg):
+    msg = "input must have 3 channels but instead has 4"
+    with pytest.raises((tf.errors.InvalidArgumentError, ValueError), match=msg):
         _adjust_saturation_in_yiq_tf(x_np, scale).numpy()


### PR DESCRIPTION
# Description

Adds python fallback for adjust_hsv_in_yiq. It's just a simple matmul, I do not see any performance regression when switching to python.

## Type of change

- [ ] Bug fix
- [ ] New Tutorial
- [ ] Updated or additional documentation
- [ ] Additional Testing
- [ ] New Activation and the changes conform to the [activation contribution guidelines](https://github.com/tensorflow/addons/blob/master/tensorflow_addons/activations/README.md#contribution-guidelines)
- [ ] New Callback and the changes conform to the [callback contribution guidelines](https://github.com/tensorflow/addons/blob/master/tensorflow_addons/callbacks/README.md#contribution-guidelines)
- [ ] New Image addition and the changes conform to the [image op contribution guidelines](https://github.com/tensorflow/addons/blob/master/tensorflow_addons/image/README.md#contribution-guidelines)
- [ ] New Layer and the changes conform to the [layer contribution guidelines](https://github.com/tensorflow/addons/blob/master/tensorflow_addons/layers/README.md#contribution-guidelines)
- [ ] New Loss and the changes conform to the [loss contribution guidelines](https://github.com/tensorflow/addons/blob/master/tensorflow_addons/losses/README.md#contribution-guidelines)
- [ ] New Metric and the changes conform to the [metric contribution guidelines](https://github.com/tensorflow/addons/blob/master/tensorflow_addons/metrics/README.md#contribution-guidelines)
- [ ] New Optimizer and the changes conform to the [optimizer contribution guidelines](https://github.com/tensorflow/addons/blob/master/tensorflow_addons/optimizers/README.md#contribution-guidelines)
- [ ] New RNN Cell and the changes conform to the [rnn contribution guidelines](https://github.com/tensorflow/addons/blob/master/tensorflow_addons/rnn/README.md#contribution-guidelines)
- [ ] New Seq2seq addition and the changes conform to the [seq2seq contribution guidelines](https://github.com/tensorflow/addons/blob/master/tensorflow_addons/seq2seq/README.md#contribution-guidelines)
- [ ] New Text addition and the changes conform to the [text op contribution guidelines](https://github.com/tensorflow/addons/blob/master/tensorflow_addons/text/README.md#contribution-guidelines)

# Checklist:

- [x] I've properly [formatted my code according to the guidelines](https://github.com/tensorflow/addons/blob/master/CONTRIBUTING.md#coding-style)
    - [ ] By running Black + Flake8
    - [ ] By running pre-commit hooks
- [ ] This PR addresses an already submitted issue for TensorFlow Addons
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] This PR contains modifications to C++ custom-ops

# How Has This Been Tested?

Passes existing tests.