### PR TITLE
:arrow_up: `scikit-learn`

### DIFF
--- a/tensorflow_addons/metrics/tests/matthews_correlation_coefficient_test.py
+++ b/tensorflow_addons/metrics/tests/matthews_correlation_coefficient_test.py
@@ -14,11 +14,11 @@
 # ==============================================================================
 """Matthews Correlation Coefficient Test."""
 
-import pytest
 import tensorflow as tf
 
 import numpy as np
 from tensorflow_addons.metrics import MatthewsCorrelationCoefficient
+from sklearn.metrics import matthews_corrcoef as sklearn_matthew
 
 
 def test_config():
@@ -53,9 +53,6 @@ def test_binary_classes():
 
 # See issue #2339
 def test_multiple_classes():
-    pytest.skip("Wait #2666 to be fixed")
-    from sklearn.metrics import matthews_corrcoef as sklearn_matthew
-
     gt_label = np.array(
         [
             [1.0, 0.0, 0.0],

--- a/tensorflow_addons/metrics/tests/r_square_test.py
+++ b/tensorflow_addons/metrics/tests/r_square_test.py
@@ -17,6 +17,7 @@
 import numpy as np
 import pytest
 import tensorflow as tf
+from sklearn.metrics import r2_score as sklearn_r2_score
 
 from tensorflow_addons.metrics import RSquare
 from tensorflow_addons.metrics.r_square import _VALID_MULTIOUTPUT
@@ -136,9 +137,6 @@ def test_r2_reset_state():
 
 @pytest.mark.parametrize("multioutput", sorted(_VALID_MULTIOUTPUT))
 def test_r2_sklearn_comparison(multioutput):
-    pytest.skip("Wait #2666 to be fixed")
-    from sklearn.metrics import r2_score as sklearn_r2_score
-
     """Test against sklearn's implementation on random inputs."""
     for _ in range(10):
         actuals = np.random.rand(64, 3)

--- a/tools/install_deps/pytest.txt
+++ b/tools/install_deps/pytest.txt
@@ -1,7 +1,7 @@
 pytest~=6.2.5
 pytest-xdist~=1.31
 pytest-extra-durations~=0.1.3
-scikit-learn~=0.22
+scikit-learn~=1.0.2
 #scikit-image~=0.17.0
 Pillow~=9.0.1
 tqdm>=4.36.1


### PR DESCRIPTION
This PR upgrade `scikit-learn` and re-enables the relevant tests on CI to partially address #2666.

Let's see what CI thinks about this...