### PR TITLE
Dice loss branch

### DIFF
--- a/tensorflow_addons/losses/dice_coef_loss.py
+++ b/tensorflow_addons/losses/dice_coef_loss.py
@@ -1,0 +1,21 @@
+import tensorflow.keras.backend as K
+import numpy as np
+import tensorflow as tf
+
+@tf.keras.utils.register_keras_serializable(package="Addons")
+def  dice_loss(y_true,y_pred,smooth=1):
+	'''
+	dice coefficient =2*sum(|y_true*y_pred|)/(sum(y_true^2)+sum(y_pred^2))
+	
+	Args:
+      ->ground truth label
+      ->predicted label
+      -smooth:default is 1
+      
+	'''
+	intersection=K.sum(K.abs(y_true*y_pred),axis=-1)
+	return 1-(2. * intersection + smooth) / (K.sum(K.square(y_true),-1) + K.sum(K.square(y_pred),-1) - intersection + smooth)
+
+
+
+

--- a/tensorflow_addons/losses/tests/dice_coef_loss_test.py
+++ b/tensorflow_addons/losses/tests/dice_coef_loss_test.py
@@ -1,0 +1,18 @@
+import unittest
+from tensorflow_addons.losses import dice_loss 
+import numpy as np
+
+class TestDiceLoss(unittest.TestCase):
+	def test_dice_loss(self):
+		y_true = np.array([[0,0,1,0],[0,0,1,0],[0,0,1.,0.]])
+		y_pred = np.array([[0,0,0.9,0],[0,0,0.1,0],[1,1,0.1,1.]])
+
+		result=dice_loss(y_true, y_pred)
+		print("result= \t ",result)
+		print("it works")
+
+
+if __name__ == '__main__':
+	unittest.main()
+
+


### PR DESCRIPTION
# Added dice loss 

Brief Description of the PR: 

dice loss can be used as a loss function for training segmentation models

Fixes # (issue)

## Type of change

- i have added the dice loss file to tensorflow_addons/losses
- i have added the test file for dice loss to tensorflow_addons/losses/tests

# How Has This Been Tested?
i have used unittest to test this code
*  
