### PR TITLE
exclude_from_weight_decay for AdamW and SGDW

### DIFF
--- a/tensorflow_addons/optimizers/lamb.py
+++ b/tensorflow_addons/optimizers/lamb.py
@@ -25,7 +25,7 @@ from typeguard import typechecked
 
 import tensorflow as tf
 from tensorflow_addons.utils.types import FloatTensorLike
-from tensorflow_addons.optimizers.utils import is_variable_excluded_by_regexes
+from tensorflow_addons.optimizers.utils import is_variable_matched_by_regexes
 
 
 @tf.keras.utils.register_keras_serializable(package="Addons")
@@ -241,13 +241,13 @@ class LAMB(tf.keras.optimizers.Optimizer):
 
     def _do_use_weight_decay(self, variable):
         """Whether to use L2 weight decay for `param_name`."""
-        return not is_variable_excluded_by_regexes(
+        return not is_variable_matched_by_regexes(
             variable, self.exclude_from_weight_decay
         )
 
     def _do_layer_adaptation(self, variable):
         """Whether to do layer-wise learning rate adaptation for
         `param_name`."""
-        return not is_variable_excluded_by_regexes(
+        return not is_variable_matched_by_regexes(
             variable, self.exclude_from_layer_adaptation
         )

--- a/tensorflow_addons/optimizers/tests/lamb_test.py
+++ b/tensorflow_addons/optimizers/tests/lamb_test.py
@@ -335,20 +335,22 @@ def test_get_config():
 
 def test_exclude_weight_decay():
     opt = lamb.LAMB(0.01, weight_decay=0.01, exclude_from_weight_decay=["var1"])
-    assert opt._do_use_weight_decay("var0")
-    assert not opt._do_use_weight_decay("var1")
-    assert not opt._do_use_weight_decay("var1_weight")
+    assert opt._do_use_weight_decay(tf.Variable([], name="var0"))
+    assert not opt._do_use_weight_decay(tf.Variable([], name="var1"))
+    assert not opt._do_use_weight_decay(tf.Variable([], name="var1_weight"))
 
 
 def test_exclude_layer_adaptation():
     opt = lamb.LAMB(0.01, exclude_from_layer_adaptation=["var1"])
-    assert opt._do_layer_adaptation("var0")
-    assert not opt._do_layer_adaptation("var1")
-    assert not opt._do_layer_adaptation("var1_weight")
+    assert opt._do_layer_adaptation(tf.Variable([], name="var0"))
+    assert not opt._do_layer_adaptation(tf.Variable([], name="var1"))
+    assert not opt._do_layer_adaptation(tf.Variable([], name="var1_weight"))
 
 
 def test_serialization():
-    optimizer = lamb.LAMB(1e-4)
+    optimizer = lamb.LAMB(
+        1e-4, weight_decay_rate=0.01, exclude_from_weight_decay=["var1"]
+    )
     config = tf.keras.optimizers.serialize(optimizer)
     new_optimizer = tf.keras.optimizers.deserialize(config)
     assert new_optimizer.get_config() == optimizer.get_config()

--- a/tensorflow_addons/optimizers/utils.py
+++ b/tensorflow_addons/optimizers/utils.py
@@ -64,12 +64,12 @@ def get_variable_name(variable) -> str:
     return param_name
 
 
-def is_variable_matched_by_regexes(variable, exclude_regexes: List[str]) -> bool:
-    """Whether variable is excluded in exclude_regexes by its name."""
-    if exclude_regexes:
+def is_variable_matched_by_regexes(variable, regexes: List[str]) -> bool:
+    """Whether variable is matched in regexes list by its name."""
+    if regexes:
         # var_name = get_variable_name(variable)
         var_name = variable.name
-        for r in exclude_regexes:
+        for r in regexes:
             if re.search(r, var_name):
                 return True
     return False

--- a/tensorflow_addons/optimizers/utils.py
+++ b/tensorflow_addons/optimizers/utils.py
@@ -67,7 +67,8 @@ def get_variable_name(variable) -> str:
 def is_variable_excluded_by_regexes(variable, exclude_regexes: List[str]) -> bool:
     """Whether to use L2 weight decay for `param_name`."""
     if exclude_regexes:
-        var_name = get_variable_name(variable)
+        # var_name = get_variable_name(variable)
+        var_name = variable.name
         for r in exclude_regexes:
             if re.search(r, var_name):
                 return True

--- a/tensorflow_addons/optimizers/utils.py
+++ b/tensorflow_addons/optimizers/utils.py
@@ -65,7 +65,7 @@ def get_variable_name(variable) -> str:
 
 
 def is_variable_excluded_by_regexes(variable, exclude_regexes: List[str]) -> bool:
-    """Whether to use L2 weight decay for `param_name`."""
+    """Whether variable is excluded in exclude_regexes by its name."""
     if exclude_regexes:
         # var_name = get_variable_name(variable)
         var_name = variable.name

--- a/tensorflow_addons/optimizers/utils.py
+++ b/tensorflow_addons/optimizers/utils.py
@@ -64,7 +64,7 @@ def get_variable_name(variable) -> str:
     return param_name
 
 
-def is_variable_excluded_by_regexes(variable, exclude_regexes: List[str]) -> bool:
+def is_variable_matched_by_regexes(variable, exclude_regexes: List[str]) -> bool:
     """Whether variable is excluded in exclude_regexes by its name."""
     if exclude_regexes:
         # var_name = get_variable_name(variable)

--- a/tensorflow_addons/optimizers/utils.py
+++ b/tensorflow_addons/optimizers/utils.py
@@ -14,7 +14,9 @@
 # ==============================================================================
 """Additional Utilities used for tfa.optimizers."""
 
+import re
 import tensorflow as tf
+from typing import List
 
 
 def fit_bn(model, *args, **kwargs):
@@ -51,3 +53,22 @@ def fit_bn(model, *args, **kwargs):
 
     model.trainable = _trainable
     model._metrics = _metrics
+
+
+def get_variable_name(variable) -> str:
+    """Get the variable name from the variable tensor."""
+    param_name = variable.name
+    m = re.match("^(.*):\\d+$", param_name)
+    if m is not None:
+        param_name = m.group(1)
+    return param_name
+
+
+def is_variable_excluded_by_regexes(variable, exclude_regexes: List[str]) -> bool:
+    """Whether to use L2 weight decay for `param_name`."""
+    if exclude_regexes:
+        var_name = get_variable_name(variable)
+        for r in exclude_regexes:
+            if re.search(r, var_name):
+                return True
+    return False


### PR DESCRIPTION
# Description
Brief Description of the PR:
- Add `exclude_from_weight_decay` for `DecoupledWeightDecayExtension` optimizers including `AdamW` and `SGDW`, like `LAMB`. There are several issues on this, like [Support exclude_from_weight_decay in AdamW #1903](https://github.com/tensorflow/addons/issues/1903) and [Add decay_var_list as init option to DecoupledWeightDecayExtension #2018](https://github.com/tensorflow/addons/issues/2018).
- This PR is a mimic of current `LAMB exclude_from_weight_decay` behavior, and it has a conflict with current `DecoupledWeightDecayExtension` `_decay_var_list`. I'm actually looking forward if a better solution can be introduced.

Fixes # (issue)
- [Support exclude_from_weight_decay in AdamW #1903](https://github.com/tensorflow/addons/issues/1903).
- [Add decay_var_list as init option to DecoupledWeightDecayExtension #2018](https://github.com/tensorflow/addons/issues/2018).
## Type of change

- [x] Bug fix
- [ ] New Tutorial
- [ ] Updated or additional documentation
- [ ] Additional Testing
- [ ] New Activation and the changes conform to the [activation contribution guidelines](https://github.com/tensorflow/addons/blob/master/tensorflow_addons/activations/README.md#contribution-guidelines)
- [ ] New Callback and the changes conform to the [callback contribution guidelines](https://github.com/tensorflow/addons/blob/master/tensorflow_addons/callbacks/README.md#contribution-guidelines)
- [ ] New Image addition and the changes conform to the [image op contribution guidelines](https://github.com/tensorflow/addons/blob/master/tensorflow_addons/image/README.md#contribution-guidelines)
- [ ] New Layer and the changes conform to the [layer contribution guidelines](https://github.com/tensorflow/addons/blob/master/tensorflow_addons/layers/README.md#contribution-guidelines)
- [ ] New Loss and the changes conform to the [loss contribution guidelines](https://github.com/tensorflow/addons/blob/master/tensorflow_addons/losses/README.md#contribution-guidelines)
- [ ] New Metric and the changes conform to the [metric contribution guidelines](https://github.com/tensorflow/addons/blob/master/tensorflow_addons/metrics/README.md#contribution-guidelines)
- [ ] New Optimizer and the changes conform to the [optimizer contribution guidelines](https://github.com/tensorflow/addons/blob/master/tensorflow_addons/optimizers/README.md#contribution-guidelines)
- [ ] New RNN Cell and the changes conform to the [rnn contribution guidelines](https://github.com/tensorflow/addons/blob/master/tensorflow_addons/rnn/README.md#contribution-guidelines)
- [ ] New Seq2seq addition and the changes conform to the [seq2seq contribution guidelines](https://github.com/tensorflow/addons/blob/master/tensorflow_addons/seq2seq/README.md#contribution-guidelines)
- [ ] New Text addition and the changes conform to the [text op contribution guidelines](https://github.com/tensorflow/addons/blob/master/tensorflow_addons/text/README.md#contribution-guidelines)

# Checklist:

- [x] I've properly [formatted my code according to the guidelines](https://github.com/tensorflow/addons/blob/master/CONTRIBUTING.md#coding-style)
    - [x] By running Black + Flake8
    - [ ] By running pre-commit hooks
- [x] This PR addresses an already submitted issue for TensorFlow Addons
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] This PR contains modifications to C++ custom-ops

# How Has This Been Tested?
If we open the commented print line 248, then:
```py
import tensorflow as tf
from tensorflow import keras
import tensorflow_addons as tfa
xx = tf.random.uniform((1000, 32, 32, 3))
yy = tf.one_hot(tf.cast(tf.random.uniform((1000,)) * 10, 'int32'), depth=32)
mm = keras.models.Sequential([keras.layers.Input([32, 32, 3]), keras.layers.Flatten(), keras.layers.BatchNormalization(), keras.layers.Dense(32)])
mm.compile(optimizer=tfa.optimizers.AdamW(weight_decay=0.01, exclude_from_weight_decay=['/gamma', '/beta']), loss="categorical_crossentropy")
mm.fit(xx, yy)
# Filtered: batch_normalization/gamma
# Filtered: batch_normalization/beta
# Filtered: batch_normalization/gamma
# Filtered: batch_normalization/beta
# 32/32 [==============================] - 1s 6ms/step - loss: 8.2161

mm.save('aa.h5')
bb = keras.models.load_model('aa.h5')
print(bb.optimizer.exclude_from_weight_decay)
# ['/gamma', '/beta']
```
If you're adding a bugfix or new feature please describe the tests that you ran to verify your changes:
*  
