### PR TITLE
Make GN and IN the same dtype behavior as BN or LN in mixed_precision

### DIFF
--- a/tensorflow_addons/layers/normalizations.py
+++ b/tensorflow_addons/layers/normalizations.py
@@ -39,6 +39,10 @@ class GroupNormalization(tf.keras.layers.Layer):
     If the number of groups is set to 1, then this operation becomes identical
     to Layer Normalization.
 
+    If mixed precision is used, cast inputs to float32 to abtain numerical
+    stability, just like 'tf.keras.layers.LayerNormalization' and
+    'tf.keras.layers.BatchNormalization' do.
+
     Relation to Instance Normalization:
     If the number of groups is set to the
     input dimension (number of groups is equal
@@ -117,6 +121,10 @@ class GroupNormalization(tf.keras.layers.Layer):
 
     def call(self, inputs):
 
+        input_dtype = inputs.dtype
+        if input_dtype in ("float16", "bfloat16") and self.dtype == "float32":
+            inputs = tf.cast(inputs, "float32")
+
         input_shape = tf.keras.backend.int_shape(inputs)
         tensor_input_shape = tf.shape(inputs)
 
@@ -131,6 +139,8 @@ class GroupNormalization(tf.keras.layers.Layer):
             outputs = tf.reshape(normalized_inputs, tensor_input_shape)
         else:
             outputs = normalized_inputs
+
+        outputs = tf.cast(outputs, input_dtype)
 
         return outputs
 
@@ -265,6 +275,7 @@ class GroupNormalization(tf.keras.layers.Layer):
                 initializer=self.gamma_initializer,
                 regularizer=self.gamma_regularizer,
                 constraint=self.gamma_constraint,
+                experimental_autocast=False,
             )
         else:
             self.gamma = None
@@ -281,6 +292,7 @@ class GroupNormalization(tf.keras.layers.Layer):
                 initializer=self.beta_initializer,
                 regularizer=self.beta_regularizer,
                 constraint=self.beta_constraint,
+                experimental_autocast=False,
             )
         else:
             self.beta = None

--- a/tensorflow_addons/layers/tests/normalizations_test.py
+++ b/tensorflow_addons/layers/tests/normalizations_test.py
@@ -395,35 +395,15 @@ def test_groupnorm_mixed_precision_accuracy(dtype):
         axis=-1, dtype=dtype, input_shape=(28, 28, 3)
     )
     baseline_norm.build(input_shape=(10, 28, 28, 3))
