### PR TITLE
Only generate ptx for highest compute capability

### DIFF
--- a/build_deps/toolchains/gpu/crosstool/clang/bin/crosstool_wrapper_driver_is_not_gcc.tpl
+++ b/build_deps/toolchains/gpu/crosstool/clang/bin/crosstool_wrapper_driver_is_not_gcc.tpl
@@ -201,9 +201,14 @@ def InvokeNvcc(argv, log=False):
 
   supported_cuda_compute_capabilities = [ %{cuda_compute_capabilities} ]
   nvccopts = '-D_FORCE_INLINES '
-  for capability in supported_cuda_compute_capabilities:
-    capability = capability.replace('.', '')
-    nvccopts += r'-gencode=arch=compute_%s,\"code=sm_%s,compute_%s\" ' % (
+  supported_cuda_compute_capabilities = sorted([
+      x.replace(".", "") for x in supported_cuda_compute_capabilities])
+  for capability in supported_cuda_compute_capabilities[:-1]:
+    nvccopts += r'-gencode=arch=compute_%s,\"code=sm_%s\" ' % (
+        capability, capability, capability)
+  if supported_cuda_compute_capabilities:
+    capability = supported_cuda_compute_capabilities[-1]
+    nvccopts += r'-gencode=arch=compute_%s,code=\"sm_%s,compute_%s\" ' % (
         capability, capability, capability)
   nvccopts += ' ' + nvcc_compiler_options
   nvccopts += undefines


### PR DESCRIPTION
Avoids binary bloat by only generating PTX for the highest compute capability in the list.