### PR TITLE
Docs: Fix one link to the FlowNet paper

### DIFF
--- a/tensorflow_addons/layers/optical_flow.py
+++ b/tensorflow_addons/layers/optical_flow.py
@@ -140,7 +140,7 @@ class CorrelationCost(tf.keras.layers.Layer):
     """Correlation Cost Layer.
 
     This layer implements the correlation operation from [FlowNet Learning
-    Optical Flow with Convolutional Networks](https://arxiv.org/abs/1504.06)(Fischer et al.).
+    Optical Flow with Convolutional Networks](https://arxiv.org/abs/1504.06852)(Fischer et al.).
 
     Args:
         kernel_size: An integer specifying the height and width of the


### PR DESCRIPTION
# Description

The link to the paper appears correctly as https://arxiv.org/abs/1504.06852 in the docstring of `_correlation_cost`. The docstring of `CorrelationCost` however contained a truncated and therefore broken version of this link.

Fixes # (issue) - N/A

## Type of change

- [X] Updated or additional documentation

# Checklist:

- [X] I've properly [formatted my code according to the guidelines](https://github.com/tensorflow/addons/blob/master/CONTRIBUTING.md#coding-style)

# How Has This Been Tested?

Generating the documentation was not tested.
