### PR TITLE
fix SpectralNormalization for mixed_precision

### DIFF
--- a/tensorflow_addons/layers/spectral_normalization.py
+++ b/tensorflow_addons/layers/spectral_normalization.py
@@ -124,8 +124,8 @@ class SpectralNormalization(tf.keras.layers.Wrapper):
             sigma = tf.matmul(tf.matmul(v, w), u, transpose_b=True)
 
             with autocast_variable.enable_auto_cast_variables(None):
-              sigma = tf.cast(sigma, self.w.dtype)
-              self.w.assign(self.w / sigma)
+                sigma = tf.cast(sigma, self.w.dtype)
+                self.w.assign(self.w / sigma)
             self.u.assign(u)
 
     def get_config(self):

--- a/tensorflow_addons/layers/spectral_normalization.py
+++ b/tensorflow_addons/layers/spectral_normalization.py
@@ -62,7 +62,7 @@ class SpectralNormalization(tf.keras.layers.Wrapper):
                 "`power_iterations={}`".format(power_iterations)
             )
         self.power_iterations = power_iterations
-        self.layer_compute_dtype = layer.compute_dtype
+        self._layer_compute_dtype = layer.compute_dtype
         self._initialized = False
 
     def build(self, input_shape):
@@ -88,7 +88,7 @@ class SpectralNormalization(tf.keras.layers.Wrapper):
             initializer=tf.initializers.TruncatedNormal(stddev=0.02),
             trainable=False,
             name="sn_u",
-            dtype=self.layer_compute_dtype,
+            dtype=self._layer_compute_dtype,
         )
 
     def call(self, inputs, training=None):

--- a/tensorflow_addons/layers/tests/spectral_normalization_test.py
+++ b/tensorflow_addons/layers/tests/spectral_normalization_test.py
@@ -110,20 +110,22 @@ def test_model_build(base_layer_fn, input_shape):
 
 @pytest.mark.usefixtures("maybe_run_functions_eagerly")
 def test_compute_with_mixed_precision():
