### PR TITLE
Make RSquare.reset_states to be able to run in tf.function

### DIFF
--- a/tensorflow_addons/metrics/r_square.py
+++ b/tensorflow_addons/metrics/r_square.py
@@ -15,6 +15,7 @@
 """Implements R^2 scores."""
 from typing import Tuple
 
+import numpy as np
 import tensorflow as tf
 from tensorflow.keras import backend as K
 from tensorflow.keras.metrics import Metric
@@ -180,7 +181,7 @@ class RSquare(Metric):
 
     def reset_states(self) -> None:
         # The state of the metric will be reset at the start of each epoch.
-        K.batch_set_value([(v, tf.zeros_like(v)) for v in self.variables])
+        K.batch_set_value([(v, np.zeros(v.shape)) for v in self.variables])
 
     def get_config(self):
         config = {

--- a/tensorflow_addons/metrics/tests/r_square_test.py
+++ b/tensorflow_addons/metrics/tests/r_square_test.py
@@ -53,8 +53,18 @@ def update_obj_states(obj, actuals, preds, sample_weight=None):
     obj.update_state(actuals, preds, sample_weight=sample_weight)
 
 
+@tf.function
+def reset_obj_states(obj):
+    obj.reset_states()
+
+
 def check_results(obj, value):
     np.testing.assert_allclose(value, obj.result(), atol=1e-5)
+
+
+def check_variables(obj, value):
+    for v in obj.variables:
+        np.testing.assert_allclose(value, v.value().numpy(), atol=1e-5)
 
 
 def test_r2_perfect_score():
@@ -107,6 +117,22 @@ def test_r2_random_score():
     update_obj_states(r2_obj, actuals, preds)
     # Check results
     check_results(r2_obj, 0.7376327)
+
+
+@pytest.mark.usefixtures("maybe_run_functions_eagerly")
+def test_r2_reset_states():
+    actuals = tf.constant([100, 700, 40, 5.7], dtype=tf.float32)
+    preds = tf.constant([100, 700, 40, 5.7], dtype=tf.float32)
+    actuals = tf.cast(actuals, dtype=tf.float32)
+    preds = tf.cast(preds, dtype=tf.float32)
+    # Initialize
+    r2_obj = initialize_vars()
+    # Update
+    update_obj_states(r2_obj, actuals, preds)
+    # Reset
+    reset_obj_states(r2_obj)
+    # Check variables
+    check_variables(r2_obj, 0.0)
 
 
 @pytest.mark.parametrize("multioutput", sorted(_VALID_MULTIOUTPUT))


### PR DESCRIPTION
# Description

Brief Description of the PR:

`RSquare.reset_states()` calles `batch_set_value()`, and the later one requires a numpy array in the input argument.

However, currently the `RSquare.reset_states()` passes a `tf.Tensor` (by `tf.zeros_like()`) instead of a numpy array.

That would cause `batch_set_value()` raising following error if `RSquare.reset_states()` is called in a tf.function.
```
.../tensorflow/python/keras/backend.py: batch_set_value
        x.assign(np.asarray(value, dtype=dtype_numpy(x)))
.../numpy/core/numeric.py:asarray
        return array(a, dtype, copy=False, order=order)

    TypeError: __array__() takes 1 positional argument but 2 were given
```

Fixes # (issue)

## Type of change

- [X] Bug fix
- [ ] New Tutorial
- [ ] Updated or additional documentation
- [ ] Additional Testing
- [ ] New Activation and the changes conform to the [activation contribution guidelines](https://github.com/tensorflow/addons/blob/master/tensorflow_addons/activations/README.md#contribution-guidelines)
- [ ] New Callback and the changes conform to the [callback contribution guidelines](https://github.com/tensorflow/addons/blob/master/tensorflow_addons/callbacks/README.md#contribution-guidelines)
- [ ] New Image addition and the changes conform to the [image op contribution guidelines](https://github.com/tensorflow/addons/blob/master/tensorflow_addons/image/README.md#contribution-guidelines)
- [ ] New Layer and the changes conform to the [layer contribution guidelines](https://github.com/tensorflow/addons/blob/master/tensorflow_addons/layers/README.md#contribution-guidelines)
- [ ] New Loss and the changes conform to the [loss contribution guidelines](https://github.com/tensorflow/addons/blob/master/tensorflow_addons/losses/README.md#contribution-guidelines)
- [ ] New Metric and the changes conform to the [metric contribution guidelines](https://github.com/tensorflow/addons/blob/master/tensorflow_addons/metrics/README.md#contribution-guidelines)
- [ ] New Optimizer and the changes conform to the [optimizer contribution guidelines](https://github.com/tensorflow/addons/blob/master/tensorflow_addons/optimizers/README.md#contribution-guidelines)
- [ ] New RNN Cell and the changes conform to the [rnn contribution guidelines](https://github.com/tensorflow/addons/blob/master/tensorflow_addons/rnn/README.md#contribution-guidelines)
- [ ] New Seq2seq addition and the changes conform to the [seq2seq contribution guidelines](https://github.com/tensorflow/addons/blob/master/tensorflow_addons/seq2seq/README.md#contribution-guidelines)
- [ ] New Text addition and the changes conform to the [text op contribution guidelines](https://github.com/tensorflow/addons/blob/master/tensorflow_addons/text/README.md#contribution-guidelines)

# Checklist:

- [X] I've properly [formatted my code according to the guidelines](https://github.com/tensorflow/addons/blob/master/CONTRIBUTING.md#coding-style)
    - [ ] By running Black + Flake8
    - [X] By running pre-commit hooks
- [ ] This PR addresses an already submitted issue for TensorFlow Addons
- [ ] I have made corresponding changes to the documentation
- [X] I have added tests that prove my fix is effective or that my feature works
- [ ] This PR contains modifications to C++ custom-ops

# How Has This Been Tested?

If you're adding a bugfix or new feature please describe the tests that you ran to verify your changes:
* Add a test, which calls RSquare.reset_states, then check whether its variables are all close to 0.
* Use maybe_run_functions_eagerly fixture to make the above test run both in eager mode and graph mode (tf.function).
