### PR TITLE
Fix F1Score docs

### DIFF
--- a/tensorflow_addons/metrics/f_scores.py
+++ b/tensorflow_addons/metrics/f_scores.py
@@ -59,7 +59,8 @@ class FBetaScore(tf.keras.metrics.Metric):
         to 0.
 
     `average` parameter behavior:
-        None: Scores for each class are returned
+
+        None: Scores for each class are returned.
 
         micro: True positivies, false positives and
             false negatives are computed globally.


### PR DESCRIPTION
Fix incorrect rendering of option "None" of F1Score's average parameter

## Type of change

- [x] Updated or additional documentation