### PR TITLE
Increment MultiOptimizer iterations after each apply_gradients

### DIFF
--- a/tools/testing/source_code_test.py
+++ b/tools/testing/source_code_test.py
@@ -179,6 +179,7 @@ def test_no_tf_control_dependencies():
         "tensorflow_addons/image/utils.py",
         "tensorflow_addons/image/dense_image_warp.py",
         "tensorflow_addons/optimizers/average_wrapper.py",
+        "tensorflow_addons/optimizers/discriminative_layer_training.py",
         "tensorflow_addons/optimizers/yogi.py",
         "tensorflow_addons/optimizers/lookahead.py",
         "tensorflow_addons/optimizers/weight_decay_optimizers.py",


### PR DESCRIPTION
MultiOptimizer does not call `super().apply_gradients`, and therefore does not update its `iterations: tf.Variable<type=int, shape=[]>` as the other optimizers in Tensorflow.
This leads to buggy behavior when training with a more complex `train_step` that relies on this variable for scheduling *learning rate* or other hyper-parameters such as *increasing/decreasing weights* for individual losses.