### PR TITLE
Fix StochasticDepth layer error in training mixed_float16 

### DIFF
--- a/tensorflow_addons/layers/stochastic_depth.py
+++ b/tensorflow_addons/layers/stochastic_depth.py
@@ -65,7 +65,9 @@ class StochasticDepth(tf.keras.layers.Layer):
         shortcut, residual = x
 
         # Random bernoulli variable indicating whether the branch should be kept or not or not
-        b_l = tf.keras.backend.random_bernoulli([], p=self.survival_probability, dtype=self.compute_dtype)
+        b_l = tf.keras.backend.random_bernoulli(
+            [], p=self.survival_probability, dtype=self.compute_dtype
+        )
 
         def _call_train():
             return shortcut + b_l * residual

--- a/tensorflow_addons/layers/stochastic_depth.py
+++ b/tensorflow_addons/layers/stochastic_depth.py
@@ -66,7 +66,7 @@ class StochasticDepth(tf.keras.layers.Layer):
 
         # Random bernoulli variable indicating whether the branch should be kept or not or not
         b_l = tf.keras.backend.random_bernoulli(
-            [], p=self.survival_probability, dtype=self.compute_dtype
+            [], p=self.survival_probability, dtype=self._compute_dtype_object
         )
 
         def _call_train():

--- a/tensorflow_addons/layers/stochastic_depth.py
+++ b/tensorflow_addons/layers/stochastic_depth.py
@@ -65,7 +65,7 @@ class StochasticDepth(tf.keras.layers.Layer):
         shortcut, residual = x
 
         # Random bernoulli variable indicating whether the branch should be kept or not or not
-        b_l = tf.keras.backend.random_bernoulli([], p=self.survival_probability)
+        b_l = tf.keras.backend.random_bernoulli([], p=self.survival_probability, dtype=self.compute_dtype)
 
         def _call_train():
             return shortcut + b_l * residual

--- a/tensorflow_addons/layers/tests/stochastic_depth_test.py
+++ b/tensorflow_addons/layers/tests/stochastic_depth_test.py
@@ -47,7 +47,9 @@ def test_with_mixed_precision_policy():
     residual = np.asarray([[0.2, 0.4, 0.5]])
 
     output = StochasticDepth()([shortcut, residual])
-
+    assert output.dtype == policy.compute_dtype
+    
+    output = StochasticDepth()([shortcut, residual], training=True)
     assert output.dtype == policy.compute_dtype
 
 

--- a/tensorflow_addons/layers/tests/stochastic_depth_test.py
+++ b/tensorflow_addons/layers/tests/stochastic_depth_test.py
@@ -48,7 +48,7 @@ def test_with_mixed_precision_policy():
 
     output = StochasticDepth()([shortcut, residual])
     assert output.dtype == policy.compute_dtype
-    
+
     output = StochasticDepth()([shortcut, residual], training=True)
     assert output.dtype == policy.compute_dtype
 


### PR DESCRIPTION
# Description
`StochasticDepth` layer throws error `TypeError: Input 'y' of 'Mul' Op has type float16 that does not match type float32 of argument 'x'.` if training in `mixed_float16` condition.
I think we need a `dtype=self._compute_dtype_object` or `dtype=self.compute_dtype` in `tf.keras.backend.random_bernoulli` here.

## Type of change

- [x] Bug fix
- [ ] New Tutorial
- [ ] Updated or additional documentation
- [ ] Additional Testing
- [ ] New Activation and the changes conform to the [activation contribution guidelines](https://github.com/tensorflow/addons/blob/master/tensorflow_addons/activations/README.md#contribution-guidelines)
- [ ] New Callback and the changes conform to the [callback contribution guidelines](https://github.com/tensorflow/addons/blob/master/tensorflow_addons/callbacks/README.md#contribution-guidelines)
- [ ] New Image addition and the changes conform to the [image op contribution guidelines](https://github.com/tensorflow/addons/blob/master/tensorflow_addons/image/README.md#contribution-guidelines)
- [ ] New Layer and the changes conform to the [layer contribution guidelines](https://github.com/tensorflow/addons/blob/master/tensorflow_addons/layers/README.md#contribution-guidelines)
- [ ] New Loss and the changes conform to the [loss contribution guidelines](https://github.com/tensorflow/addons/blob/master/tensorflow_addons/losses/README.md#contribution-guidelines)
- [ ] New Metric and the changes conform to the [metric contribution guidelines](https://github.com/tensorflow/addons/blob/master/tensorflow_addons/metrics/README.md#contribution-guidelines)
- [ ] New Optimizer and the changes conform to the [optimizer contribution guidelines](https://github.com/tensorflow/addons/blob/master/tensorflow_addons/optimizers/README.md#contribution-guidelines)
- [ ] New RNN Cell and the changes conform to the [rnn contribution guidelines](https://github.com/tensorflow/addons/blob/master/tensorflow_addons/rnn/README.md#contribution-guidelines)
- [ ] New Seq2seq addition and the changes conform to the [seq2seq contribution guidelines](https://github.com/tensorflow/addons/blob/master/tensorflow_addons/seq2seq/README.md#contribution-guidelines)
- [ ] New Text addition and the changes conform to the [text op contribution guidelines](https://github.com/tensorflow/addons/blob/master/tensorflow_addons/text/README.md#contribution-guidelines)

# Checklist:

- [x] I've properly [formatted my code according to the guidelines](https://github.com/tensorflow/addons/blob/master/CONTRIBUTING.md#coding-style)
    - [x] By running Black + Flake8
    - [ ] By running pre-commit hooks
- [ ] This PR addresses an already submitted issue for TensorFlow Addons
- [ ] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] This PR contains modifications to C++ custom-ops

# How Has This Been Tested?
  Minimal reproducing code:
  ```py
  from tensorflow import keras
  from tensorflow_addons.layers import StochasticDepth
  import numpy as np
  
  keras.mixed_precision.set_global_policy("mixed_float16")
  
  inputs = keras.layers.Input([10, 10, 3])
  nn = keras.layers.Conv2D(3, 1)(inputs)
  sd = StochasticDepth(0.5)
  nn = sd([inputs, nn])
  nn = keras.layers.Flatten()(nn)
  nn = keras.layers.Dense(2, activation="softmax", dtype="float32")(nn)
  mm = keras.models.Model(inputs, nn)
  mm.compile(loss="sparse_categorical_crossentropy", optimizer="adam")
  xx = np.random.normal(size=[10, 10, 10, 3])
  cc = np.mean(xx)
  yy = np.array([ii.sum() > cc for ii in xx]).astype('int')
  mm.fit(xx, yy, epochs=2)
  ```
  Will throw error without `dtype=self._compute_dtype_object` or `dtype=self.compute_dtype`.
  Or just use `test_with_mixed_precision_policy` with `training=True`.