-  tf.keras.mixed_precision.set_global_policy(tf.keras.mixed_precision.Policy('mixed_float16'))
-  inputs = tf.keras.layers.Input(shape=[2, 2, 1])
-
-  base_layer = tf.keras.layers.Conv2D(
-    1, (2, 2), kernel_initializer=tf.constant_initializer(value=2)
-  )
-  sn_layer = spectral_normalization.SpectralNormalization(base_layer)
-  model = tf.keras.models.Sequential(layers=[inputs, sn_layer])
-
-  for training in [False, True]:
-    _ = model(
-      tf.constant(np.ones((1, 2, 2, 1), dtype=np.float32)), training=training
+    tf.keras.mixed_precision.set_global_policy(
+        tf.keras.mixed_precision.Policy("mixed_float16")
     )
-    assert model.layers[0].u.dtype == tf.float16
+    inputs = tf.keras.layers.Input(shape=[2, 2, 1])
+
+    base_layer = tf.keras.layers.Conv2D(
+        1, (2, 2), kernel_initializer=tf.constant_initializer(value=2)
+    )
+    sn_layer = spectral_normalization.SpectralNormalization(base_layer)
+    model = tf.keras.models.Sequential(layers=[inputs, sn_layer])
+
+    for training in [False, True]:
+        _ = model(
+            tf.constant(np.ones((1, 2, 2, 1), dtype=np.float32)), training=training
+        )
+        assert model.layers[0].u.dtype == tf.float16
 
 
 @pytest.mark.usefixtures("maybe_run_functions_eagerly")

--- a/tensorflow_addons/layers/tests/spectral_normalization_test.py
+++ b/tensorflow_addons/layers/tests/spectral_normalization_test.py
@@ -109,6 +109,24 @@ def test_model_build(base_layer_fn, input_shape):
 
 
 @pytest.mark.usefixtures("maybe_run_functions_eagerly")
+def test_compute_with_mixed_precision():
+  tf.keras.mixed_precision.set_global_policy(tf.keras.mixed_precision.Policy('mixed_float16'))
+  inputs = tf.keras.layers.Input(shape=[2, 2, 1])
+
+  base_layer = tf.keras.layers.Conv2D(
+    1, (2, 2), kernel_initializer=tf.constant_initializer(value=2)
+  )
+  sn_layer = spectral_normalization.SpectralNormalization(base_layer)
+  model = tf.keras.models.Sequential(layers=[inputs, sn_layer])
+
+  for training in [False, True]:
+    _ = model(
+      tf.constant(np.ones((1, 2, 2, 1), dtype=np.float32)), training=training
+    )
+    assert model.layers[0].u.dtype == tf.float16
+
+
+@pytest.mark.usefixtures("maybe_run_functions_eagerly")
 def test_normalization():
     inputs = tf.keras.layers.Input(shape=[2, 2, 1])
 


### PR DESCRIPTION
# Description

When mixed_precision is used, SpectralNormalization computes with dtype=compute_dtype. Assigning the computed normalized weights (with compute_dtype) to the layer's kernel (dtype) fails.

With this fix, omputations of the spectral normalization are performed in compute_dtype. The auxiliary weight u is also stored in compute_dtype. To rescale the weights of the layer, we compute the delta on each weight, upcast and add it to the original weight. 

Fixes #2398

## Type of change

- [x] Bug fix
- [ ] New Tutorial
- [ ] Updated or additional documentation
- [ ] Additional Testing
- [ ] New Activation and the changes conform to the [activation contribution guidelines](https://github.com/tensorflow/addons/blob/master/tensorflow_addons/activations/README.md#contribution-guidelines)
- [ ] New Callback and the changes conform to the [callback contribution guidelines](https://github.com/tensorflow/addons/blob/master/tensorflow_addons/callbacks/README.md#contribution-guidelines)
- [ ] New Image addition and the changes conform to the [image op contribution guidelines](https://github.com/tensorflow/addons/blob/master/tensorflow_addons/image/README.md#contribution-guidelines)
- [ ] New Layer and the changes conform to the [layer contribution guidelines](https://github.com/tensorflow/addons/blob/master/tensorflow_addons/layers/README.md#contribution-guidelines)
- [ ] New Loss and the changes conform to the [loss contribution guidelines](https://github.com/tensorflow/addons/blob/master/tensorflow_addons/losses/README.md#contribution-guidelines)
- [ ] New Metric and the changes conform to the [metric contribution guidelines](https://github.com/tensorflow/addons/blob/master/tensorflow_addons/metrics/README.md#contribution-guidelines)
- [ ] New Optimizer and the changes conform to the [optimizer contribution guidelines](https://github.com/tensorflow/addons/blob/master/tensorflow_addons/optimizers/README.md#contribution-guidelines)
- [ ] New RNN Cell and the changes conform to the [rnn contribution guidelines](https://github.com/tensorflow/addons/blob/master/tensorflow_addons/rnn/README.md#contribution-guidelines)
- [ ] New Seq2seq addition and the changes conform to the [seq2seq contribution guidelines](https://github.com/tensorflow/addons/blob/master/tensorflow_addons/seq2seq/README.md#contribution-guidelines)
- [ ] New Text addition and the changes conform to the [text op contribution guidelines](https://github.com/tensorflow/addons/blob/master/tensorflow_addons/text/README.md#contribution-guidelines)

# Checklist:

- [x] I've properly [formatted my code according to the guidelines](https://github.com/tensorflow/addons/blob/master/CONTRIBUTING.md#coding-style)
    - [x] By running Black + Flake8
    - [ ] By running pre-commit hooks
- [x] This PR addresses an already submitted issue for TensorFlow Addons
- [ ] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] This PR contains modifications to C++ custom-ops

# How Has This Been Tested?

Additional unit test which checks if a model with mixed_float16 computes without errors and check that the auxilary variable u has the compute_dtype.