### PR TITLE
Adds a Relational Memory Core cell

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -166,6 +166,8 @@
 /tensorflow_addons/rnn/tests/nas_cell_test.py @qlzh727
 /tensorflow_addons/rnn/peephole_lstm_cell.py @qlzh727
 /tensorflow_addons/rnn/tests/peephole_lstm_cell_test.py @qlzh727
+/tensorflow_addons/rnn/rmc_cell.py @gugarosa
+/tensorflow_addons/rnn/tests/rmc_cell_test.py @gugarosa
 
 /tensorflow_addons/seq2seq/ @qlzh727 @guillaumekln
 

--- a/tensorflow_addons/rnn/rmc_cell.py
+++ b/tensorflow_addons/rnn/rmc_cell.py
@@ -170,7 +170,7 @@ class RMCCell(keras.layers.AbstractRNNCell):
     def _attend_over_memory(self, inputs, memory):
         for _ in range(self.n_blocks):
             concat_memory = tf.concat([inputs, memory], 1)
-            att_memory, _ = self.attn(memory, concat_memory, concat_memory)
+            att_memory = self.attn(memory, concat_memory, concat_memory)
             norm_memory = self.before_norm(att_memory + memory)
             linear_memory = norm_memory
 

--- a/tensorflow_addons/rnn/rmc_cell.py
+++ b/tensorflow_addons/rnn/rmc_cell.py
@@ -16,9 +16,6 @@
 
 import tensorflow as tf
 import tensorflow.keras as keras
