### PR TITLE
Remove compatibility code for TensorFlow < 2.4

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,7 +80,7 @@ what it was tested against.
 #### Python Op Compatibility Matrix
 | TensorFlow Addons | TensorFlow | Python  |
 |:----------------------- |:---|:---------- |
-| tfa-nightly | 2.3, 2.4, 2.5 |3.6, 3.7, 3.8, 3.9 | 
+| tfa-nightly | 2.4, 2.5, 2.6 |3.6, 3.7, 3.8, 3.9 | 
 | tensorflow-addons-0.13.0 | 2.3, 2.4, 2.5 |3.6, 3.7, 3.8, 3.9 |
 | tensorflow-addons-0.12.1 | 2.3, 2.4 |3.6, 3.7, 3.8 |
 | tensorflow-addons-0.11.2 | 2.2, 2.3 |3.5, 3.6, 3.7, 3.8 |

--- a/tensorflow_addons/activations/gelu.py
+++ b/tensorflow_addons/activations/gelu.py
@@ -14,11 +14,9 @@
 # ==============================================================================
 
 import tensorflow as tf
-import math
 import warnings
 
 from tensorflow_addons.utils.types import TensorLike
-from distutils.version import LooseVersion
 
 
 @tf.keras.utils.register_keras_serializable(package="Addons")
