### PR TITLE
FC loss - clip focal_weight & set reduction to AUTO

### DIFF
--- a/tensorflow_addons/losses/focal_loss.py
+++ b/tensorflow_addons/losses/focal_loss.py
@@ -68,7 +68,7 @@ class SigmoidFocalCrossEntropy(LossFunctionWrapper):
         from_logits: bool = False,
         alpha: FloatTensorLike = 0.25,
         gamma: FloatTensorLike = 2.0,
-        reduction: str = tf.keras.losses.Reduction.NONE,
+        reduction: str = tf.keras.losses.Reduction.AUTO,
         name: str = "sigmoid_focal_crossentropy",
     ):
         super().__init__(
@@ -136,7 +136,8 @@ def sigmoid_focal_crossentropy(
 
     if gamma:
         gamma = tf.cast(gamma, dtype=y_true.dtype)
-        modulating_factor = tf.pow((1.0 - p_t), gamma)
-
+        focal_weight = K.clip((1.0 - p_t), K.epsilon(), 1.0) 
+        modulating_factor = tf.pow(focal_weight, gamma)
+        
     # compute the final loss and return
     return tf.reduce_sum(alpha_factor * modulating_factor * ce, axis=-1)


### PR DESCRIPTION
# Description

Brief Description of the PR: 

The current focal loss has a bug that induces a complex number when gamma <1, which may be due to leakage in floating number calculation that results in negative numbers in probability. 

Also, with the default reduction =NONE,  exploding gradient case is observed with an adequate learning rate.

Made the simple following changes:
- Use the keras backend clip function to set minimum focal_weight values with epsilon, which solves the negative number problem.
-  Set reduction = AUTO, which mitigates the exploding gradient problem. 

## Type of change

- [c ] Bug fix

# How Has This Been Tested?

Tested it on a [Colab notebook](https://colab.research.google.com/drive/1tp4e-WtN39HjL9jS7aPulE0Bp_U1kFtX?usp=sharing) with TPU and tensorflow=2.8 and tensorflow_addons=0.16.1.

Please let me know if we need a more exhaustive demonstration, I can provide some more tests on Colab. Allowing edits by maintainers just in case. 