-from tensorflow.keras.layers import AbstractRNNCell, Dense, LayerNormalization
-from tensorflow.python.keras import (activations, constraints, initializers,
-                                     regularizers)
 
 from tensorflow_addons.utils.types import (
     Activation,
@@ -42,6 +39,17 @@ class RMCCell(keras.layers.AbstractRNNCell):
     A. Santoro, et al.
     "Relational recurrent neural networks".
     Advances in neural information processing systems, 2018.
+
+    Example:
+
+    >>> inputs = np.random.random([30,23,9]).astype(np.float32)
+    >>> RMCCell = tfa.rnn.RMCCell(2, 2, 1)
+    >>> rnn = tf.keras.layers.RNN(RMCCell, return_sequences=True, return_state=True)
+    >>> outputs, memory_state = rnn(inputs, initial_state=RMCCell.get_initial_state(30))
+    >>> outputs.shape
+    TensorShape([30, 23, 4])
+    >>> memory_state.shape
+    TensorShape([30, 4])
 
     """
 
@@ -98,27 +106,26 @@ class RMCCell(keras.layers.AbstractRNNCell):
         self.units = self.slot_size * n_slots
         self.n_gates = 2 * self.slot_size
 
-        self.activation = activations.get(activation)
-        self.recurrent_activation = activations.get(recurrent_activation)
+        self.activation = activation
+        self.recurrent_activation = recurrent_activation
         self.forget_bias = forget_bias
 
-        self.kernel_initializer = initializers.get(kernel_initializer)
-        self.recurrent_initializer = initializers.get(recurrent_initializer)
-        self.bias_initializer = initializers.get(bias_initializer)
+        self.kernel_initializer = kernel_initializer
+        self.recurrent_initializer = recurrent_initializer
+        self.bias_initializer = bias_initializer
 
-        self.kernel_regularizer = regularizers.get(kernel_regularizer)
-        self.recurrent_regularizer = regularizers.get(recurrent_regularizer)
-        self.bias_regularizer = regularizers.get(bias_regularizer)
+        self.kernel_regularizer = kernel_regularizer
+        self.recurrent_regularizer = recurrent_regularizer
+        self.bias_regularizer = bias_regularizer
         
-        self.kernel_constraint = constraints.get(kernel_constraint)
-        self.recurrent_constraint = constraints.get(recurrent_constraint)
-        self.bias_constraint = constraints.get(bias_constraint)
+        self.kernel_constraint = kernel_constraint
+        self.recurrent_constraint = recurrent_constraint
+        self.bias_constraint = bias_constraint
 
-        self.projector = Dense(self.slot_size)
-        self.before_norm = LayerNormalization()
-        self.linear = [Dense(self.slot_size, activation="relu")
-                       for _ in range(n_layers)]
-        self.after_norm = LayerNormalization()
+        self.projector = keras.layers.Dense(self.slot_size)
+        self.before_norm = keras.layers.LayerNormalization()
+        self.linear = [keras.layers.Dense(self.slot_size, activation="relu") for _ in range(n_layers)]
+        self.after_norm = keras.layers.LayerNormalization()
         self.attn = MultiHeadAttention(self.slot_size, self.n_heads)
 
     @property
@@ -158,136 +165,75 @@ class RMCCell(keras.layers.AbstractRNNCell):
         self.built = True
 
     def _attend_over_memory(self, inputs, memory):
-        """Performs an Attention mechanism over the current memory.
-
-        Args:
-            inputs (tf.Tensor): An input tensor.
-            memory (tf.Tensor): Current memory tensor.
-
-        Returns:
-            Updated current memory based on Multi-Head Attention mechanism.
-
-        """
-
-        # For every feed-forward network
         for _ in range(self.n_blocks):
-            # Concatenates the inputs with the memory
             concat_memory = tf.concat([inputs, memory], 1)
-
-            # Passes down the multi-head attention layer
             att_memory, _ = self.attn(memory, concat_memory, concat_memory)
-
-            # Passes down the first normalization layer
             norm_memory = self.before_norm(att_memory + memory)
-
-            # Makes a copy to feed the linear layers
             linear_memory = norm_memory
 
-            # For every linear layer
             for l in self.linear:
-                # Passes down the layer
                 linear_memory = l(linear_memory)
 
-            # Calculates the final memory from the network with another normalization layer
             memory = self.after_norm(norm_memory + linear_memory)
 
         return memory
 
     def call(self, inputs, states):
-        """Method that holds vital information whenever this class is called.
-
-        Args:
-            inputs (tf.Tensor): An input tensor.
-            states (list): A list holding previous states and memories.
-
-        Returns:
-            Output states as well as current state and memory.
-
-        """
-
-        # Gathering previous hidden and memory states
+        # Gathers previous hidden and memory states
         h_prev, m_prev = states
 
-        # Projecting the inputs to the same size as the memory
+        # Projects the inputs to the same size as the memory
         inputs = tf.expand_dims(self.projector(inputs), 1)
 
-        # Reshaping the previous hidden state tensor
-        h_prev = tf.reshape(
-            h_prev, [h_prev.shape[0], self.n_slots, self.slot_size])
+        # Reshapes the previous hidden state and memory tensors
+        h_prev = tf.reshape(h_prev, [h_prev.shape[0], self.n_slots, self.slot_size])
+        m_prev = tf.reshape(m_prev, [m_prev.shape[0], self.n_slots, self.slot_size])
 
-        # Reshaping the previous memory tensor
-        m_prev = tf.reshape(
-            m_prev, [m_prev.shape[0], self.n_slots, self.slot_size])
-
-        # Copying the inputs for the forget and input gates
+        # Copies the inputs for the forget and input gates
         inputs_f = inputs
         inputs_i = inputs
 
-        # Splitting up the kernel into forget and input gates kernels
+        # Splits up the kernel into forget and input gates kernels
+        # Also calculates the forget and input gates kernel outputs
         k_f, k_i = tf.split(self.kernel, 2, axis=1)
-
-        # Calculating the forget and input gates kernel outputs
         x_f = tf.tensordot(inputs_f, k_f, axes=[[-1], [0]])
         x_i = tf.tensordot(inputs_i, k_i, axes=[[-1], [0]])
 
-        # Splitting up the recurrent kernel into forget and input gates kernels
+        # Splits up the recurrent kernel into forget and input gates kernels
+        # Also calculates the forget and input gates recurrent kernel outputs
         rk_f, rk_i = tf.split(self.recurrent_kernel, 2, axis=1)
-
-        # Calculating the forget and input gates recurrent kernel outputs
         x_f += tf.tensordot(h_prev, rk_f, axes=[[-1], [0]])
         x_i += tf.tensordot(h_prev, rk_i, axes=[[-1], [0]])
 
-        # Splitting up the bias into forget and input gates biases
+        # Splits up the bias into forget and input gates biases
+        # Also adds the forget and input gates bias outputs
         b_f, b_i = tf.split(self.bias, 2, axis=0)
-
-        # Adding the forget and input gate bias
         x_f = tf.nn.bias_add(x_f, b_f)
         x_i = tf.nn.bias_add(x_i, b_i)
 
-        # Calculating the attention mechanism over the previous memory
+        # Calculates the attention mechanism over the previous memory
+        # Also calculates current memory and hidden states
         att_m = self._attend_over_memory(inputs, m_prev)
-
-        # Calculating current memory state
-        m = self.recurrent_activation(
-            x_f + self.forget_bias) * m_prev + self.recurrent_activation(x_i) * self.activation(att_m)
-
-        # Calculating current hidden state
+        m = self.recurrent_activation(x_f + self.forget_bias) * m_prev + self.recurrent_activation(x_i) * self.activation(att_m)
         h = self.activation(m)
 
-        # Reshaping both the current hidden and memory states to their correct output size
+        # Reshapes both current hidden and memory states to their correct output size
         h = tf.reshape(h, [h.shape[0], self.units])
         m = tf.reshape(m, [m.shape[0], self.units])
 
         return h, [h, m]
 
     def get_initial_state(self, batch_size):
-        """Gets the cell initial state by creating an identity matrix.
-
-        Args:
-            batch_size (int): Size of the batch.
-
-        """
-
-        # Creates an identity matrix
         states = tf.eye(self.n_slots, batch_shape=[batch_size])
 
-        # If the slot size is bigger than number of slots
         if self.slot_size > self.n_slots:
-            # Calculates its difference
             diff = self.slot_size - self.n_slots
-
-            # Creates a new tensor for padding
             padding = tf.zeros((batch_size, self.n_slots, diff))
-
-            # Concatenates the initial states with the padding
             states = tf.concat([states, padding], -1)
 
-        # If the slot size is smaller than number of slots
         elif self.slot_size < self.n_slots:
-            # Just gather the tensor until the desired size
             states = states[:, :, :self.slot_size]
 
-        # Reshapes to a flatten output
         states = tf.reshape(states, (states.shape[0], -1))
 
         return states, states
@@ -302,18 +248,18 @@ class RMCCell(keras.layers.AbstractRNNCell):
             "n_layers": self.n_layers,
             "units": self.units,
             "n_gates": self.n_gates,
-            "activation": activations.serialize(self.activation),
-            "recurrent_activation": activations.serialize(self.recurrent_activation),
+            "activation": tf.keras.activations.serialize(self.activation),
+            "recurrent_activation": tf.keras.activations.serialize(self.recurrent_activation),
             "forget_bias": self.forget_bias,
-            "kernel_initializer": initializers.serialize(self.kernel_initializer),
-            "recurrent_initializer": initializers.serialize(self.recurrent_initializer),
-            "bias_initializer": initializers.serialize(self.bias_initializer),
-            "kernel_regularizer": regularizers.serialize(self.kernel_regularizer),
-            "recurrent_regularizer": regularizers.serialize(self.recurrent_regularizer),
-            "bias_regularizer": regularizers.serialize(self.bias_regularizer),
-            "kernel_constraint": constraints.serialize(self.kernel_constraint),
-            "recurrent_constraint": constraints.serialize(self.recurrent_constraint),
-            "bias_constraint": constraints.serialize(self.bias_constraint),
+            "kernel_initializer": tf.keras.initializers.serialize(self.kernel_initializer),
+            "recurrent_initializer": tf.keras.initializers.serialize(self.recurrent_initializer),
+            "bias_initializer": tf.keras.initializers.serialize(self.bias_initializer),
+            "kernel_regularizer": tf.keras.regularizers.serialize(self.kernel_regularizer),
+            "recurrent_regularizer": tf.keras.regularizers.serialize(self.recurrent_regularizer),
+            "bias_regularizer": tf.keras.regularizers.serialize(self.bias_regularizer),
+            "kernel_constraint": tf.keras.constraints.serialize(self.kernel_constraint),
+            "recurrent_constraint": tf.keras.constraints.serialize(self.recurrent_constraint),
+            "bias_constraint": tf.keras.constraints.serialize(self.bias_constraint),
         }
         base_config = super().get_config()
         return {**base_config, **config}

--- a/tensorflow_addons/rnn/rmc_cell.py
+++ b/tensorflow_addons/rnn/rmc_cell.py
@@ -13,3 +13,307 @@
 # limitations under the License.
 # ==============================================================================
 """Implements RMC Cell."""
+
+import tensorflow as tf
+import tensorflow.keras as keras
+from tensorflow.keras.layers import AbstractRNNCell, Dense, LayerNormalization
+from tensorflow.python.keras import (activations, constraints, initializers,
+                                     regularizers)
+
+from tensorflow_addons.utils.types import (
+    Activation,
+    Initializer,
+    Regularizer,
+    Constraint
+)
+
+from nalp.models.layers import MultiHeadAttention
+from typeguard import typechecked
+
+
+@tf.keras.utils.register_keras_serializable(package="Addons")
+class RMCCell(keras.layers.AbstractRNNCell):
+    """Relational Memory Core (RMC) cell.
+
+    This implements the recurrent cell from the paper:
+
+        https://papers.nips.cc/paper/2018/file/e2eabaf96372e20a9e3d4b5f83723a61-Paper.pdf
+    
+    A. Santoro, et al.
+    "Relational recurrent neural networks".
+    Advances in neural information processing systems, 2018.
+
+    """
+
+    @typechecked
+    def __init__(
+        self,
+        n_slots: int,
+        n_heads: int,
+        head_size: int,
+        n_blocks: int = 1,
+        n_layers: int = 3,
+        activation: Activation = "tanh",
+        recurrent_activation: Activation = "hard_sigmoid",
+        forget_bias: float = 1.0,
+        kernel_initializer: Initializer = "glorot_uniform",
+        recurrent_initializer: Initializer = "orthogonal",
+        bias_initializer: Initializer = "zeros",
+        kernel_regularizer: Regularizer = None,
+        recurrent_regularizer: Regularizer = None,
+        bias_regularizer: Regularizer = None,
+        kernel_constraint: Constraint = None,
+        recurrent_constraint: Constraint = None,
+        bias_constraint: Constraint = None,
+        **kwargs):
+        """Initializes the parameters for a RMC cell.
+
+        Args:
+            n_slots: Number of memory slots.
+            n_heads: Number of attention heads.
+            head_size: Size of each attention head.
+            n_blocks: Number of feed-forward networks.
+            n_layers: Amout of layers per feed-forward network.
+            activation: Output activation function.
+            recurrent_activation: Recurrent step activation function.
+            forget_bias: Forget gate bias values.
+            kernel_initializer: Kernel initializer function.
+            recurrent_initializer: Recurrent kernel initializer function.
+            bias_initializer: Bias initializer function.
+            kernel_regularizer: Kernel regularizer function.
+            recurrent_regularizer: Recurrent kernel regularizer function.
+            bias_regularizer: Bias regularizer function.
+            kernel_constraint: Kernel constraint function.
+            recurrent_constraint: Recurrent kernel constraint function.
+            bias_constraint: Bias constraint function.
+
+        """
+        super().__init__(**kwargs)
+        self.n_slots = n_slots
+        self.slot_size = n_heads * head_size
+        self.n_heads = n_heads
+        self.head_size = head_size
+        self.n_blocks = n_blocks
+        self.n_layers = n_layers
+        self.units = self.slot_size * n_slots
+        self.n_gates = 2 * self.slot_size
+
+        self.activation = activations.get(activation)
+        self.recurrent_activation = activations.get(recurrent_activation)
+        self.forget_bias = forget_bias
+
+        self.kernel_initializer = initializers.get(kernel_initializer)
+        self.recurrent_initializer = initializers.get(recurrent_initializer)
+        self.bias_initializer = initializers.get(bias_initializer)
+
+        self.kernel_regularizer = regularizers.get(kernel_regularizer)
+        self.recurrent_regularizer = regularizers.get(recurrent_regularizer)
+        self.bias_regularizer = regularizers.get(bias_regularizer)
+        
+        self.kernel_constraint = constraints.get(kernel_constraint)
+        self.recurrent_constraint = constraints.get(recurrent_constraint)
+        self.bias_constraint = constraints.get(bias_constraint)
+
+        self.projector = Dense(self.slot_size)
+        self.before_norm = LayerNormalization()
+        self.linear = [Dense(self.slot_size, activation="relu")
+                       for _ in range(n_layers)]
+        self.after_norm = LayerNormalization()
+        self.attn = MultiHeadAttention(self.slot_size, self.n_heads)
+
+    @property
+    def state_size(self):
+        return [self.units, self.units]
+
+    @property
+    def output_size(self):
+        return self.units
+
+    def build(self, inputs_shape):
+        # Variables for the RMC cell. `kernel` stands for the `W` matrix,
+        # `recurrent_kernel` stands for the `U` matrix and
+        # `bias` stands for the `b` array
+        self.kernel = self.add_weight(
+            shape=(self.slot_size, self.n_gates),
+            name="kernel",
+            initializer=self.kernel_initializer,
+            regularizer=self.kernel_regularizer,
+            constraint=self.kernel_constraint
+        )
+        self.recurrent_kernel = self.add_weight(
+            shape=(self.slot_size, self.n_gates),
+            name="recurrent_kernel",
+            initializer=self.recurrent_initializer,
+            regularizer=self.recurrent_regularizer,
+            constraint=self.recurrent_constraint
+        )
+        self.bias = self.add_weight(
+            shape=(self.n_gates,),
+            name="bias",
+            initializer=self.bias_initializer,
+            regularizer=self.bias_regularizer,
+            constraint=self.bias_constraint
+        )
+
+        self.built = True
+
+    def _attend_over_memory(self, inputs, memory):
+        """Performs an Attention mechanism over the current memory.
+
+        Args:
+            inputs (tf.Tensor): An input tensor.
+            memory (tf.Tensor): Current memory tensor.
+
+        Returns:
+            Updated current memory based on Multi-Head Attention mechanism.
+
+        """
+
+        # For every feed-forward network
+        for _ in range(self.n_blocks):
+            # Concatenates the inputs with the memory
+            concat_memory = tf.concat([inputs, memory], 1)
+
+            # Passes down the multi-head attention layer
+            att_memory, _ = self.attn(memory, concat_memory, concat_memory)
+
+            # Passes down the first normalization layer
+            norm_memory = self.before_norm(att_memory + memory)
+
+            # Makes a copy to feed the linear layers
+            linear_memory = norm_memory
+
+            # For every linear layer
+            for l in self.linear:
+                # Passes down the layer
+                linear_memory = l(linear_memory)
+
+            # Calculates the final memory from the network with another normalization layer
+            memory = self.after_norm(norm_memory + linear_memory)
+
+        return memory
+
+    def call(self, inputs, states):
+        """Method that holds vital information whenever this class is called.
+
+        Args:
+            inputs (tf.Tensor): An input tensor.
+            states (list): A list holding previous states and memories.
+
+        Returns:
+            Output states as well as current state and memory.
+
+        """
+
+        # Gathering previous hidden and memory states
+        h_prev, m_prev = states
+
+        # Projecting the inputs to the same size as the memory
+        inputs = tf.expand_dims(self.projector(inputs), 1)
+
+        # Reshaping the previous hidden state tensor
+        h_prev = tf.reshape(
+            h_prev, [h_prev.shape[0], self.n_slots, self.slot_size])
+
+        # Reshaping the previous memory tensor
+        m_prev = tf.reshape(
+            m_prev, [m_prev.shape[0], self.n_slots, self.slot_size])
+
+        # Copying the inputs for the forget and input gates
+        inputs_f = inputs
+        inputs_i = inputs
+
+        # Splitting up the kernel into forget and input gates kernels
+        k_f, k_i = tf.split(self.kernel, 2, axis=1)
+
+        # Calculating the forget and input gates kernel outputs
+        x_f = tf.tensordot(inputs_f, k_f, axes=[[-1], [0]])
+        x_i = tf.tensordot(inputs_i, k_i, axes=[[-1], [0]])
+
+        # Splitting up the recurrent kernel into forget and input gates kernels
+        rk_f, rk_i = tf.split(self.recurrent_kernel, 2, axis=1)
+
+        # Calculating the forget and input gates recurrent kernel outputs
+        x_f += tf.tensordot(h_prev, rk_f, axes=[[-1], [0]])
+        x_i += tf.tensordot(h_prev, rk_i, axes=[[-1], [0]])
+
+        # Splitting up the bias into forget and input gates biases
+        b_f, b_i = tf.split(self.bias, 2, axis=0)
+
+        # Adding the forget and input gate bias
+        x_f = tf.nn.bias_add(x_f, b_f)
+        x_i = tf.nn.bias_add(x_i, b_i)
+
+        # Calculating the attention mechanism over the previous memory
+        att_m = self._attend_over_memory(inputs, m_prev)
+
+        # Calculating current memory state
+        m = self.recurrent_activation(
+            x_f + self.forget_bias) * m_prev + self.recurrent_activation(x_i) * self.activation(att_m)
+
+        # Calculating current hidden state
+        h = self.activation(m)
+
+        # Reshaping both the current hidden and memory states to their correct output size
+        h = tf.reshape(h, [h.shape[0], self.units])
+        m = tf.reshape(m, [m.shape[0], self.units])
+
+        return h, [h, m]
+
+    def get_initial_state(self, batch_size):
+        """Gets the cell initial state by creating an identity matrix.
+
+        Args:
+            batch_size (int): Size of the batch.
+
+        """
+
+        # Creates an identity matrix
+        states = tf.eye(self.n_slots, batch_shape=[batch_size])
+
+        # If the slot size is bigger than number of slots
+        if self.slot_size > self.n_slots:
+            # Calculates its difference
+            diff = self.slot_size - self.n_slots
+
+            # Creates a new tensor for padding
+            padding = tf.zeros((batch_size, self.n_slots, diff))
+
+            # Concatenates the initial states with the padding
+            states = tf.concat([states, padding], -1)
+
+        # If the slot size is smaller than number of slots
+        elif self.slot_size < self.n_slots:
+            # Just gather the tensor until the desired size
+            states = states[:, :, :self.slot_size]
+
+        # Reshapes to a flatten output
+        states = tf.reshape(states, (states.shape[0], -1))
+
+        return states, states
+
+    def get_config(self):
+        config = {
+            "n_slots": self.n_slots,
+            "slot_size": self.slot_size,
+            "n_heads": self.n_heads,
+            "head_size": self.head_size,
+            "n_blocks": self.n_blocks,
+            "n_layers": self.n_layers,
+            "units": self.units,
+            "n_gates": self.n_gates,
+            "activation": activations.serialize(self.activation),
+            "recurrent_activation": activations.serialize(self.recurrent_activation),
+            "forget_bias": self.forget_bias,
+            "kernel_initializer": initializers.serialize(self.kernel_initializer),
+            "recurrent_initializer": initializers.serialize(self.recurrent_initializer),
+            "bias_initializer": initializers.serialize(self.bias_initializer),
+            "kernel_regularizer": regularizers.serialize(self.kernel_regularizer),
+            "recurrent_regularizer": regularizers.serialize(self.recurrent_regularizer),
+            "bias_regularizer": regularizers.serialize(self.bias_regularizer),
+            "kernel_constraint": constraints.serialize(self.kernel_constraint),
+            "recurrent_constraint": constraints.serialize(self.recurrent_constraint),
+            "bias_constraint": constraints.serialize(self.bias_constraint),
+        }
+        base_config = super().get_config()
+        return {**base_config, **config}

--- a/tensorflow_addons/rnn/rmc_cell.py
+++ b/tensorflow_addons/rnn/rmc_cell.py
@@ -41,14 +41,16 @@ class RMCCell(keras.layers.AbstractRNNCell):
 
     Example:
 
-    >>> inputs = np.random.random([30,23,9]).astype(np.float32)
-    >>> RMCCell = tfa.rnn.RMCCell(2, 2, 1)
+    >>> inputs = np.random.random([2, 3, 5]).astype(np.float32)
+    >>> RMCCell = tfa.rnn.RMCCell(2, 4, 2)
     >>> rnn = tf.keras.layers.RNN(RMCCell, return_sequences=True, return_state=True)
-    >>> outputs, memory_state = rnn(inputs, initial_state=RMCCell.get_initial_state(30))
+    >>> outputs, [hidden_state, memory_state] = rnn(inputs, initial_state=RMCCell.get_initial_state(2))
     >>> outputs.shape
-    TensorShape([30, 23, 4])
+    TensorShape([2, 3, 16])
+    >>> hidden_state.shape
+    TensorShape([2, 16])
     >>> memory_state.shape
-    TensorShape([30, 4])
+    TensorShape([2, 16])
 
     """
 

--- a/tensorflow_addons/rnn/rmc_cell.py
+++ b/tensorflow_addons/rnn/rmc_cell.py
@@ -12,11 +12,4 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 # ==============================================================================
-"""Additional RNN cells that corform to Keras API."""
-
-from tensorflow_addons.rnn.nas_cell import NASCell
-from tensorflow_addons.rnn.layer_norm_lstm_cell import LayerNormLSTMCell
-from tensorflow_addons.rnn.layer_norm_simple_rnn_cell import LayerNormSimpleRNNCell
-from tensorflow_addons.rnn.esn_cell import ESNCell
-from tensorflow_addons.rnn.peephole_lstm_cell import PeepholeLSTMCell
-from tensorflow_addons.rnn.rmc_cell import RMCCell
+"""Implements RMC Cell."""

--- a/tensorflow_addons/rnn/tests/rmc_cell_test.py
+++ b/tensorflow_addons/rnn/tests/rmc_cell_test.py
@@ -12,11 +12,4 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 # ==============================================================================
-"""Additional RNN cells that corform to Keras API."""
-
-from tensorflow_addons.rnn.nas_cell import NASCell
-from tensorflow_addons.rnn.layer_norm_lstm_cell import LayerNormLSTMCell
-from tensorflow_addons.rnn.layer_norm_simple_rnn_cell import LayerNormSimpleRNNCell
-from tensorflow_addons.rnn.esn_cell import ESNCell
-from tensorflow_addons.rnn.peephole_lstm_cell import PeepholeLSTMCell
-from tensorflow_addons.rnn.rmc_cell import RMCCell
+"""Tests for RMC Cell."""

--- a/tensorflow_addons/rnn/tests/rmc_cell_test.py
+++ b/tensorflow_addons/rnn/tests/rmc_cell_test.py
@@ -20,6 +20,177 @@ import tensorflow.keras as keras
 
 from tensorflow_addons.rnn import RMCCell
 
+
+def test_base_rmc():
+    batch_size = 3
+    units = 16
+
+    expected_output = np.array(
+        [
+            [
+                0.1684311,
+                0.10384876,
+                -0.03758289,
+                -0.07105169,
+                -0.28325063,
+                0.34296486,
+                -0.18999499,
+                0.11927383,
+                0.1684311,
+                0.10384876,
+                -0.03758289,
+                -0.07105169,
+                -0.28325063,
+                0.34296486,
+                -0.18999499,
+                0.11927383,
+            ],
+            [
+                0.1840748,
+                0.09620976,
+                -0.02045382,
+                -0.07496377,
+                -0.30143705,
+                0.3523398,
+                -0.21200192,
+                0.13750899,
+                0.1840748,
+                0.09620976,
+                -0.02045382,
+                -0.07496377,
+                -0.30143705,
+                0.3523398,
+                -0.21200192,
+                0.13750899,
+            ],
+            [
+                0.19798864,
+                0.09918775,
+                -0.01345633,
+                -0.08062034,
+                -0.31641114,
+                0.3658627,
+                -0.22976933,
+                0.14713316,
+                0.19798864,
+                0.09918775,
+                -0.01345633,
+                -0.08062034,
+                -0.31641114,
+                0.3658627,
+                -0.22976933,
+                0.14713316,
+            ],
+        ],
+        dtype=np.float32,
+    )
+    expected_state = np.array(
+        [
+            [
+                0.1684311,
+                0.10384876,
+                -0.03758289,
+                -0.07105169,
+                -0.28325063,
+                0.34296486,
+                -0.18999499,
+                0.11927383,
+                0.1684311,
+                0.10384876,
+                -0.03758289,
+                -0.07105169,
+                -0.28325063,
+                0.34296486,
+                -0.18999499,
+                0.11927383,
+            ],
+            [
+                0.1840748,
+                0.09620976,
+                -0.02045382,
+                -0.07496377,
+                -0.30143705,
+                0.3523398,
+                -0.21200192,
+                0.13750899,
+                0.1840748,
+                0.09620976,
+                -0.02045382,
+                -0.07496377,
+                -0.30143705,
+                0.3523398,
+                -0.21200192,
+                0.13750899,
+            ],
+            [
+                0.19798864,
+                0.09918775,
+                -0.01345633,
+                -0.08062034,
+                -0.31641114,
+                0.3658627,
+                -0.22976933,
+                0.14713316,
+                0.19798864,
+                0.09918775,
+                -0.01345633,
+                -0.08062034,
+                -0.31641114,
+                0.3658627,
+                -0.22976933,
+                0.14713316,
+            ],
+        ],
+        dtype=np.float32,
+    )
+
+    const_initializer = tf.constant_initializer(0.1)
+    cell = RMCCell(
+        n_slots=2,
+        n_heads=4,
+        head_size=2,
+        n_blocks=1,
+        n_layers=3,
+        activation=None,
+        recurrent_activation=None,
+        forget_bias=0.0,
+        kernel_initializer=const_initializer,
+        recurrent_initializer=const_initializer,
+        bias_initializer=const_initializer,
+        kernel_regularizer=None,
+        recurrent_regularizer=None,
+        bias_regularizer=None,
+        kernel_constraint=None,
+        recurrent_constraint=None,
+        bias_constraint=None,
+    )
+
+    inputs = tf.constant(
+        np.array(
+            [[1.0, 1.0, 1.0, 1.0], [2.0, 2.0, 2.0, 2.0], [3.0, 3.0, 3.0, 3.0]],
+            dtype=np.float32,
+        ),
+        dtype=tf.float32,
+    )
+    state_value = tf.constant(
+        0.1 * np.ones((batch_size, units), dtype=np.float32), dtype=tf.float32
+    )
+
+    init_state = [state_value, state_value]
+    output, state = cell(inputs, init_state)
+
+    # Asserts whether the outputs are being correctly calculated
+    assert output.shape == (batch_size, units)
+    np.testing.assert_allclose(output, expected_output, rtol=1e-6, atol=1e-6)
+
+    # Asserts whether the states are being correctly calculated
+    assert len(state) == 2
+    h, m = state
+    assert h.shape == (batch_size, units)
+    assert m.shape == (batch_size, units)
+    np.testing.assert_allclose(h, expected_state, rtol=1e-6, atol=1e-6)
+
+
 def test_keras_rnn():
     """Tests that RMCCell works with keras RNN layer."""
     cell = RMCCell(2, 4, 2)
@@ -50,7 +221,8 @@ def test_config_rmc():
         kernel_constraint=None,
         recurrent_constraint=None,
         bias_constraint=None,
-        name="rmc_cell_3")
+        name="rmc_cell_3",
+    )
 
     expected_config = {
         "name": "rmc_cell_3",
@@ -62,17 +234,37 @@ def test_config_rmc():
         "n_blocks": 1,
         "n_layers": 3,
         "activation": tf.keras.activations.serialize(tf.keras.activations.get("tanh")),
-        "recurrent_activation": tf.keras.activations.serialize(tf.keras.activations.get("hard_sigmoid")),
+        "recurrent_activation": tf.keras.activations.serialize(
+            tf.keras.activations.get("hard_sigmoid")
+        ),
         "forget_bias": 1.0,
-        "kernel_initializer": tf.keras.initializers.serialize(tf.keras.initializers.get("glorot_uniform")),
-        "recurrent_initializer": tf.keras.initializers.serialize(tf.keras.initializers.get("orthogonal")),
-        "bias_initializer": tf.keras.initializers.serialize(tf.keras.initializers.get("zeros")),
-        "kernel_regularizer": tf.keras.regularizers.serialize(tf.keras.regularizers.get(None)),
-        "recurrent_regularizer": tf.keras.regularizers.serialize(tf.keras.regularizers.get(None)),
-        "bias_regularizer": tf.keras.regularizers.serialize(tf.keras.regularizers.get(None)),
-        "kernel_constraint": tf.keras.constraints.serialize(tf.keras.constraints.get(None)),
-        "recurrent_constraint": tf.keras.constraints.serialize(tf.keras.constraints.get(None)),
-        "bias_constraint": tf.keras.constraints.serialize(tf.keras.constraints.get(None)),
+        "kernel_initializer": tf.keras.initializers.serialize(
+            tf.keras.initializers.get("glorot_uniform")
+        ),
+        "recurrent_initializer": tf.keras.initializers.serialize(
+            tf.keras.initializers.get("orthogonal")
+        ),
+        "bias_initializer": tf.keras.initializers.serialize(
+            tf.keras.initializers.get("zeros")
+        ),
+        "kernel_regularizer": tf.keras.regularizers.serialize(
+            tf.keras.regularizers.get(None)
+        ),
+        "recurrent_regularizer": tf.keras.regularizers.serialize(
+            tf.keras.regularizers.get(None)
+        ),
+        "bias_regularizer": tf.keras.regularizers.serialize(
+            tf.keras.regularizers.get(None)
+        ),
+        "kernel_constraint": tf.keras.constraints.serialize(
+            tf.keras.constraints.get(None)
+        ),
+        "recurrent_constraint": tf.keras.constraints.serialize(
+            tf.keras.constraints.get(None)
+        ),
+        "bias_constraint": tf.keras.constraints.serialize(
+            tf.keras.constraints.get(None)
+        ),
     }
     config = cell.get_config()
     assert config == expected_config

