### PR TITLE
build fix Raspberry Pi 4 Linux ARM64

### DIFF
--- a/configure.py
+++ b/configure.py
@@ -141,7 +141,7 @@ def create_build_configuration():
         write("build:windows --host_cxxopt=/std:c++14")
 
     if is_macos() or is_linux():
-        if not is_linux_ppc64le():
+        if not is_linux_ppc64le() and not is_linux_arm() and not is_linux_aarch64():
             write("build --copt=-mavx")
         write("build --cxxopt=-std=c++14")
         write("build --host_cxxopt=-std=c++14")


### PR DESCRIPTION
# Description

The build under Ubuntu on Raspberry PI fails. The gcc switch `mavx` is x86 specific:

    gcc: error: unrecognized command line option '-mavx'

## Type of change

- [x] Bug fix

# How Has This Been Tested?

The compilation steps:

~~~shell
python3 ./configure.py

bazel build build_pip_pkg
bazel-bin/build_pip_pkg artifacts
~~~

are now also working on a Rasp Pi 4 using Ubuntu.