### PR TITLE
Restore single class MatthewsCorrelationCoefficient test cases

### DIFF
--- a/tensorflow_addons/metrics/matthews_correlation_coefficient.py
+++ b/tensorflow_addons/metrics/matthews_correlation_coefficient.py
@@ -50,9 +50,9 @@ class MatthewsCorrelationCoefficient(tf.keras.metrics.Metric):
 
     Usage:
 
-    >>> y_true = np.array([[0.0, 1.0], [0.0, 1.0], [0.0, 1.0], [1.0, 0.0]], dtype=np.float32)
-    >>> y_pred = np.array([[0.0, 1.0], [1.0, 0.0], [0.0, 1.0], [0.0, 1.0]], dtype=np.float32)
-    >>> metric = tfa.metrics.MatthewsCorrelationCoefficient(num_classes=2)
+    >>> y_true = np.array([[1.0], [1.0], [1.0], [0.0]], dtype=np.float32)
+    >>> y_pred = np.array([[1.0], [0.0], [1.0], [1.0]], dtype=np.float32)
+    >>> metric = tfa.metrics.MatthewsCorrelationCoefficient(num_classes=1)
     >>> metric.update_state(y_true, y_pred)
     >>> result = metric.result()
     >>> result.numpy()

--- a/tensorflow_addons/metrics/tests/matthews_correlation_coefficient_test.py
+++ b/tensorflow_addons/metrics/tests/matthews_correlation_coefficient_test.py
@@ -37,14 +37,10 @@ def check_results(obj, value):
 
 
 def test_binary_classes():
-    gt_label = tf.constant(
-        [[0.0, 1.0], [0.0, 1.0], [0.0, 1.0], [1.0, 0.0]], dtype=tf.float32
-    )
-    preds = tf.constant(
-        [[0.0, 1.0], [1.0, 0.0], [0.0, 1.0], [0.0, 1.0]], dtype=tf.float32
-    )
+    gt_label = tf.constant([[1.0], [1.0], [1.0], [0.0]], dtype=tf.float32)
+    preds = tf.constant([[1.0], [0.0], [1.0], [1.0]], dtype=tf.float32)
     # Initialize
-    mcc = MatthewsCorrelationCoefficient(2)
+    mcc = MatthewsCorrelationCoefficient(1)
     # Update
     mcc.update_state(gt_label, preds)
     # Check results
@@ -110,13 +106,9 @@ def test_keras_model():
 
 
 def test_reset_states_graph():
-    gt_label = tf.constant(
-        [[0.0, 1.0], [0.0, 1.0], [0.0, 1.0], [1.0, 0.0]], dtype=tf.float32
-    )
-    preds = tf.constant(
-        [[0.0, 1.0], [1.0, 0.0], [0.0, 1.0], [0.0, 1.0]], dtype=tf.float32
-    )
-    mcc = MatthewsCorrelationCoefficient(2)
+    gt_label = tf.constant([[1.0], [1.0], [1.0], [0.0]], dtype=tf.float32)
+    preds = tf.constant([[1.0], [0.0], [1.0], [1.0]], dtype=tf.float32)
+    mcc = MatthewsCorrelationCoefficient(1)
     mcc.update_state(gt_label, preds)
 
     @tf.function


### PR DESCRIPTION
# Description

This PR restores single class tests for `MatthewsCorrelationCoefficient`. These tests [have been removed](https://github.com/tensorflow/addons/pull/2406/files#diff-e829e6b4a6d8a09df73c9f183a92d8ba1e81f81c2e40b56ab6410a663267d885L39-R47) in #2406 which unfortunately broke `MatthewsCorrelationCoefficient` with `num_classes=1`. This was a breaking change which doesn't seem like it was intended. These test will currently fail on master but passed in 0.12.1 (or any version before #2406).

Please consider this PR as an issue report. Unfortunately I don't have time time right now to properly look into fixing this issue, but maybe @jonpsy know more about this.

/cc @jonpsy @bhack @seanpmorgan

## Type of change

- [ ] Bug fix
- [ ] New Tutorial
- [ ] Updated or additional documentation
- [x] Additional Testing
- [ ] New Activation and the changes conform to the [activation contribution guidelines](https://github.com/tensorflow/addons/blob/master/tensorflow_addons/activations/README.md#contribution-guidelines)
- [ ] New Callback and the changes conform to the [callback contribution guidelines](https://github.com/tensorflow/addons/blob/master/tensorflow_addons/callbacks/README.md#contribution-guidelines)
- [ ] New Image addition and the changes conform to the [image op contribution guidelines](https://github.com/tensorflow/addons/blob/master/tensorflow_addons/image/README.md#contribution-guidelines)
- [ ] New Layer and the changes conform to the [layer contribution guidelines](https://github.com/tensorflow/addons/blob/master/tensorflow_addons/layers/README.md#contribution-guidelines)
- [ ] New Loss and the changes conform to the [loss contribution guidelines](https://github.com/tensorflow/addons/blob/master/tensorflow_addons/losses/README.md#contribution-guidelines)
- [ ] New Metric and the changes conform to the [metric contribution guidelines](https://github.com/tensorflow/addons/blob/master/tensorflow_addons/metrics/README.md#contribution-guidelines)
- [ ] New Optimizer and the changes conform to the [optimizer contribution guidelines](https://github.com/tensorflow/addons/blob/master/tensorflow_addons/optimizers/README.md#contribution-guidelines)
- [ ] New RNN Cell and the changes conform to the [rnn contribution guidelines](https://github.com/tensorflow/addons/blob/master/tensorflow_addons/rnn/README.md#contribution-guidelines)
- [ ] New Seq2seq addition and the changes conform to the [seq2seq contribution guidelines](https://github.com/tensorflow/addons/blob/master/tensorflow_addons/seq2seq/README.md#contribution-guidelines)
- [ ] New Text addition and the changes conform to the [text op contribution guidelines](https://github.com/tensorflow/addons/blob/master/tensorflow_addons/text/README.md#contribution-guidelines)

# Checklist:

- [x] I've properly [formatted my code according to the guidelines](https://github.com/tensorflow/addons/blob/master/CONTRIBUTING.md#coding-style)
    - [x] By running Black + Flake8
    - [x] By running pre-commit hooks
- [ ] This PR addresses an already submitted issue for TensorFlow Addons
- [ ] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] This PR contains modifications to C++ custom-ops