--- a/tensorflow_addons/rnn/tests/rmc_cell_test.py
+++ b/tensorflow_addons/rnn/tests/rmc_cell_test.py
@@ -191,8 +191,98 @@ def test_base_rmc():
     np.testing.assert_allclose(h, expected_state, rtol=1e-6, atol=1e-6)
 
 
+def test_attend_over_memory_rmc():
+    batch_size = 3
+    n_slots = 2
+    slot_size = 8
+
+    cell = RMCCell(n_slots, 4, 2)
+
+    seq_input = tf.convert_to_tensor(
+        np.random.rand(batch_size, n_slots, slot_size), dtype=tf.float32
+    )
+    memory_value = tf.constant(
+        np.ones((batch_size, n_slots, slot_size), dtype=np.float32), dtype=tf.float32
+    )
+    expected_att_memory = np.array(
+        [
+            [
+                [
+                    -0.6603111,
+                    -0.4110478,
+                    0.5193146,
+                    1.2311147,
+                    -1.0648061,
+                    0.5235050,
+                    1.3777641,
+                    -1.5155334,
+                ],
+                [
+                    -0.6603111,
+                    -0.4110478,
+                    0.5193146,
+                    1.2311147,
+                    -1.0648061,
+                    0.52350503,
+                    1.3777641,
+                    -1.5155334,
+                ],
+            ],
+            [
+                [
+                    -0.67101234,
+                    -0.5338758,
+                    0.65634435,
+                    1.0622097,
+                    -1.3630745,
+                    0.6724906,
+                    1.3870882,
+                    -1.2101701,
+                ],
+                [
+                    -0.67101234,
+                    -0.5338758,
+                    0.65634435,
+                    1.0622097,
+                    -1.3630745,
+                    0.6724906,
+                    1.3870882,
+                    -1.2101701,
+                ],
+            ],
+            [
+                [
+                    -0.72084284,
+                    -0.47108832,
+                    0.6819248,
+                    1.0832782,
+                    -1.162886,
+                    0.5546384,
+                    1.4232899,
+                    -1.3883144,
+                ],
+                [
+                    -0.72084284,
+                    -0.47108832,
+                    0.6819248,
+                    1.0832782,
+                    -1.162886,
+                    0.5546384,
+                    1.4232899,
+                    -1.3883144,
+                ],
+            ],
+        ],
+        dtype=np.float32,
+    )
+
+    att_memory = cell._attend_over_memory(seq_input, memory_value)
+
+    assert att_memory.shape == (batch_size, n_slots, slot_size)
+    np.testing.assert_allclose(att_memory, expected_att_memory, rtol=1e-6, atol=1e-6)
+
+
 def test_keras_rnn():
