### PR TITLE
Fix documentation of adabelief

### DIFF
--- a/tensorflow_addons/optimizers/adabelief.py
+++ b/tensorflow_addons/optimizers/adabelief.py
@@ -113,7 +113,7 @@ class AdaBelief(tf.keras.optimizers.Optimizer):
             rectify: boolean. Whether to apply learning rate rectification as
                 from RAdam.
             total_steps: An integer. Total number of training steps. Enable
-                warmup by setting a positive value.
+                warmup by setting a value greater than zero.
             warmup_proportion: A floating point value. The proportion of
                 increasing steps.
             min_lr: A floating point value. Minimum learning rate after warmup.


### PR DESCRIPTION
This PR fixes the documentation of `total_steps`, which enables the warmup only if the value is bigger than zero. However, the documentation says "positive value". Zero (the default value) is positive though