-
-    for _ in range(10):
-        x = random_generator.normal(shape=(10, 28, 28, 3), mean=5.0, stddev=10.0)
-        computed_1 = tf.reduce_mean(
-            norm(x, training=True) - baseline_norm(x, training=True)
-        ).numpy()
-        computed_2 = tf.reduce_mean(
-            norm(x, training=False) - baseline_norm(x, training=False)
-        ).numpy()
-        if dtype == "mixed_float16":
-            test_utils.assert_allclose_according_to_type(
-                computed_1,
-                0.0,
-                half_rtol=1e-4,
-                half_atol=1e-4,
-                bfloat16_rtol=1e-4,
-                bfloat16_atol=1e-4,
-            )
-            test_utils.assert_allclose_according_to_type(
-                computed_2,
-                0.0,
-                half_rtol=1e-4,
-                half_atol=1e-4,
-                bfloat16_rtol=1e-4,
-                bfloat16_atol=1e-4,
-            )
-        else:
-            test_utils.assert_allclose_according_to_type(computed_1, 0.0)
-            test_utils.assert_allclose_according_to_type(computed_2, 0.0)
+    x = random_generator.normal(shape=(10, 28, 28, 3), mean=5.0, stddev=10.0)
+    computed_1 = tf.reduce_mean(
+        norm(x, training=True) - baseline_norm(x, training=True)
+    ).numpy()
+    computed_2 = tf.reduce_mean(
+        norm(x, training=False) - baseline_norm(x, training=False)
+    ).numpy()
+    test_utils.assert_allclose_according_to_type(computed_1, 0.0)
+    test_utils.assert_allclose_according_to_type(computed_2, 0.0)
 
 
 def calculate_frn(

--- a/tensorflow_addons/layers/tests/normalizations_test.py
+++ b/tensorflow_addons/layers/tests/normalizations_test.py
@@ -379,10 +379,9 @@ def test_groupnorm_mixed_precision_behavior(dtype):
         assert w_in_norm.shape == w_in_base_norm.shape
 
 
-@pytest.mark.with_device(["cpu"])
 @pytest.mark.usefixtures("maybe_run_functions_eagerly")
 @pytest.mark.parametrize("dtype", ["float16", "mixed_float16", "float32", "float64"])
-def test_groupnorm_mixed_precision_accuracy_cpu(dtype):
+def test_groupnorm_mixed_precision_accuracy(dtype):
     random_generator = tf.random.Generator.from_seed(0x2020)
 
     norm = GroupNormalization(
@@ -409,82 +408,18 @@ def test_groupnorm_mixed_precision_accuracy_cpu(dtype):
             test_utils.assert_allclose_according_to_type(
                 computed_1,
                 0.0,
-                rtol=1e-5,
-                atol=1e-5,
-                float_rtol=1e-5,
-                float_atol=1e-5,
-                half_rtol=1e-5,
-                half_atol=1e-5,
-                bfloat16_rtol=1e-5,
-                bfloat16_atol=1e-5,
+                half_rtol=1e-4,
+                half_atol=1e-4,
+                bfloat16_rtol=1e-4,
+                bfloat16_atol=1e-4,
             )
             test_utils.assert_allclose_according_to_type(
                 computed_2,
                 0.0,
-                rtol=1e-5,
-                atol=1e-5,
-                float_rtol=1e-5,
-                float_atol=1e-5,
-                half_rtol=1e-5,
-                half_atol=1e-5,
-                bfloat16_rtol=1e-5,
-                bfloat16_atol=1e-5,
-            )
-        else:
-            test_utils.assert_allclose_according_to_type(computed_1, 0.0)
-            test_utils.assert_allclose_according_to_type(computed_2, 0.0)
-
-
-@pytest.mark.with_device(["gpu"])
-@pytest.mark.usefixtures("maybe_run_functions_eagerly")
-@pytest.mark.parametrize("dtype", ["float16", "mixed_float16", "float32", "float64"])
-def test_groupnorm_mixed_precision_accuracy_gpu(dtype):
-    random_generator = tf.random.Generator.from_seed(0x2020)
-
-    norm = GroupNormalization(
-        axis=-1,
-        groups=1,
-        dtype=dtype,
-    )
-    norm.build(input_shape=(10, 28, 28, 3))
-
-    baseline_norm = tf.keras.layers.LayerNormalization(
-        axis=-1, dtype=dtype, input_shape=(28, 28, 3)
-    )
-    baseline_norm.build(input_shape=(10, 28, 28, 3))
-
-    for _ in range(10):
-        x = random_generator.normal(shape=(10, 28, 28, 3), mean=5.0, stddev=10.0)
-        computed_1 = tf.reduce_mean(
-            norm(x, training=True) - baseline_norm(x, training=True)
-        ).numpy()
-        computed_2 = tf.reduce_mean(
-            norm(x, training=False) - baseline_norm(x, training=False)
-        ).numpy()
-        if dtype == "mixed_float16":
-            test_utils.assert_allclose_according_to_type(
-                computed_1,
-                0.0,
-                rtol=1e-5,
-                atol=1e-5,
-                float_rtol=1e-5,
-                float_atol=1e-5,
-                half_rtol=1e-5,
-                half_atol=1e-5,
-                bfloat16_rtol=1e-5,
-                bfloat16_atol=1e-5,
-            )
-            test_utils.assert_allclose_according_to_type(
-                computed_2,
-                0.0,
-                rtol=1e-5,
-                atol=1e-5,
-                float_rtol=1e-5,
-                float_atol=1e-5,
-                half_rtol=1e-5,
-                half_atol=1e-5,
-                bfloat16_rtol=1e-5,
-                bfloat16_atol=1e-5,
+                half_rtol=1e-4,
+                half_atol=1e-4,
+                bfloat16_rtol=1e-4,
+                bfloat16_atol=1e-4,
             )
         else:
             test_utils.assert_allclose_according_to_type(computed_1, 0.0)


### PR DESCRIPTION
This PR makes GroupNorm and InstanceNorm the same dtype behavior as keras' BatchNorm or LayerNorm in mixed_precision.

Fixes #2550

## Type of change

- [x] Bug fix


# Checklist:

- [x] I've properly [formatted my code according to the guidelines](https://github.com/tensorflow/addons/blob/master/CONTRIBUTING.md#coding-style)
    - [x] By running Black + Flake8
    - [x] By running pre-commit hooks
- [x] This PR addresses an already submitted issue for TensorFlow Addons
- [x] I have added tests that prove my fix is effective or that my feature works

# How Has This Been Tested?
` python -m pytest .\tensorflow_addons\layers\tests\normalizations_test.py`
Add accuracy tests for modified GN by setting tf.keras.layers.LayerNormalization as baseline.

