### PR TITLE
:arrow_up:  `tensorflow-macos==2.6.0`

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -45,11 +45,11 @@ jobs:
         include:
           - os: 'macos-11'
             cpu: 'arm64'
-            tf-version: '2.5.0'
+            tf-version: '2.6.0'
             py-version: '3.8'
           - os: 'macos-11'
             cpu: 'arm64'
-            tf-version: '2.5.0'
+            tf-version: '2.6.0'
             py-version: '3.9'
       fail-fast: false
     steps:
@@ -99,11 +99,11 @@ jobs:
         include:
           - os: 'macOS'
             cpu: 'arm64'
-            tf-version: '2.5.0'
+            tf-version: '2.6.0'
             py-version: '3.8'
           - os: 'macOS'
             cpu: 'arm64'
-            tf-version: '2.5.0'
+            tf-version: '2.6.0'
             py-version: '3.9'
       fail-fast: false
     if: (github.event_name == 'push' && github.ref == 'refs/heads/master') || github.event_name == 'release'


### PR DESCRIPTION
This PR updates the `tensorflow-macos` used to build TF Addons to `v2.6.0` as it is now [available on PyPI](https://pypi.org/project/tensorflow-macos)

Fixes https://github.com/tensorflow/addons/pull/2559#discussion_r704449823

/cc @bhack
