### PR TITLE
Use multipython image for dev container

### DIFF
--- a/tools/docker/dev_container.Dockerfile
+++ b/tools/docker/dev_container.Dockerfile
@@ -1,11 +1,11 @@
 #syntax=docker/dockerfile:1.1.5-experimental
-FROM tensorflow/tensorflow:2.1.0-custom-op-ubuntu16 as dev_container_cpu
+FROM gcr.io/tensorflow-testing/nosla-cuda11.2-cudnn8.1-ubuntu18.04-manylinux2010-multipython as dev_container_cpu
 ARG TF_PACKAGE
 ARG TF_VERSION
 
 # Temporary until custom-op container is updated
-RUN ln -sf /usr/bin/python3 /usr/bin/python
-RUN ln -sf /usr/local/bin/pip3 /usr/local/bin/pip
+RUN ln -sf /usr/local/bin/python3.8 /usr/bin/python
+RUN ln -sf /usr/local/bin/pip3.8 /usr/local/bin/pip
 RUN pip install --default-timeout=1000 $TF_PACKAGE==$TF_VERSION
 
 COPY tools/install_deps /install_deps


### PR DESCRIPTION
# Description

Previous container only supports up to py3.6 which TF2.7 is not built for. TF team has stopped publishing these custom-op images since TF2.5.

Using the CUDA image makes the container larger, but it still uses the cpu only version of TF so it's accurate to call it dev_cpu. Building the gpu image would be pretty trivial now, but also this limits the maintenance burden on our team.

There is no multipython container without GPU installs:
https://console.cloud.google.com/gcr/images/tensorflow-testing/GLOBAL