### PR TITLE
crf_decode: fix broken type annotation

### DIFF
--- a/tensorflow_addons/text/crf.py
+++ b/tensorflow_addons/text/crf.py
@@ -524,7 +524,7 @@ def crf_decode_backward(inputs: TensorLike, state: TensorLike) -> tf.Tensor:
 
 def crf_decode(
     potentials: TensorLike, transition_params: TensorLike, sequence_length: TensorLike
-) -> tf.Tensor:
+) -> Tuple[tf.Tensor, tf.Tensor]:
     """Decode the highest scoring sequence of tags.
 
     Args:


### PR DESCRIPTION
# Description

crf_decode returns a tuple of decode_tags, best_score, but the type annotation suggests that it returns only one tensor

## Type of change

- [x] Bug fix