### PR TITLE
Pin mac build environment's OS version

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -38,7 +38,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: ['macos-latest', 'windows-latest', 'ubuntu-18.04']
+        os: ['macos-10.15', 'windows-latest', 'ubuntu-18.04']
         py-version: ['3.7', '3.8', '3.9']
         tf-version: ['2.5.1', '2.7.0']
         cpu: ['x86']

--- a/build_deps/build_pip_pkg.sh
+++ b/build_deps/build_pip_pkg.sh
@@ -80,7 +80,7 @@ function main() {
     if [[ x"$(arch)" == x"arm64" ]]; then
       BUILD_CMD="${BUILD_CMD} --plat-name macosx_11_0_arm64"
     else
-      BUILD_CMD="${BUILD_CMD} --plat-name macosx_10_13_x86_64"
+      BUILD_CMD="${BUILD_CMD} --plat-name macosx_10_15_x86_64"
     fi
     PYTHON=python3
   else


### PR DESCRIPTION
# Description
`macos-latest` has started migrating to macos-11:
https://github.blog/changelog/2021-09-29-github-actions-jobs-running-on-macos-latest-are-now-running-on-macos-big-sur-11/

Making a PR to set these as pinned versions.