-    """Tests that RMCCell works with keras RNN layer."""
     cell = RMCCell(2, 4, 2)
     seq_input = tf.convert_to_tensor(
         np.random.rand(2, 3, 5), name="seq_input", dtype=tf.float32

--- a/tensorflow_addons/rnn/tests/rmc_cell_test.py
+++ b/tensorflow_addons/rnn/tests/rmc_cell_test.py
@@ -13,3 +13,70 @@
 # limitations under the License.
 # ==============================================================================
 """Tests for RMC Cell."""
+
+import numpy as np
+import tensorflow as tf
+import tensorflow.keras as keras
+
+from tensorflow_addons.rnn import RMCCell
+
+def test_keras_rnn():
+    """Tests that RMCCell works with keras RNN layer."""
+    cell = RMCCell(2, 4, 2)
+    seq_input = tf.convert_to_tensor(
+        np.random.rand(2, 3, 5), name="seq_input", dtype=tf.float32
+    )
+    rnn_layer = keras.layers.RNN(cell=cell)
+    rnn_outputs = rnn_layer(seq_input)
+    assert rnn_outputs.shape == (2, 16)
+
+
+def test_config_rmc():
+    cell = RMCCell(
+        n_slots=2,
+        n_heads=4,
+        head_size=2,
+        n_blocks=1,
+        n_layers=3,
+        activation="tanh",
+        recurrent_activation="hard_sigmoid",
+        forget_bias=1.0,
+        kernel_initializer="glorot_uniform",
+        recurrent_initializer="orthogonal",
+        bias_initializer="zeros",
+        kernel_regularizer=None,
+        recurrent_regularizer=None,
+        bias_regularizer=None,
+        kernel_constraint=None,
+        recurrent_constraint=None,
+        bias_constraint=None,
+        name="rmc_cell_3")
+
+    expected_config = {
+        "name": "rmc_cell_3",
+        "trainable": True,
+        "dtype": "float32",
+        "n_slots": 2,
+        "n_heads": 4,
+        "head_size": 2,
+        "n_blocks": 1,
+        "n_layers": 3,
+        "activation": tf.keras.activations.serialize(tf.keras.activations.get("tanh")),
+        "recurrent_activation": tf.keras.activations.serialize(tf.keras.activations.get("hard_sigmoid")),
+        "forget_bias": 1.0,
+        "kernel_initializer": tf.keras.initializers.serialize(tf.keras.initializers.get("glorot_uniform")),
+        "recurrent_initializer": tf.keras.initializers.serialize(tf.keras.initializers.get("orthogonal")),
+        "bias_initializer": tf.keras.initializers.serialize(tf.keras.initializers.get("zeros")),
+        "kernel_regularizer": tf.keras.regularizers.serialize(tf.keras.regularizers.get(None)),
+        "recurrent_regularizer": tf.keras.regularizers.serialize(tf.keras.regularizers.get(None)),
+        "bias_regularizer": tf.keras.regularizers.serialize(tf.keras.regularizers.get(None)),
+        "kernel_constraint": tf.keras.constraints.serialize(tf.keras.constraints.get(None)),
+        "recurrent_constraint": tf.keras.constraints.serialize(tf.keras.constraints.get(None)),
+        "bias_constraint": tf.keras.constraints.serialize(tf.keras.constraints.get(None)),
+    }
+    config = cell.get_config()
+    assert config == expected_config
+
+    restored_cell = RMCCell.from_config(config)
+    restored_config = restored_cell.get_config()
+    assert config == restored_config


### PR DESCRIPTION
# Description

Relational Memory Core networks recently gain the spotlight as they use attention-based mechanisms to improve memory learning in recurrent networks. According to Santoro et al. [1], they have outperformed LSTMs and GRUs in several tasks and decreased the performance gap between recurrent-based networks and transformer-based architectures.

Nevertheless, it is hard to find any implementation into well-known frameworks, such as Tensorflow and PyTorch. Thus, this pull request aims at fulfilling such a gap by adding the structure of a Relational Memory Core cell.

The files have been implemented accordingly to the contribution guidelines, as well as to the RNN-based guidelines. Additionally, throughout the implementation process, every function was checked and revised to match the style that has been proposed by other files in the `rnn` package. Finally, several tests to attest their shapes and calculation have been implemented, as well as all the contribution guideline scripts have been run, e.g., style, sanity check, and CPU/GPU-based tests.

[1] A. Santoro, et al. "Relational recurrent neural networks". Advances in neural information processing systems, 2018.

## Type of change

- [ ] Bug fix
- [ ] New Tutorial
- [ ] Updated or additional documentation
- [ ] Additional Testing
- [ ] New Activation and the changes conform to the [activation contribution guidelines](https://github.com/tensorflow/addons/blob/master/tensorflow_addons/activations/README.md#contribution-guidelines)
- [ ] New Callback and the changes conform to the [callback contribution guidelines](https://github.com/tensorflow/addons/blob/master/tensorflow_addons/callbacks/README.md#contribution-guidelines)
- [ ] New Image addition and the changes conform to the [image op contribution guidelines](https://github.com/tensorflow/addons/blob/master/tensorflow_addons/image/README.md#contribution-guidelines)
- [ ] New Layer and the changes conform to the [layer contribution guidelines](https://github.com/tensorflow/addons/blob/master/tensorflow_addons/layers/README.md#contribution-guidelines)
- [ ] New Loss and the changes conform to the [loss contribution guidelines](https://github.com/tensorflow/addons/blob/master/tensorflow_addons/losses/README.md#contribution-guidelines)
- [ ] New Metric and the changes conform to the [metric contribution guidelines](https://github.com/tensorflow/addons/blob/master/tensorflow_addons/metrics/README.md#contribution-guidelines)
- [ ] New Optimizer and the changes conform to the [optimizer contribution guidelines](https://github.com/tensorflow/addons/blob/master/tensorflow_addons/optimizers/README.md#contribution-guidelines)
- [X] New RNN Cell and the changes conform to the [rnn contribution guidelines](https://github.com/tensorflow/addons/blob/master/tensorflow_addons/rnn/README.md#contribution-guidelines)
- [ ] New Seq2seq addition and the changes conform to the [seq2seq contribution guidelines](https://github.com/tensorflow/addons/blob/master/tensorflow_addons/seq2seq/README.md#contribution-guidelines)
- [ ] New Text addition and the changes conform to the [text op contribution guidelines](https://github.com/tensorflow/addons/blob/master/tensorflow_addons/text/README.md#contribution-guidelines)

# Checklist:

- [X] I've properly [formatted my code according to the guidelines](https://github.com/tensorflow/addons/blob/master/CONTRIBUTING.md#coding-style)
    - [X] By running Black + Flake8
    - [ ] By running pre-commit hooks
- [ ] This PR addresses an already submitted issue for TensorFlow Addons
- [X] I have made corresponding changes to the documentation
- [X] I have added tests that prove my fix is effective or that my feature works
- [ ] This PR contains modifications to C++ custom-ops

# How Has This Been Tested?

If you're adding a bugfix or new feature please describe the tests that you ran to verify your changes:
*  `test_base_rmc`: tests whether the expected output and hidden state matches a small level of tolerance and the corresponding shapes;
*  `test_attend_over_memory_rmc`: tests whether the attended memory function is capable of receiving pre-defined inputs and producing correctly-shaped outputs;
* `test_keras_rnn`: tests whether an RMC-based cell can be used within the RNN class provided by Keras;
* `test_config_rmc`: tests whether the configuration object saved by the RMC can be serialized and de-serialized.
