### PR TITLE
Wrap specific padding behavior for convolution layer in tf.keras

### DIFF
--- a/tensorflow_addons/layers/tests/wrappers_test.py
+++ b/tensorflow_addons/layers/tests/wrappers_test.py
@@ -203,7 +203,7 @@ def test_removal(base_layer_fn, input_shape, data_init):
 @pytest.mark.parametrize("stride", [1, 2])
 @pytest.mark.parametrize("padding", ["same", "valid", "causal"])
 @pytest.mark.parametrize("dilation_rate", [1, 2])
-def test_convpadspecific_behavior_1d(
+def test_convpadconcretization_behavior_1d(
     input_shape, kernel_size, stride, padding, dilation_rate
 ):
     if dilation_rate > 1 and stride != 1:
@@ -218,10 +218,10 @@ def test_convpadspecific_behavior_1d(
             * dim
             + [3]
         )
-        tf.keras.utils.set_random_seed(1000)
+        tf.random.set_seed(1000)
         x = tf.random.normal(shape=input_shape, seed=1000)
 
-        tf.keras.utils.set_random_seed(1000)
+        tf.random.set_seed(1000)
         kernel_initializer = tf.keras.initializers.GlorotUniform(seed=1000)
         conv1d = tf.keras.layers.Conv1D(
             filters=8,
@@ -237,7 +237,7 @@ def test_convpadspecific_behavior_1d(
         )
         y = conv1d(x)
 
-        tf.keras.utils.set_random_seed(1000)
+        tf.random.set_seed(1000)
         kernel_initializer = tf.keras.initializers.GlorotUniform(seed=1000)
         conv1d_ = tf.keras.layers.Conv1D(
             filters=8,
@@ -267,7 +267,7 @@ def test_convpadspecific_behavior_1d(
 @pytest.mark.parametrize("stride", [1, 2])
 @pytest.mark.parametrize("padding", ["same", "valid"])
 @pytest.mark.parametrize("dilation_rate", [1, 2])
-def test_convpadspecific_behavior_2d(
+def test_convpadconcretization_behavior_2d(
     input_shape, kernel_size, stride, padding, dilation_rate
 ):
     if dilation_rate > 1 and stride != 1:
@@ -282,10 +282,10 @@ def test_convpadspecific_behavior_2d(
             * dim
             + [3]
         )
-        tf.keras.utils.set_random_seed(1000)
+        tf.random.set_seed(1000)
         x = tf.random.normal(shape=input_shape, seed=1000)
 
-        tf.keras.utils.set_random_seed(1000)
+        tf.random.set_seed(1000)
         kernel_initializer = tf.keras.initializers.GlorotUniform(seed=1000)
         conv2d = tf.keras.layers.Conv2D(
             filters=8,
@@ -301,7 +301,7 @@ def test_convpadspecific_behavior_2d(
         )
         y = conv2d(x)
 
-        tf.keras.utils.set_random_seed(1000)
+        tf.random.set_seed(1000)
         kernel_initializer = tf.keras.initializers.GlorotUniform(seed=1000)
         conv2d_ = tf.keras.layers.Conv2D(
             filters=8,
@@ -331,7 +331,7 @@ def test_convpadspecific_behavior_2d(
 @pytest.mark.parametrize("stride", [1, 2])
 @pytest.mark.parametrize("padding", ["same", "valid"])
 @pytest.mark.parametrize("dilation_rate", [1, 2])
-def test_convpadspecific_behavior_3d(
+def test_convpadconcretization_behavior_3d(
     input_shape, kernel_size, stride, padding, dilation_rate
 ):
     if dilation_rate > 1 and stride != 1:
@@ -346,10 +346,10 @@ def test_convpadspecific_behavior_3d(
             * dim
             + [3]
         )
-        tf.keras.utils.set_random_seed(1000)
+        tf.random.set_seed(1000)
         x = tf.random.normal(shape=input_shape, seed=1000)
 
-        tf.keras.utils.set_random_seed(1000)
+        tf.random.set_seed(1000)
         kernel_initializer = tf.keras.initializers.GlorotUniform(seed=1000)
         conv3d = tf.keras.layers.Conv3D(
             filters=8,
@@ -365,7 +365,7 @@ def test_convpadspecific_behavior_3d(
         )
         y = conv3d(x)
 
-        tf.keras.utils.set_random_seed(1000)
+        tf.random.set_seed(1000)
         kernel_initializer = tf.keras.initializers.GlorotUniform(seed=1000)
         conv3d_ = tf.keras.layers.Conv3D(
             filters=8,
@@ -397,7 +397,7 @@ def test_convpadspecific_behavior_3d(
 @pytest.mark.parametrize("dilation_rate", [1, 2])
 @pytest.mark.parametrize("padding_mode", ["constant", "reflect", "symmetric"])
 @pytest.mark.parametrize("padding_constant", [0, 1])
-def test_convpadspecific_behavior_1d_with_padding_mode(
+def test_convpadconcretization_behavior_1d_with_padding_mode(
     input_shape,
     kernel_size,
     stride,
@@ -420,10 +420,10 @@ def test_convpadspecific_behavior_1d_with_padding_mode(
             * dim
             + [3]
         )
-        tf.keras.utils.set_random_seed(1000)
+        tf.random.set_seed(1000)
         x = tf.random.normal(shape=input_shape, seed=1000)
 
-        tf.keras.utils.set_random_seed(1000)
+        tf.random.set_seed(1000)
         kernel_initializer = tf.keras.initializers.GlorotUniform(seed=1000)
         conv1d = tf.keras.layers.Conv1D(
             filters=8,
@@ -439,7 +439,7 @@ def test_convpadspecific_behavior_1d_with_padding_mode(
         )
         y = conv1d(x)
 
-        tf.keras.utils.set_random_seed(1000)
+        tf.random.set_seed(1000)
         kernel_initializer = tf.keras.initializers.GlorotUniform(seed=1000)
         conv1d_ = tf.keras.layers.Conv1D(
             filters=8,
@@ -468,7 +468,7 @@ def test_convpadspecific_behavior_1d_with_padding_mode(
 @pytest.mark.parametrize("dilation_rate", [1, 2])
 @pytest.mark.parametrize("padding_mode", ["constant", "reflect", "symmetric"])
 @pytest.mark.parametrize("padding_constant", [0, 1])
-def test_convpadspecific_behavior_2d_with_padding_mode(
+def test_convpadconcretization_behavior_2d_with_padding_mode(
     input_shape,
     kernel_size,
     stride,
@@ -489,10 +489,10 @@ def test_convpadspecific_behavior_2d_with_padding_mode(
             * dim
             + [3]
         )
-        tf.keras.utils.set_random_seed(1000)
+        tf.random.set_seed(1000)
         x = tf.random.normal(shape=input_shape, seed=1000)
 
-        tf.keras.utils.set_random_seed(1000)
+        tf.random.set_seed(1000)
         kernel_initializer = tf.keras.initializers.GlorotUniform(seed=1000)
         conv2d = tf.keras.layers.Conv2D(
             filters=8,
@@ -508,7 +508,7 @@ def test_convpadspecific_behavior_2d_with_padding_mode(
         )
         y = conv2d(x)
 
-        tf.keras.utils.set_random_seed(1000)
+        tf.random.set_seed(1000)
         kernel_initializer = tf.keras.initializers.GlorotUniform(seed=1000)
         conv2d_ = tf.keras.layers.Conv2D(
             filters=8,
@@ -537,7 +537,7 @@ def test_convpadspecific_behavior_2d_with_padding_mode(
 @pytest.mark.parametrize("dilation_rate", [1, 2])
 @pytest.mark.parametrize("padding_mode", ["constant", "reflect", "symmetric"])
 @pytest.mark.parametrize("padding_constant", [0, 1])
-def test_convpadspecific_behavior_3d_with_padding_mode(
+def test_convpadconcretization_behavior_3d_with_padding_mode(
     input_shape,
     kernel_size,
     stride,
@@ -558,10 +558,10 @@ def test_convpadspecific_behavior_3d_with_padding_mode(
             * dim
             + [3]
         )
-        tf.keras.utils.set_random_seed(1000)
+        tf.random.set_seed(1000)
         x = tf.random.normal(shape=input_shape, seed=1000)
 
-        tf.keras.utils.set_random_seed(1000)
+        tf.random.set_seed(1000)
         kernel_initializer = tf.keras.initializers.GlorotUniform(seed=1000)
         conv3d = tf.keras.layers.Conv3D(
             filters=8,
@@ -577,7 +577,7 @@ def test_convpadspecific_behavior_3d_with_padding_mode(
         )
         y = conv3d(x)
 
-        tf.keras.utils.set_random_seed(1000)
+        tf.random.set_seed(1000)
         kernel_initializer = tf.keras.initializers.GlorotUniform(seed=1000)
         conv3d_ = tf.keras.layers.Conv3D(
             filters=8,

--- a/tensorflow_addons/layers/tests/wrappers_test.py
+++ b/tensorflow_addons/layers/tests/wrappers_test.py
@@ -203,7 +203,7 @@ def test_removal(base_layer_fn, input_shape, data_init):
 @pytest.mark.parametrize("stride", [1, 2])
 @pytest.mark.parametrize("padding", ["same", "valid", "causal"])
 @pytest.mark.parametrize("dilation_rate", [1, 2])
-def test_specificconvpad_behavior_1d(
+def test_convpadspecific_behavior_1d(
     input_shape, kernel_size, stride, padding, dilation_rate
 ):
     if dilation_rate > 1 and stride != 1:
@@ -251,7 +251,7 @@ def test_specificconvpad_behavior_1d(
             use_bias=False,
             kernel_initializer=kernel_initializer,
         )
-        conv1d_2 = wrappers.SpecificConvPad(
+        conv1d_2 = wrappers.ConvPadConcretization(
             conv1d_, padding_mode="constant", padding_constant=0
         )
         y_ = conv1d_2(x)
@@ -267,7 +267,7 @@ def test_specificconvpad_behavior_1d(
 @pytest.mark.parametrize("stride", [1, 2])
 @pytest.mark.parametrize("padding", ["same", "valid"])
 @pytest.mark.parametrize("dilation_rate", [1, 2])
-def test_specificconvpad_behavior_2d(
+def test_convpadspecific_behavior_2d(
     input_shape, kernel_size, stride, padding, dilation_rate
 ):
     if dilation_rate > 1 and stride != 1:
@@ -315,7 +315,7 @@ def test_specificconvpad_behavior_2d(
             use_bias=False,
             kernel_initializer=kernel_initializer,
         )
-        conv2d_2 = wrappers.SpecificConvPad(
+        conv2d_2 = wrappers.ConvPadConcretization(
             conv2d_, padding_mode="constant", padding_constant=0
         )
         y_ = conv2d_2(x)
@@ -331,7 +331,7 @@ def test_specificconvpad_behavior_2d(
 @pytest.mark.parametrize("stride", [1, 2])
 @pytest.mark.parametrize("padding", ["same", "valid"])
 @pytest.mark.parametrize("dilation_rate", [1, 2])
-def test_specificconvpad_behavior_3d(
+def test_convpadspecific_behavior_3d(
     input_shape, kernel_size, stride, padding, dilation_rate
 ):
     if dilation_rate > 1 and stride != 1:
@@ -379,7 +379,7 @@ def test_specificconvpad_behavior_3d(
             use_bias=False,
             kernel_initializer=kernel_initializer,
         )
-        conv3d_2 = wrappers.SpecificConvPad(
+        conv3d_2 = wrappers.ConvPadConcretization(
             conv3d_, padding_mode="constant", padding_constant=0
         )
         y_ = conv3d_2(x)
@@ -397,7 +397,7 @@ def test_specificconvpad_behavior_3d(
 @pytest.mark.parametrize("dilation_rate", [1, 2])
 @pytest.mark.parametrize("padding_mode", ["constant", "reflect", "symmetric"])
 @pytest.mark.parametrize("padding_constant", [0, 1])
-def test_specificconvpad_behavior_1d_with_padding_mode(
+def test_convpadspecific_behavior_1d_with_padding_mode(
     input_shape,
     kernel_size,
     stride,
@@ -453,7 +453,7 @@ def test_specificconvpad_behavior_1d_with_padding_mode(
             use_bias=False,
             kernel_initializer=kernel_initializer,
         )
-        conv1d_2 = wrappers.SpecificConvPad(
+        conv1d_2 = wrappers.ConvPadConcretization(
             conv1d_, padding_mode=padding_mode, padding_constant=padding_constant
         )
         y_ = conv1d_2(x)
@@ -468,7 +468,7 @@ def test_specificconvpad_behavior_1d_with_padding_mode(
 @pytest.mark.parametrize("dilation_rate", [1, 2])
 @pytest.mark.parametrize("padding_mode", ["constant", "reflect", "symmetric"])
 @pytest.mark.parametrize("padding_constant", [0, 1])
-def test_specificconvpad_behavior_2d_with_padding_mode(
+def test_convpadspecific_behavior_2d_with_padding_mode(
     input_shape,
     kernel_size,
     stride,
@@ -522,7 +522,7 @@ def test_specificconvpad_behavior_2d_with_padding_mode(
             use_bias=False,
             kernel_initializer=kernel_initializer,
         )
-        conv2d_2 = wrappers.SpecificConvPad(
+        conv2d_2 = wrappers.ConvPadConcretization(
             conv2d_, padding_mode=padding_mode, padding_constant=padding_constant
         )
         y_ = conv2d_2(x)
@@ -537,7 +537,7 @@ def test_specificconvpad_behavior_2d_with_padding_mode(
 @pytest.mark.parametrize("dilation_rate", [1, 2])
 @pytest.mark.parametrize("padding_mode", ["constant", "reflect", "symmetric"])
 @pytest.mark.parametrize("padding_constant", [0, 1])
-def test_specificconvpad_behavior_3d_with_padding_mode(
+def test_convpadspecific_behavior_3d_with_padding_mode(
     input_shape,
     kernel_size,
     stride,
@@ -591,7 +591,7 @@ def test_specificconvpad_behavior_3d_with_padding_mode(
             use_bias=False,
             kernel_initializer=kernel_initializer,
         )
-        conv3d_2 = wrappers.SpecificConvPad(
+        conv3d_2 = wrappers.ConvPadConcretization(
             conv3d_, padding_mode=padding_mode, padding_constant=padding_constant
         )
         y_ = conv3d_2(x)

--- a/tensorflow_addons/layers/tests/wrappers_test.py
+++ b/tensorflow_addons/layers/tests/wrappers_test.py
@@ -198,8 +198,8 @@ def test_removal(base_layer_fn, input_shape, data_init):
 
 
 @pytest.mark.usefixtures("maybe_run_functions_eagerly")
-@pytest.mark.parametrize("input_shape", [15, 16, 17])
-@pytest.mark.parametrize("kernel_size", [1, 2, 3])
+@pytest.mark.parametrize("input_shape", [16, 17])
+@pytest.mark.parametrize("kernel_size", [2, 3])
 @pytest.mark.parametrize("stride", [1, 2])
 @pytest.mark.parametrize("padding", ["same", "valid", "causal"])
 @pytest.mark.parametrize("dilation_rate", [1, 2])
@@ -262,8 +262,8 @@ def test_convpadconcretization_behavior_1d(
 
 
 @pytest.mark.usefixtures("maybe_run_functions_eagerly")
-@pytest.mark.parametrize("input_shape", [15, 16, 17])
-@pytest.mark.parametrize("kernel_size", [1, 2, 3])
+@pytest.mark.parametrize("input_shape", [16, 17])
+@pytest.mark.parametrize("kernel_size", [2, 3])
 @pytest.mark.parametrize("stride", [1, 2])
 @pytest.mark.parametrize("padding", ["same", "valid"])
 @pytest.mark.parametrize("dilation_rate", [1, 2])
@@ -326,8 +326,8 @@ def test_convpadconcretization_behavior_2d(
 
 
 @pytest.mark.usefixtures("maybe_run_functions_eagerly")
-@pytest.mark.parametrize("input_shape", [15, 16, 17])
-@pytest.mark.parametrize("kernel_size", [1, 2, 3])
+@pytest.mark.parametrize("input_shape", [16, 17])
+@pytest.mark.parametrize("kernel_size", [2, 3])
 @pytest.mark.parametrize("stride", [1, 2])
 @pytest.mark.parametrize("padding", ["same", "valid"])
 @pytest.mark.parametrize("dilation_rate", [1, 2])
@@ -390,13 +390,12 @@ def test_convpadconcretization_behavior_3d(
 
 
 @pytest.mark.usefixtures("maybe_run_functions_eagerly")
-@pytest.mark.parametrize("input_shape", [15, 16, 17])
-@pytest.mark.parametrize("kernel_size", [1, 2, 3])
+@pytest.mark.parametrize("input_shape", [16, 17])
+@pytest.mark.parametrize("kernel_size", [2, 3])
 @pytest.mark.parametrize("stride", [1, 2])
 @pytest.mark.parametrize("padding", ["same", "valid", "causal"])
 @pytest.mark.parametrize("dilation_rate", [1, 2])
 @pytest.mark.parametrize("padding_mode", ["constant", "reflect", "symmetric"])
-@pytest.mark.parametrize("padding_constant", [0, 1])
 def test_convpadconcretization_behavior_1d_with_padding_mode(
     input_shape,
     kernel_size,
@@ -404,7 +403,6 @@ def test_convpadconcretization_behavior_1d_with_padding_mode(
     padding,
     dilation_rate,
     padding_mode,
-    padding_constant,
 ):
     if dilation_rate > 1 and stride != 1:
         pass
@@ -453,21 +451,18 @@ def test_convpadconcretization_behavior_1d_with_padding_mode(
             use_bias=False,
             kernel_initializer=kernel_initializer,
         )
-        conv1d_2 = wrappers.ConvPadConcretization(
-            conv1d_, padding_mode=padding_mode, padding_constant=padding_constant
-        )
+        conv1d_2 = wrappers.ConvPadConcretization(conv1d_, padding_mode=padding_mode)
         y_ = conv1d_2(x)
         assert y.shape == y_.shape
 
 
 @pytest.mark.usefixtures("maybe_run_functions_eagerly")
-@pytest.mark.parametrize("input_shape", [15, 16, 17])
-@pytest.mark.parametrize("kernel_size", [1, 2, 3])
+@pytest.mark.parametrize("input_shape", [16, 17])
+@pytest.mark.parametrize("kernel_size", [2, 3])
 @pytest.mark.parametrize("stride", [1, 2])
 @pytest.mark.parametrize("padding", ["same", "valid"])
 @pytest.mark.parametrize("dilation_rate", [1, 2])
 @pytest.mark.parametrize("padding_mode", ["constant", "reflect", "symmetric"])
-@pytest.mark.parametrize("padding_constant", [0, 1])
 def test_convpadconcretization_behavior_2d_with_padding_mode(
     input_shape,
     kernel_size,
@@ -475,7 +470,6 @@ def test_convpadconcretization_behavior_2d_with_padding_mode(
     padding,
     dilation_rate,
     padding_mode,
-    padding_constant,
 ):
     if dilation_rate > 1 and stride != 1:
         pass
@@ -522,21 +516,18 @@ def test_convpadconcretization_behavior_2d_with_padding_mode(
             use_bias=False,
             kernel_initializer=kernel_initializer,
         )
-        conv2d_2 = wrappers.ConvPadConcretization(
-            conv2d_, padding_mode=padding_mode, padding_constant=padding_constant
-        )
+        conv2d_2 = wrappers.ConvPadConcretization(conv2d_, padding_mode=padding_mode)
         y_ = conv2d_2(x)
         assert y.shape == y_.shape
 
 
 @pytest.mark.usefixtures("maybe_run_functions_eagerly")
-@pytest.mark.parametrize("input_shape", [15, 16, 17])
-@pytest.mark.parametrize("kernel_size", [1, 2, 3])
+@pytest.mark.parametrize("input_shape", [16, 17])
+@pytest.mark.parametrize("kernel_size", [2, 3])
 @pytest.mark.parametrize("stride", [1, 2])
 @pytest.mark.parametrize("padding", ["same", "valid"])
 @pytest.mark.parametrize("dilation_rate", [1, 2])
 @pytest.mark.parametrize("padding_mode", ["constant", "reflect", "symmetric"])
-@pytest.mark.parametrize("padding_constant", [0, 1])
 def test_convpadconcretization_behavior_3d_with_padding_mode(
     input_shape,
     kernel_size,
@@ -544,7 +535,6 @@ def test_convpadconcretization_behavior_3d_with_padding_mode(
     padding,
     dilation_rate,
     padding_mode,
-    padding_constant,
 ):
     if dilation_rate > 1 and stride != 1:
         pass
@@ -591,8 +581,6 @@ def test_convpadconcretization_behavior_3d_with_padding_mode(
             use_bias=False,
             kernel_initializer=kernel_initializer,
         )
-        conv3d_2 = wrappers.ConvPadConcretization(
-            conv3d_, padding_mode=padding_mode, padding_constant=padding_constant
-        )
+        conv3d_2 = wrappers.ConvPadConcretization(conv3d_, padding_mode=padding_mode)
         y_ = conv3d_2(x)
         assert y.shape == y_.shape

--- a/tensorflow_addons/layers/tests/wrappers_test.py
+++ b/tensorflow_addons/layers/tests/wrappers_test.py
@@ -195,3 +195,404 @@ def test_removal(base_layer_fn, input_shape, data_init):
     wn_removed_output = wn_removed_layer(sample_data)
     np.testing.assert_allclose(wn_removed_output.numpy(), wn_output.numpy())
     assert isinstance(wn_removed_layer, base_layer.__class__)
+
+
+@pytest.mark.usefixtures("maybe_run_functions_eagerly")
+@pytest.mark.parametrize("input_shape", [15, 16, 17])
+@pytest.mark.parametrize("kernel_size", [1, 2, 3])
+@pytest.mark.parametrize("stride", [1, 2])
+@pytest.mark.parametrize("padding", ["same", "valid", "causal"])
+@pytest.mark.parametrize("dilation_rate", [1, 2])
+def test_specificconvpad_behavior_1d(
+    input_shape, kernel_size, stride, padding, dilation_rate
+):
+    if dilation_rate > 1 and stride != 1:
+        pass
+    else:
+        dim = 1
+        input_shape = (
+            [8]
+            + [
+                input_shape,
+            ]
+            * dim
+            + [3]
+        )
+        tf.keras.utils.set_random_seed(1000)
+        x = tf.random.normal(shape=input_shape, seed=1000)
+
+        tf.keras.utils.set_random_seed(1000)
+        kernel_initializer = tf.keras.initializers.GlorotUniform(seed=1000)
+        conv1d = tf.keras.layers.Conv1D(
+            filters=8,
+            kernel_size=[
+                kernel_size,
+            ]
+            * dim,
+            strides=(stride,) * dim,
+            padding=padding,
+            dilation_rate=dilation_rate,
+            use_bias=False,
+            kernel_initializer=kernel_initializer,
+        )
+        y = conv1d(x)
+
+        tf.keras.utils.set_random_seed(1000)
+        kernel_initializer = tf.keras.initializers.GlorotUniform(seed=1000)
+        conv1d_ = tf.keras.layers.Conv1D(
+            filters=8,
+            kernel_size=[
+                kernel_size,
+            ]
+            * dim,
+            strides=(stride,) * dim,
+            padding=padding,
+            dilation_rate=dilation_rate,
+            use_bias=False,
+            kernel_initializer=kernel_initializer,
+        )
+        conv1d_2 = wrappers.SpecificConvPad(
+            conv1d_, padding_mode="constant", padding_constant=0
+        )
+        y_ = conv1d_2(x)
+
+        assert y.shape == y_.shape
+        computed = tf.reduce_mean(y - y_)
+        test_utils.assert_allclose_according_to_type(computed, 0.0)
+
+
+@pytest.mark.usefixtures("maybe_run_functions_eagerly")
+@pytest.mark.parametrize("input_shape", [15, 16, 17])
+@pytest.mark.parametrize("kernel_size", [1, 2, 3])
+@pytest.mark.parametrize("stride", [1, 2])
+@pytest.mark.parametrize("padding", ["same", "valid"])
+@pytest.mark.parametrize("dilation_rate", [1, 2])
+def test_specificconvpad_behavior_2d(
+    input_shape, kernel_size, stride, padding, dilation_rate
+):
+    if dilation_rate > 1 and stride != 1:
+        pass
+    else:
+        dim = 2
+        input_shape = (
+            [8]
+            + [
+                input_shape,
+            ]
+            * dim
+            + [3]
+        )
+        tf.keras.utils.set_random_seed(1000)
+        x = tf.random.normal(shape=input_shape, seed=1000)
+
+        tf.keras.utils.set_random_seed(1000)
+        kernel_initializer = tf.keras.initializers.GlorotUniform(seed=1000)
+        conv2d = tf.keras.layers.Conv2D(
+            filters=8,
+            kernel_size=[
+                kernel_size,
+            ]
+            * dim,
+            strides=(stride,) * dim,
+            padding=padding,
+            dilation_rate=dilation_rate,
+            use_bias=False,
+            kernel_initializer=kernel_initializer,
+        )
+        y = conv2d(x)
+
+        tf.keras.utils.set_random_seed(1000)
+        kernel_initializer = tf.keras.initializers.GlorotUniform(seed=1000)
+        conv2d_ = tf.keras.layers.Conv2D(
+            filters=8,
+            kernel_size=[
+                kernel_size,
+            ]
+            * dim,
+            strides=(stride,) * dim,
+            padding=padding,
+            dilation_rate=dilation_rate,
+            use_bias=False,
+            kernel_initializer=kernel_initializer,
+        )
+        conv2d_2 = wrappers.SpecificConvPad(
+            conv2d_, padding_mode="constant", padding_constant=0
+        )
+        y_ = conv2d_2(x)
+
+        assert y.shape == y_.shape
+        computed = tf.reduce_mean(y - y_)
+        test_utils.assert_allclose_according_to_type(computed, 0.0)
+
+
+@pytest.mark.usefixtures("maybe_run_functions_eagerly")
+@pytest.mark.parametrize("input_shape", [15, 16, 17])
+@pytest.mark.parametrize("kernel_size", [1, 2, 3])
+@pytest.mark.parametrize("stride", [1, 2])
+@pytest.mark.parametrize("padding", ["same", "valid"])
+@pytest.mark.parametrize("dilation_rate", [1, 2])
+def test_specificconvpad_behavior_3d(
+    input_shape, kernel_size, stride, padding, dilation_rate
+):
+    if dilation_rate > 1 and stride != 1:
+        pass
+    else:
+        dim = 3
+        input_shape = (
+            [8]
+            + [
+                input_shape,
+            ]
+            * dim
+            + [3]
+        )
+        tf.keras.utils.set_random_seed(1000)
+        x = tf.random.normal(shape=input_shape, seed=1000)
+
+        tf.keras.utils.set_random_seed(1000)
+        kernel_initializer = tf.keras.initializers.GlorotUniform(seed=1000)
+        conv3d = tf.keras.layers.Conv3D(
+            filters=8,
+            kernel_size=[
+                kernel_size,
+            ]
+            * dim,
+            strides=(stride,) * dim,
+            padding=padding,
+            dilation_rate=dilation_rate,
+            use_bias=False,
+            kernel_initializer=kernel_initializer,
+        )
+        y = conv3d(x)
+
+        tf.keras.utils.set_random_seed(1000)
+        kernel_initializer = tf.keras.initializers.GlorotUniform(seed=1000)
+        conv3d_ = tf.keras.layers.Conv3D(
+            filters=8,
+            kernel_size=[
+                kernel_size,
+            ]
+            * dim,
+            strides=(stride,) * dim,
+            padding=padding,
+            dilation_rate=dilation_rate,
+            use_bias=False,
+            kernel_initializer=kernel_initializer,
+        )
+        conv3d_2 = wrappers.SpecificConvPad(
+            conv3d_, padding_mode="constant", padding_constant=0
+        )
+        y_ = conv3d_2(x)
+
+        assert y.shape == y_.shape
+        computed = tf.reduce_mean(y - y_)
+        test_utils.assert_allclose_according_to_type(computed, 0.0)
+
+
+@pytest.mark.usefixtures("maybe_run_functions_eagerly")
+@pytest.mark.parametrize("input_shape", [15, 16, 17])
+@pytest.mark.parametrize("kernel_size", [1, 2, 3])
+@pytest.mark.parametrize("stride", [1, 2])
+@pytest.mark.parametrize("padding", ["same", "valid", "causal"])
+@pytest.mark.parametrize("dilation_rate", [1, 2])
+@pytest.mark.parametrize("padding_mode", ["constant", "reflect", "symmetric"])
+@pytest.mark.parametrize("padding_constant", [0, 1])
+def test_specificconvpad_behavior_1d_with_padding_mode(
+    input_shape,
+    kernel_size,
+    stride,
+    padding,
+    dilation_rate,
+    padding_mode,
+    padding_constant,
+):
+    if dilation_rate > 1 and stride != 1:
+        pass
+    elif padding == "causal" and padding_mode != "constant":
+        pass
+    else:
+        dim = 1
+        input_shape = (
+            [8]
+            + [
+                input_shape,
+            ]
+            * dim
+            + [3]
+        )
+        tf.keras.utils.set_random_seed(1000)
+        x = tf.random.normal(shape=input_shape, seed=1000)
+
+        tf.keras.utils.set_random_seed(1000)
+        kernel_initializer = tf.keras.initializers.GlorotUniform(seed=1000)
+        conv1d = tf.keras.layers.Conv1D(
+            filters=8,
+            kernel_size=[
+                kernel_size,
+            ]
+            * dim,
+            strides=(stride,) * dim,
+            padding=padding,
+            dilation_rate=dilation_rate,
+            use_bias=False,
+            kernel_initializer=kernel_initializer,
+        )
+        y = conv1d(x)
+
+        tf.keras.utils.set_random_seed(1000)
+        kernel_initializer = tf.keras.initializers.GlorotUniform(seed=1000)
+        conv1d_ = tf.keras.layers.Conv1D(
+            filters=8,
+            kernel_size=[
+                kernel_size,
+            ]
+            * dim,
+            strides=(stride,) * dim,
+            padding=padding,
+            dilation_rate=dilation_rate,
+            use_bias=False,
+            kernel_initializer=kernel_initializer,
+        )
+        conv1d_2 = wrappers.SpecificConvPad(
+            conv1d_, padding_mode=padding_mode, padding_constant=padding_constant
+        )
+        y_ = conv1d_2(x)
+        assert y.shape == y_.shape
+
+
+@pytest.mark.usefixtures("maybe_run_functions_eagerly")
+@pytest.mark.parametrize("input_shape", [15, 16, 17])
+@pytest.mark.parametrize("kernel_size", [1, 2, 3])
+@pytest.mark.parametrize("stride", [1, 2])
+@pytest.mark.parametrize("padding", ["same", "valid"])
+@pytest.mark.parametrize("dilation_rate", [1, 2])
+@pytest.mark.parametrize("padding_mode", ["constant", "reflect", "symmetric"])
+@pytest.mark.parametrize("padding_constant", [0, 1])
+def test_specificconvpad_behavior_2d_with_padding_mode(
+    input_shape,
+    kernel_size,
+    stride,
+    padding,
+    dilation_rate,
+    padding_mode,
+    padding_constant,
+):
+    if dilation_rate > 1 and stride != 1:
+        pass
+    else:
+        dim = 2
+        input_shape = (
+            [8]
+            + [
+                input_shape,
+            ]
+            * dim
+            + [3]
+        )
+        tf.keras.utils.set_random_seed(1000)
+        x = tf.random.normal(shape=input_shape, seed=1000)
+
+        tf.keras.utils.set_random_seed(1000)
+        kernel_initializer = tf.keras.initializers.GlorotUniform(seed=1000)
+        conv2d = tf.keras.layers.Conv2D(
+            filters=8,
+            kernel_size=[
+                kernel_size,
+            ]
+            * dim,
+            strides=(stride,) * dim,
+            padding=padding,
+            dilation_rate=dilation_rate,
+            use_bias=False,
+            kernel_initializer=kernel_initializer,
+        )
+        y = conv2d(x)
+
+        tf.keras.utils.set_random_seed(1000)
+        kernel_initializer = tf.keras.initializers.GlorotUniform(seed=1000)
+        conv2d_ = tf.keras.layers.Conv2D(
+            filters=8,
+            kernel_size=[
+                kernel_size,
+            ]
+            * dim,
+            strides=(stride,) * dim,
+            padding=padding,
+            dilation_rate=dilation_rate,
+            use_bias=False,
+            kernel_initializer=kernel_initializer,
+        )
+        conv2d_2 = wrappers.SpecificConvPad(
+            conv2d_, padding_mode=padding_mode, padding_constant=padding_constant
+        )
+        y_ = conv2d_2(x)
+        assert y.shape == y_.shape
+
+
+@pytest.mark.usefixtures("maybe_run_functions_eagerly")
+@pytest.mark.parametrize("input_shape", [15, 16, 17])
+@pytest.mark.parametrize("kernel_size", [1, 2, 3])
+@pytest.mark.parametrize("stride", [1, 2])
+@pytest.mark.parametrize("padding", ["same", "valid"])
+@pytest.mark.parametrize("dilation_rate", [1, 2])
+@pytest.mark.parametrize("padding_mode", ["constant", "reflect", "symmetric"])
+@pytest.mark.parametrize("padding_constant", [0, 1])
+def test_specificconvpad_behavior_3d_with_padding_mode(
+    input_shape,
+    kernel_size,
+    stride,
+    padding,
+    dilation_rate,
+    padding_mode,
+    padding_constant,
+):
+    if dilation_rate > 1 and stride != 1:
+        pass
+    else:
+        dim = 3
+        input_shape = (
+            [8]
+            + [
+                input_shape,
+            ]
+            * dim
+            + [3]
+        )
+        tf.keras.utils.set_random_seed(1000)
+        x = tf.random.normal(shape=input_shape, seed=1000)
+
+        tf.keras.utils.set_random_seed(1000)
+        kernel_initializer = tf.keras.initializers.GlorotUniform(seed=1000)
+        conv3d = tf.keras.layers.Conv3D(
+            filters=8,
+            kernel_size=[
+                kernel_size,
+            ]
+            * dim,
+            strides=(stride,) * dim,
+            padding=padding,
+            dilation_rate=dilation_rate,
+            use_bias=False,
+            kernel_initializer=kernel_initializer,
+        )
+        y = conv3d(x)
+
+        tf.keras.utils.set_random_seed(1000)
+        kernel_initializer = tf.keras.initializers.GlorotUniform(seed=1000)
+        conv3d_ = tf.keras.layers.Conv3D(
+            filters=8,
+            kernel_size=[
+                kernel_size,
+            ]
+            * dim,
+            strides=(stride,) * dim,
+            padding=padding,
+            dilation_rate=dilation_rate,
+            use_bias=False,
+            kernel_initializer=kernel_initializer,
+        )
+        conv3d_2 = wrappers.SpecificConvPad(
+            conv3d_, padding_mode=padding_mode, padding_constant=padding_constant
+        )
+        y_ = conv3d_2(x)
+        assert y.shape == y_.shape

--- a/tensorflow_addons/layers/wrappers.py
+++ b/tensorflow_addons/layers/wrappers.py
@@ -292,6 +292,7 @@ class ConvPadConcretization(tf.keras.layers.Wrapper):
     >>> conv1d = tf.keras.layers.Conv1D(filters=1, kernel_size=[3,]*1, strides=(2,)*1, padding="same",dilation_rate=1,kernel_initializer=tf.initializers.Ones(),use_bias=False)
     >>> conv1d_ = tf.keras.layers.Conv1D(filters=1, kernel_size=[3,]*1, strides=(2,)*1, padding="same",dilation_rate=1,kernel_initializer=tf.initializers.Ones(),use_bias=False)
     >>> conv1d_2 = ConvPadConcretization(conv1d_, padding_mode='constant',padding_constant=0)
+
     When 'constant' padding with constant 0, wrappered layer should have the same behavior than original one. So:
     >>> y = conv1d(x)
     >>> print(tf.squeeze(y)) # the original layer's output

--- a/tensorflow_addons/layers/wrappers.py
+++ b/tensorflow_addons/layers/wrappers.py
@@ -230,7 +230,7 @@ class WeightNormalization(tf.keras.layers.Wrapper):
 
 
 @tf.keras.utils.register_keras_serializable(package="Addons")
-class SpecificConvPad(tf.keras.layers.Wrapper):
+class ConvPadConcretization(tf.keras.layers.Wrapper):
     """
     Extend padding behavior of tf.keras.layers.Conv1D, tf.keras.layers.Conv2D
     and tf.keras.layers.Conv3D.
@@ -252,7 +252,7 @@ class SpecificConvPad(tf.keras.layers.Wrapper):
     >>> import numpy as np
     >>> x = np.random.rand(1, 5, 1)
     >>> conv1d = tf.keras.layers.Conv1D(filters=1, kernel_size=[3,]*1, strides=(1,)*1, padding="same",dilation_rate=1)
-    >>> conv1d = SpecificConvPad(conv1d, padding_mode='constant',padding_constant=0)
+    >>> conv1d = ConvPadConcretization(conv1d, padding_mode='constant',padding_constant=0)
     >>> y = conv1d(x)
     >>> print(y.shape)
     (1, 5, 1)
@@ -260,21 +260,21 @@ class SpecificConvPad(tf.keras.layers.Wrapper):
     Inidicate the artificial padding behavior:
     >>> x = tf.constant([1.,2.,3.,4.,5.],shape=[1,5,1])
     >>> conv1d_ = tf.keras.layers.Conv1D(filters=1, kernel_size=[2,]*1, strides=(1,)*1, padding="same",dilation_rate=1,kernel_initializer=tf.initializers.Ones(),use_bias=False)
-    >>> conv1d = SpecificConvPad(conv1d_, padding_mode='constant',padding_constant=1)
+    >>> conv1d = ConvPadConcretization(conv1d_, padding_mode='constant',padding_constant=1)
     >>> y = conv1d(x)
     >>> # x --> padded_x [1.,2.,3.,4.,5.,1.], zero padding x from right side
     >>> # kernel = [1,1]
     >>> # padded_x --> y [3.,7.,5.,9.,6.], conv padded x by kernel, and do not need extral 'padding'
     >>> print(tf.squeeze(y))
     tf.Tensor([3. 5. 7. 9. 6.], shape=(5,), dtype=float32)
-    >>> conv1d = SpecificConvPad(conv1d_, padding_mode='reflect')
+    >>> conv1d = ConvPadConcretization(conv1d_, padding_mode='reflect')
     >>> y = conv1d(x)
     >>> # x --> padded_x [1.,2.,3.,4.,5.,4.], zero padding x from right side
     >>> # kernel = [1,1]
     >>> # padded_x --> y [3.,7.,5.,9.,9.], conv padded x by kernel, and do not need extral 'padding'
     >>> print(tf.squeeze(y))
     tf.Tensor([3. 5. 7. 9. 9.], shape=(5,), dtype=float32)
-    >>> conv1d = SpecificConvPad(conv1d_, padding_mode='symmetric')
+    >>> conv1d = ConvPadConcretization(conv1d_, padding_mode='symmetric')
     >>> y = conv1d(x)
     >>> # x --> padded_x [1.,2.,3.,4.,5.,5.], zero padding x from right side
     >>> # kernel = [1,1]
@@ -289,7 +289,7 @@ class SpecificConvPad(tf.keras.layers.Wrapper):
     tf.Tensor([1. 2. 3. 4. 5.], shape=(5,), dtype=float32)
     >>> conv1d = tf.keras.layers.Conv1D(filters=1, kernel_size=[3,]*1, strides=(2,)*1, padding="same",dilation_rate=1,kernel_initializer=tf.initializers.Ones(),use_bias=False)
     >>> conv1d_ = tf.keras.layers.Conv1D(filters=1, kernel_size=[3,]*1, strides=(2,)*1, padding="same",dilation_rate=1,kernel_initializer=tf.initializers.Ones(),use_bias=False)
-    >>> conv1d_2 = SpecificConvPad(conv1d_, padding_mode='constant',padding_constant=0)
+    >>> conv1d_2 = ConvPadConcretization(conv1d_, padding_mode='constant',padding_constant=0)
     When 'constant' padding with constant 0, wrappered layer should have the same behavior than original one. So:
     >>> y = conv1d(x)
     >>> print(tf.squeeze(y))
@@ -329,13 +329,13 @@ class SpecificConvPad(tf.keras.layers.Wrapper):
 
         if "name" not in kwargs.keys():
             kwargs["name"] = "specific_padded_" + layer.name
-        super(SpecificConvPad, self).__init__(layer, **kwargs)
+        super(ConvPadConcretization, self).__init__(layer, **kwargs)
 
     def build(self, input_shape):
         """Build `Layer`"""
         input_shape = tf.TensorShape(input_shape)
         self.input_spec = tf.keras.layers.InputSpec(shape=[None] + input_shape[1:])
-        # input_shape is needed for
+
         _kernel_size = self.layer.kernel_size
         _strides = self.layer.strides
         self._padding = (
@@ -390,7 +390,7 @@ class SpecificConvPad(tf.keras.layers.Wrapper):
                     self.layer.padding = self._normalize_padding("valid")
                     self.layer._is_causal = (
                         self.layer.padding == self._normalize_padding("causal")
-                    )  # causal is very special
+                    )
         layer_input_shape = self._prefix_input_shape(input_shape)
         super().build(layer_input_shape)
 

--- a/tensorflow_addons/layers/wrappers.py
+++ b/tensorflow_addons/layers/wrappers.py
@@ -267,6 +267,7 @@ class ConvPadConcretization(tf.keras.layers.Wrapper):
     >>> # padded_x --> y [3.,7.,5.,9.,6.], conv padded x by kernel, and do not need extral 'padding'
     >>> print(tf.squeeze(y))
     tf.Tensor([3. 5. 7. 9. 6.], shape=(5,), dtype=float32)
+    >>> conv1d_ = tf.keras.layers.Conv1D(filters=1, kernel_size=[2,]*1, strides=(1,)*1, padding="same",dilation_rate=1,kernel_initializer=tf.initializers.Ones(),use_bias=False)
     >>> conv1d = ConvPadConcretization(conv1d_, padding_mode='reflect')
     >>> y = conv1d(x)
     >>> # x --> padded_x [1.,2.,3.,4.,5.,4.], zero padding x from right side
@@ -274,13 +275,14 @@ class ConvPadConcretization(tf.keras.layers.Wrapper):
     >>> # padded_x --> y [3.,7.,5.,9.,9.], conv padded x by kernel, and do not need extral 'padding'
     >>> print(tf.squeeze(y))
     tf.Tensor([3. 5. 7. 9. 9.], shape=(5,), dtype=float32)
+    >>> conv1d_ = tf.keras.layers.Conv1D(filters=1, kernel_size=[2,]*1, strides=(1,)*1, padding="same",dilation_rate=1,kernel_initializer=tf.initializers.Ones(),use_bias=False)
     >>> conv1d = ConvPadConcretization(conv1d_, padding_mode='symmetric')
     >>> y = conv1d(x)
     >>> # x --> padded_x [1.,2.,3.,4.,5.,5.], zero padding x from right side
     >>> # kernel = [1,1]
     >>> # padded_x --> y [3.,7.,5.,9.,10.], conv padded x by kernel, and do not need extral 'padding'
     >>> print(tf.squeeze(y))
-    tf.Tensor([3. 5. 7. 9. 10.], shape=(5,), dtype=float32)
+    tf.Tensor([ 3.  5.  7.  9. 10.], shape=(5,), dtype=float32)
 
     This wrapper will maintain original layer's shape-wise behavior ant only change the numerical-wise behavior:
     >>> import numpy as np
@@ -292,13 +294,13 @@ class ConvPadConcretization(tf.keras.layers.Wrapper):
     >>> conv1d_2 = ConvPadConcretization(conv1d_, padding_mode='constant',padding_constant=0)
     When 'constant' padding with constant 0, wrappered layer should have the same behavior than original one. So:
     >>> y = conv1d(x)
-    >>> print(tf.squeeze(y))
-    tf.Tensor([3. 9. 9.], shape=(3,), dtype=float32) # the original layer's output
+    >>> print(tf.squeeze(y)) # the original layer's output
+    tf.Tensor([3. 9. 9.], shape=(3,), dtype=float32)
     >>> y_2 = conv1d_2(x)
-    >>> print(tf.squeeze(y_2))
-    tf.Tensor([3. 9. 9.], shape=(3,), dtype=float32) # the wrappered layer's output
-    >>> print(np.isclose(tf.reduce_mean(y-y_2),0.0))
-    True #
+    >>> print(tf.squeeze(y_2))  # the wrappered layer's output
+    tf.Tensor([3. 9. 9.], shape=(3,), dtype=float32)
+    >>> print(np.isclose(tf.reduce_mean(y-y_2),0.0)) # so the wrapped conv's behavior is equal to original's procedure in shape-wise.
+    True
 
     Args:
       layer: A `tf.keras.layers.Conv1D`, `tf.keras.layers.Conv2D` or `tf.keras.layers.Conv3D` instance.
@@ -384,7 +386,7 @@ class ConvPadConcretization(tf.keras.layers.Wrapper):
                             )
                         )
                     )
-                    self.padding_vectors = self._norm_paddings_by_data_format(
+                    self.padding_vectors = self._normalize_paddings_by_data_format(
                         _tf_data_format, _paddings
                     )
                     self.layer.padding = self._normalize_padding("valid")
@@ -517,7 +519,7 @@ class ConvPadConcretization(tf.keras.layers.Wrapper):
         return length
 
     @typechecked
-    def _norm_paddings_by_data_format(self, data_format: str, paddings: Iterable):
+    def _normalize_paddings_by_data_format(self, data_format: str, paddings: Iterable):
         out_buf = []
         for data_format_per_dim in data_format:
             if data_format_per_dim.upper() in ["N", "C"]:

--- a/tensorflow_addons/layers/wrappers.py
+++ b/tensorflow_addons/layers/wrappers.py
@@ -473,24 +473,11 @@ class SpecificConvPad(tf.keras.layers.Wrapper):
         Give out equivalent conv paddings from current padding to VALID padding.
         For example, there is a conv(X,padding='same'), find the equivalent conv paddings and
         make conv(X,padding='same')===conv(pad(X,equivalent_conv_paddings),padding='VALID')
-
         see the:
         https://www.tensorflow.org/api_docs/python/tf/nn#notes_on_padding_2
         If padding == "SAME": output_shape = ceil(input_length/stride)
         If padding == "VALID": output_shape = ceil((input_length-(filter_size-1)*dilation_rate)/stride)
 
-        NOTE In conv op, FULL padding, CUSUAL padding and VALID padding have explicit padding prodedure.
-        We can easliy give out the equivalent conv paddings without know the input_length.
-        However, it "SAME" is very special and ambiguous, beacuse its padding prodedure is influenced by
-        input_length and stride to ensure "output_shape===ceil(input_length/stride)".
-        So we should give out a equivalent padding prodedure to find the equivalent conv paddings from "SAME" to "VALID" finally.
-        Consider the equation, where pad_length is should known first:
-            ceil(input_length/stride) == ceil((input_length+pad_length-(filter_size-1)*dilation_rate)/stride)
-            ceil function makes the pad_length not unique.
-            but by testing,
-            we find tensorflow (C++ API) 'SAME' padding's feature:
-            1. always choose the minimum pad_length.
-            2. divide pad_length equally to pad_left and pad_right and make pad_left<=pad_right
         return  paddings(padding vectors) for conv's padding behaviour
         """
         dilated_filter_size = filter_size + (filter_size - 1) * (dilation_rate - 1)

--- a/tensorflow_addons/layers/wrappers.py
+++ b/tensorflow_addons/layers/wrappers.py
@@ -14,7 +14,9 @@
 # =============================================================================
 
 import logging
-
+import copy
+from typing import Union, List, Tuple, Iterable
+from functools import partial
 import tensorflow as tf
 from typeguard import typechecked
 
@@ -225,3 +227,336 @@ class WeightNormalization(tf.keras.layers.Wrapper):
             self.layer.kernel = kernel
 
         return self.layer
+
+
+@tf.keras.utils.register_keras_serializable(package="Addons")
+class SpecificConvPad(tf.keras.layers.Wrapper):
+    """
+    Extend padding behavior of tf.keras.layers.Conv1D, tf.keras.layers.Conv2D
+    and tf.keras.layers.Conv3D.
+
+    As everyone knows, convolution layer in keras API only support
+    "same", "valid", "causal" and "full" padding. However, these padding
+    methods is different in shape-wise but same in numerical-wise, i.e.,
+    they are all zero-padding. If we need "reflect" padding, or
+    "symmetric" padding, just like 'tf.pad()', it will be very inconvenient.
+
+    This wrapper gives a convolution layer more spcific padding method,
+    like "constant" padding with a constant that user can specify, "reflect"
+    padding or "symmetric" padding, just like 'tf.pad()', maintain original
+    layer's shape-wise behavior ant only change the numerical-wise behavior.
+    For example, a user can get a convolution layer with "same" padding in
+    shape-wise and "reflect" padding in numerical-wise simultaneously.
+
+    Wrap `tf.keras.layers.Conv1D`:
+    >>> import numpy as np
+    >>> x = np.random.rand(1, 5, 1)
+    >>> conv1d = tf.keras.layers.Conv1D(filters=1, kernel_size=[3,]*1, strides=(1,)*1, padding="same",dilation_rate=1)
+    >>> conv1d = SpecificConvPad(conv1d, padding_mode='constant',padding_constant=0)
+    >>> y = conv1d(x)
+    >>> print(y.shape)
+    (1, 5, 1)
+
+    Inidicate the artificial padding behavior:
+    >>> x = tf.constant([1.,2.,3.,4.,5.],shape=[1,5,1])
+    >>> conv1d_ = tf.keras.layers.Conv1D(filters=1, kernel_size=[2,]*1, strides=(1,)*1, padding="same",dilation_rate=1,kernel_initializer=tf.initializers.Ones(),use_bias=False)
+    >>> conv1d = SpecificConvPad(conv1d_, padding_mode='constant',padding_constant=1)
+    >>> y = conv1d(x)
+    >>> # x --> padded_x [1.,2.,3.,4.,5.,1.], zero padding x from right side
+    >>> # kernel = [1,1]
+    >>> # padded_x --> y [3.,7.,5.,9.,6.], conv padded x by kernel, and do not need extral 'padding'
+    >>> print(tf.squeeze(y))
+    tf.Tensor([3. 5. 7. 9. 6.], shape=(5,), dtype=float32)
+    >>> conv1d = SpecificConvPad(conv1d_, padding_mode='reflect')
+    >>> y = conv1d(x)
+    >>> # x --> padded_x [1.,2.,3.,4.,5.,4.], zero padding x from right side
+    >>> # kernel = [1,1]
+    >>> # padded_x --> y [3.,7.,5.,9.,9.], conv padded x by kernel, and do not need extral 'padding'
+    >>> print(tf.squeeze(y))
+    tf.Tensor([3. 5. 7. 9. 9.], shape=(5,), dtype=float32)
+    >>> conv1d = SpecificConvPad(conv1d_, padding_mode='symmetric')
+    >>> y = conv1d(x)
+    >>> # x --> padded_x [1.,2.,3.,4.,5.,5.], zero padding x from right side
+    >>> # kernel = [1,1]
+    >>> # padded_x --> y [3.,7.,5.,9.,10.], conv padded x by kernel, and do not need extral 'padding'
+    >>> print(tf.squeeze(y))
+    tf.Tensor([3. 5. 7. 9. 10.], shape=(5,), dtype=float32)
+
+    This wrapper will maintain original layer's shape-wise behavior ant only change the numerical-wise behavior:
+    >>> import numpy as np
+    >>> x = tf.constant([1.,2.,3.,4.,5.],shape=[1,5,1])
+    >>> print(tf.squeeze(x))
+    tf.Tensor([1. 2. 3. 4. 5.], shape=(5,), dtype=float32)
+    >>> conv1d = tf.keras.layers.Conv1D(filters=1, kernel_size=[3,]*1, strides=(2,)*1, padding="same",dilation_rate=1,kernel_initializer=tf.initializers.Ones(),use_bias=False)
+    >>> conv1d_ = tf.keras.layers.Conv1D(filters=1, kernel_size=[3,]*1, strides=(2,)*1, padding="same",dilation_rate=1,kernel_initializer=tf.initializers.Ones(),use_bias=False)
+    >>> conv1d_2 = SpecificConvPad(conv1d_, padding_mode='constant',padding_constant=0)
+    When 'constant' padding with constant 0, wrappered layer should have the same behavior than original one. So:
+    >>> y = conv1d(x)
+    >>> print(tf.squeeze(y))
+    tf.Tensor([3. 9. 9.], shape=(3,), dtype=float32) # the original layer's output
+    >>> y_2 = conv1d_2(x)
+    >>> print(tf.squeeze(y_2))
+    tf.Tensor([3. 9. 9.], shape=(3,), dtype=float32) # the wrappered layer's output
+    >>> print(np.isclose(tf.reduce_mean(y-y_2),0.0))
+    True #
+
+    Args:
+      layer: A `tf.keras.layers.Conv1D`, `tf.keras.layers.Conv2D` or `tf.keras.layers.Conv3D` instance.
+      padding_mode: Specific padding mode in `constant`, `reflect` or `symmetric`.
+      padding_constant: Padding constant for `constant` padding_mode.
+    Raises:
+      ValueError: If not initialized with a `tf.keras.layers.Conv1D`, `tf.keras.layers.Conv2D` or `tf.keras.layers.Conv3D` instance.
+      ValueError: If `padding_mode` does not in `constant`, `reflect` or `symmetric`.
+      ValueError: If original `layers.padding` is `causal` but `padding_mode` is not `constant`.
+    """
+
+    @typechecked
+    def __init__(
+        self,
+        layer: Union[
+            tf.keras.layers.Conv1D,
+            tf.keras.layers.Conv2D,
+            tf.keras.layers.Conv3D,
+        ],
+        padding_mode: Union[str, None] = None,
+        padding_constant: int = 0,
+        **kwargs,
+    ):
+
+        self.padding_vectors = None
+        self.padding_mode = padding_mode
+        self.padding_constant = padding_constant
+
+        if "name" not in kwargs.keys():
+            kwargs["name"] = "specific_padded_" + layer.name
+        super(SpecificConvPad, self).__init__(layer, **kwargs)
+
+    def build(self, input_shape):
+        """Build `Layer`"""
+        input_shape = tf.TensorShape(input_shape)
+        self.input_spec = tf.keras.layers.InputSpec(shape=[None] + input_shape[1:])
+        # input_shape is needed for
+        _kernel_size = self.layer.kernel_size
+        _strides = self.layer.strides
+        self._padding = (
+            _padding
+        ) = (
+            self.layer.padding.lower()
+        )  # save original padding for get_config and from_config
+        _tf_data_format = self.layer._tf_data_format
+        _dilation_rate = self.layer.dilation_rate
+        _input_shape = self._grab_length_by_data_format(
+            _tf_data_format, input_shape.as_list()
+        )
+
+        if self.padding_mode is None:
+            self.fused = True
+        else:  # padding_mode is str, confirmed by @typechecked
+            if isinstance(_padding, (list, tuple)):
+                self.fused = True
+            else:
+                if _padding in ["valid"]:
+                    self.fused = True
+                elif _padding in ["same", "full", "causal"]:
+                    self.padding_mode = self._normalize_specific_padding_mode(
+                        self.padding_mode
+                    )
+                    if _padding == "causal":
+                        if self.padding_mode != self._normalize_specific_padding_mode(
+                            "constant"
+                        ):
+                            raise ValueError(
+                                "specific causal padding mode should only be CONSTANT not {}",
+                                format(self.padding_mode),
+                            )
+                    self.fused = False
+                    _get_conv_paddings = partial(
+                        self._get_conv_paddings, padding=_padding
+                    )
+                    _paddings = iter(
+                        list(
+                            map(
+                                _get_conv_paddings,
+                                _input_shape,
+                                _kernel_size,
+                                _strides,
+                                _dilation_rate,
+                            )
+                        )
+                    )
+                    self.padding_vectors = self._norm_paddings_by_data_format(
+                        _tf_data_format, _paddings
+                    )
+                    self.layer.padding = self._normalize_padding("valid")
+                    self.layer._is_causal = (
+                        self.layer.padding == self._normalize_padding("causal")
+                    )  # causal is very special
+        layer_input_shape = self._prefix_input_shape(input_shape)
+        super().build(layer_input_shape)
+
+    def _prefix_input_shape(self, input_shape):
+        if not self.fused:
+            input_shape = tf.TensorShape(input_shape).as_list()
+            input_shape = copy.deepcopy(input_shape)
+            layer_input_shape = list(
+                map(
+                    self._get_padded_length_from_paddings,
+                    input_shape,
+                    self.padding_vectors,
+                )
+            )
+        else:
+            layer_input_shape = input_shape
+        return layer_input_shape
+
+    def call(self, inputs, **kwargs):
+        """Call `Layer`"""
+        # For correct output when a layer have not been built, pad behavior must put here but not in build() func
+        if not self.fused:
+            inputs = tf.pad(
+                inputs,
+                paddings=self.padding_vectors,
+                mode=self.padding_mode,
+                constant_values=self.padding_constant,
+            )
+        output = self.layer(inputs, **kwargs)
+        return output
+
+    def get_config(self):
+        config = {
+            "padding_mode": self.padding_mode,
+            "padding_constant": self.padding_constant,
+        }
+        base_config = super().get_config()
+        if "layer" in base_config.keys():
+            if "config" in base_config["layer"].keys():
+                if "padding" in base_config["layer"]["config"].keys():
+                    base_config["layer"]["config"]["padding"] = self._padding
+        return dict(list(base_config.items()) + list(config.items()))
+
+    @typechecked
+    def _normalize_padding(self, value: Union[List, Tuple, str]):
+        if isinstance(value, (list, tuple)):
+            return value
+        padding = value.lower()
+        if padding not in {"valid", "same", "causal", "full"}:
+            raise ValueError(
+                "The `padding` argument must be a list/tuple or one of "
+                '"valid", "same", "full" (or "causal", only for `Conv1D). '
+                f"Received: {padding}"
+            )
+        return padding
+
+    @typechecked
+    def _normalize_specific_padding_mode(self, value: Union[List, Tuple, str]):
+        if isinstance(value, (list, tuple)):
+            return value
+        padding = value.lower()
+        if padding not in {"constant", "reflect", "symmetric"}:
+            raise ValueError(
+                "The `padding` argument must be a list/tuple or one of "
+                '"constant", "reflect" or "symmetric"). '
+                f"Received: {padding}"
+            )
+        return padding.upper()
+
+    @typechecked
+    def _get_conv_paddings(
+        self,
+        input_length: int,
+        filter_size: int,
+        stride: int,
+        dilation_rate: int,
+        padding: str,
+    ):
+        """
+        Give out equivalent conv paddings from current padding to VALID padding.
+        For example, there is a conv(X,padding='same'), find the equivalent conv paddings and
+        make conv(X,padding='same')===conv(pad(X,equivalent_conv_paddings),padding='VALID')
+
+        see the:
+        https://www.tensorflow.org/api_docs/python/tf/nn#notes_on_padding_2
+        If padding == "SAME": output_shape = ceil(input_length/stride)
+        If padding == "VALID": output_shape = ceil((input_length-(filter_size-1)*dilation_rate)/stride)
+
+        NOTE In conv op, FULL padding, CUSUAL padding and VALID padding have explicit padding prodedure.
+        We can easliy give out the equivalent conv paddings without know the input_length.
+        However, it "SAME" is very special and ambiguous, beacuse its padding prodedure is influenced by
+        input_length and stride to ensure "output_shape===ceil(input_length/stride)".
+        So we should give out a equivalent padding prodedure to find the equivalent conv paddings from "SAME" to "VALID" finally.
+        Consider the equation, where pad_length is should known first:
+            ceil(input_length/stride) == ceil((input_length+pad_length-(filter_size-1)*dilation_rate)/stride)
+            ceil function makes the pad_length not unique.
+            but by testing,
+            we find tensorflow (C++ API) 'SAME' padding's feature:
+            1. always choose the minimum pad_length.
+            2. divide pad_length equally to pad_left and pad_right and make pad_left<=pad_right
+        return  paddings(padding vectors) for conv's padding behaviour
+        """
+        dilated_filter_size = filter_size + (filter_size - 1) * (dilation_rate - 1)
+        padding = padding.lower()
+        if padding in "valid":
+            pad_left = 0
+            pad_right = 0
+        elif padding == "causal":
+            pad_left = dilated_filter_size - 1
+            pad_right = 0
+        elif padding == "same":
+            flag = input_length % stride
+            if flag == 0:
+                pad_all = max(dilated_filter_size - stride, 0)
+            else:
+                pad_all = max(dilated_filter_size - flag, 0)
+            pad_left = pad_all // 2
+            pad_right = pad_all - pad_left
+        elif (
+            padding == "full"
+        ):  # full padding has been deprecated in many conv or deconv layers
+            pad_left = dilated_filter_size - 1
+            pad_right = dilated_filter_size - 1
+        else:
+            raise ValueError(
+                "Padding should in 'valid', 'causal', 'same' or 'full', not {}.", format
+            )
+        return [pad_left, pad_right]
+
+    @typechecked
+    def _get_padded_length_from_paddings(
+        self, length: Union[int, None], paddings: Tuple[int, int]
+    ):
+        if length is not None:
+            pad_left, pad_right = paddings
+            length = length + pad_left + pad_right
+        return length
+
+    @typechecked
+    def _norm_paddings_by_data_format(self, data_format: str, paddings: Iterable):
+        out_buf = []
+        for data_format_per_dim in data_format:
+            if data_format_per_dim.upper() in ["N", "C"]:
+                out_buf.append(tuple([0, 0]))
+            elif data_format_per_dim.upper() in ["D", "H", "W"]:
+                out_buf.append(tuple(next(paddings)))
+            else:
+                raise ValueError(
+                    "data_format should consist with 'N', 'C', 'D', 'H' or 'W' but not '{}'.".format(
+                        out_buf
+                    )
+                )
+        return out_buf
+
+    @typechecked
+    def _grab_length_by_data_format(self, data_format: str, length: Union[Tuple, List]):
+        out_buf = []
+        for data_format_per_dim, length_per_dim in zip(data_format, length):
+            if data_format_per_dim.upper() in ["N", "C"]:
+                pass
+            elif data_format_per_dim.upper() in ["D", "H", "W"]:
+                out_buf.append(int(length_per_dim))
+            else:
+                raise ValueError(
+                    "data_format should consist with 'N', 'C', 'D', 'H' or 'W' but not '{}'.".format(
+                        out_buf
+                    )
+                )
+        return out_buf


### PR DESCRIPTION
# Description

more details in #2674

Extend padding behavior of a keras convolution layer.
For example, a user can get a convolution layer with "same" padding in shape-wise and "reflect" padding in numerical-wise simultaneously. Such as:
```
x = tf.constant([1.,2.,3.,4.,5.],shape=[1,5,1])
conv1d_ = tf.keras.layers.Conv1D(filters=1, kernel_size=[2,]*1, strides=(1,)*1, padding="same")
conv1d = SpecificConvPad(conv1d_, padding_mode='constant',padding_constant=1)
y = conv1d(x)
````

## Type of change
- [x] Additional Testing
- [x] New Layer and the changes conform to the [layer contribution guidelines](https://github.com/tensorflow/addons/blob/master/tensorflow_addons/layers/README.md#contribution-guidelines)

# Checklist:

- [x] I've properly [formatted my code according to the guidelines](https://github.com/tensorflow/addons/blob/master/CONTRIBUTING.md#coding-style)
    - [x] By running Black + Flake8
    - [x] By running pre-commit hooks
- [x] I have added tests that prove my fix is effective or that my feature works

# How Has This Been Tested?
Shape-wise padding behavior has been tested to ensure to be consistent with original padding behavior.
