### PR TITLE
Remove bad link.

### DIFF
--- a/docs/tutorials/layers_normalizations.ipynb
+++ b/docs/tutorials/layers_normalizations.ipynb
@@ -304,9 +304,7 @@
         "\n",
         "[Instance norm](https://arxiv.org/pdf/1607.08022.pdf)\n",
         "\n",
-        "[Group Norm](https://arxiv.org/pdf/1803.08494.pdf)\n",
-        "\n",
-        "[Complete Normalizations Overview](http://mlexplained.com/2018/11/30/an-overview-of-normalization-methods-in-deep-learning/)"
+        "[Group Norm](https://arxiv.org/pdf/1803.08494.pdf)"
       ]
     }
   ],


### PR DESCRIPTION
mlexplained.com is dead.