### PR TITLE
[tensorflow_addons/custom_ops/layers/cc/kernels/embedding_bag_ops.cc] Reserve vector allocation

### DIFF
--- a/tensorflow_addons/custom_ops/layers/cc/kernels/embedding_bag_ops.cc
+++ b/tensorflow_addons/custom_ops/layers/cc/kernels/embedding_bag_ops.cc
@@ -98,6 +98,7 @@ struct EmbeddingBagBackwardFunctor<CPUDevice, T, Tindices> {
     // The pair (x, {y_i}) in index_vec means
     // index y_i in `indices` contributes to bag `x`.
     std::vector<std::pair<Tindices, std::vector<Eigen::Index>>> index_vec;
+    index_vec[index_map[index]].second.reserve(indices.size());
     for (Eigen::Index i = 0; i < indices.size(); ++i) {
       Tindices index = indices.data()[i];
       if (index_map.find(index) == index_map.end()) {


### PR DESCRIPTION
# Description

Micro optimisation I know!

## Type of change

- [x] Bug fix

# Checklist:

- [x] I've properly [formatted my code according to the guidelines](https://github.com/tensorflow/addons/blob/master/CONTRIBUTING.md#coding-style)
    - [x] By running Black + Flake8
    - [x] By running pre-commit hooks
- [x] This PR addresses an already submitted issue for TensorFlow Addons
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] This PR contains modifications to C++ custom-ops

# How Has This Been Tested?

Context is clear that there's a [`std::vector<T,Allocator>::push_back`](https://en.cppreference.com/w/cpp/container/vector/push_back) in every loop iteration; therefore that's the right amount of space to reserve.