### PR TITLE
Correcting the order

### DIFF
--- a/docs/tutorials/networks_seq2seq_nmt.ipynb
+++ b/docs/tutorials/networks_seq2seq_nmt.ipynb
@@ -371,7 +371,7 @@
         }
       ],
       "source": [
-        "print(\"max_length_spanish, max_length_english, vocab_size_spanish, vocab_size_english\")\n",
+        "print(\"max_length_english, max_length_spanish, vocab_size_english, vocab_size_spanish\")\n",
         "max_length_input, max_length_output, vocab_inp_size, vocab_tar_size"
       ]
     },


### PR DESCRIPTION
The order in which the parameters are printed [here](https://www.tensorflow.org/addons/tutorials/networks_seq2seq_nmt#some_important_parameters) was incorrect and thus correcting it.

@bhack , please review.