@@ -48,8 +46,8 @@ def gelu(x: TensorLike, approximate: bool = True) -> tf.Tensor:
     See [Gaussian Error Linear Units (GELUs)](https://arxiv.org/abs/1606.08415)
     and [BERT: Pre-training of Deep Bidirectional Transformers for Language Understanding](https://arxiv.org/abs/1810.04805).
 
-    Note that `approximate` will default to `False` from TensorFlow version 2.4 onwards.
     Consider using `tf.nn.gelu` instead.
+    Note that the default of `approximate` changed to `False` in `tf.nn.gelu`.
 
     Usage:
 
@@ -68,28 +66,9 @@ def gelu(x: TensorLike, approximate: bool = True) -> tf.Tensor:
     """
     warnings.warn(
         "gelu activation has been migrated to core TensorFlow, "
-        "and will be deprecated in Addons 0.13.",
+        "and will be deprecated in Addons 0.13. "
+        "Note that the default of `approximate` changed to `False` in `tf.nn.gelu`.",
         DeprecationWarning,
     )
 
-    x = tf.convert_to_tensor(x)
-
-    if LooseVersion(tf.__version__) >= "2.4":
-        gelu_op = tf.nn.gelu
-        warnings.warn(
-            "Default value of `approximate` is changed from `True` to `False`"
-        )
-    else:
-        gelu_op = _gelu_py
-
-    return gelu_op(x, approximate)
-
-
-def _gelu_py(x: TensorLike, approximate: bool = True) -> tf.Tensor:
-    x = tf.convert_to_tensor(x)
-    if approximate:
-        pi = tf.cast(math.pi, x.dtype)
-        coeff = tf.cast(0.044715, x.dtype)
-        return 0.5 * x * (1.0 + tf.tanh(tf.sqrt(2.0 / pi) * (x + coeff * tf.pow(x, 3))))
-    else:
-        return 0.5 * x * (1.0 + tf.math.erf(x / tf.cast(tf.sqrt(2.0), x.dtype)))
+    return tf.nn.gelu(x, approximate)

--- a/tensorflow_addons/callbacks/average_model_checkpoint.py
+++ b/tensorflow_addons/callbacks/average_model_checkpoint.py
@@ -63,9 +63,8 @@ class AverageModelCheckpoint(tf.keras.callbacks.ModelCheckpoint):
 
     def _get_optimizer(self):
         optimizer = self.model.optimizer
-        # TODO(fsx950223): change _optimizer to inner_optimizer after tf2.3 is not support
         if type(optimizer).__name__ in ["LossScaleOptimizer", "LossScaleOptimizerV1"]:
-            optimizer = optimizer._optimizer
+            optimizer = optimizer.inner_optimizer
 
         return optimizer
 

--- a/tensorflow_addons/image/tests/transform_ops_test.py
+++ b/tensorflow_addons/image/tests/transform_ops_test.py
@@ -14,8 +14,6 @@
 # ==============================================================================
 """Tests for transform ops."""
 
-from distutils.version import LooseVersion
-
 import pytest
 import numpy as np
 import tensorflow as tf
@@ -75,9 +73,6 @@ def test_extreme_projective_transform(dtype):
 @pytest.mark.parametrize("dtype", _DTYPES)
 @pytest.mark.parametrize("fill_value", [0.0, 1.0])
 def test_transform_constant_fill_mode(dtype, fill_value):
-    if fill_value != 0.0 and LooseVersion(tf.__version__) < LooseVersion("2.4.0"):
-        pytest.skip("Nonzero fill_value is not supported for TensorFlow < 2.4.0.")
-
     image = tf.constant(
         [[0, 1, 2, 3], [4, 5, 6, 7], [8, 9, 10, 11], [12, 13, 14, 15]], dtype=dtype
     )
@@ -138,10 +133,6 @@ def test_transform_wrap_fill_mode(dtype):
     np.testing.assert_equal(image_transformed.numpy(), expected)
 
 
-@pytest.mark.skipif(
-    LooseVersion(tf.__version__) < LooseVersion("2.4.0"),
-    reason="NEAREST fill mode is not supported for TensorFlow < 2.4.0.",
-)
 @pytest.mark.with_device(["cpu", "gpu"])
 @pytest.mark.usefixtures("maybe_run_functions_eagerly")
 @pytest.mark.parametrize("dtype", _DTYPES)

--- a/tensorflow_addons/image/transform_ops.py
+++ b/tensorflow_addons/image/transform_ops.py
@@ -14,9 +14,6 @@
 # ==============================================================================
 """Image transform ops."""
 
-import warnings
-from distutils.version import LooseVersion
-
 import tensorflow as tf
 from tensorflow_addons.image import utils as img_utils
 from tensorflow_addons.utils.types import TensorLike
@@ -123,36 +120,17 @@ def transform(
                 % len(transforms.get_shape())
             )
 
-        if LooseVersion(tf.__version__) >= LooseVersion("2.4.0"):
-            fill_value = tf.convert_to_tensor(
-                fill_value, dtype=tf.float32, name="fill_value"
-            )
-            output = tf.raw_ops.ImageProjectiveTransformV3(
-                images=images,
-                transforms=transforms,
-                output_shape=output_shape,
-                interpolation=interpolation.upper(),
-                fill_mode=fill_mode.upper(),
-                fill_value=fill_value,
-            )
-        else:
-            fill_mode = fill_mode.upper()
-            # TODO(WindQAQ): Get rid of the check once we drop TensorFlow < 2.4 support.
-            if fill_mode == "CONSTANT":
-                warnings.warn(
-                    "fill_value is not supported and is always 0 for TensorFlow < 2.4.0."
-                )
-            if fill_mode == "NEAREST":
-                raise ValueError(
-                    "NEAREST fill_mode is not supported for TensorFlow < 2.4.0."
-                )
-            output = tf.raw_ops.ImageProjectiveTransformV2(
-                images=images,
-                transforms=transforms,
-                output_shape=output_shape,
-                interpolation=interpolation.upper(),
-                fill_mode=fill_mode,
-            )
+        fill_value = tf.convert_to_tensor(
+            fill_value, dtype=tf.float32, name="fill_value"
+        )
+        output = tf.raw_ops.ImageProjectiveTransformV3(
+            images=images,
+            transforms=transforms,
+            output_shape=output_shape,
+            interpolation=interpolation.upper(),
+            fill_mode=fill_mode.upper(),
+            fill_value=fill_value,
+        )
         return img_utils.from_4D_image(output, original_ndims)
 
 


### PR DESCRIPTION
# Description

#2516 removed support for TensorFlow 2.3. This PR is a followup and removes leftover compatibility code that should no longer be needed.
/cc @seanpmorgan 

# Checklist:

- [x] I've properly [formatted my code according to the guidelines](https://github.com/tensorflow/addons/blob/master/CONTRIBUTING.md#coding-style)
    - [x] By running Black + Flake8
    - [x] By running pre-commit hooks
- [ ] This PR addresses an already submitted issue for TensorFlow Addons
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] This PR contains modifications to C++ custom-ops

# How Has This Been Tested?

This is covered by the existing unittests running on CI
