### PR TITLE
Make MultiOptimizer serializable

### DIFF
--- a/tensorflow_addons/optimizers/discriminative_layer_training.py
+++ b/tensorflow_addons/optimizers/discriminative_layer_training.py
@@ -124,7 +124,15 @@ class MultiOptimizer(tf.keras.optimizers.Optimizer):
 
     def get_config(self):
         config = super(MultiOptimizer, self).get_config()
-        config.update({"optimizer_specs": self.optimizer_specs})
+        optimizer_specs_without_gv = []
+        for optimizer_spec in self.optimizer_specs:
+            optimizer_specs_without_gv.append(
+                {
+                    "optimizer": optimizer_spec["optimizer"],
+                    "weights": optimizer_spec["weights"],
+                }
+            )
+        config.update({"optimizer_specs": optimizer_specs_without_gv})
         return config
 
     @classmethod

--- a/tensorflow_addons/optimizers/tests/discriminative_layer_training_test.py
+++ b/tensorflow_addons/optimizers/tests/discriminative_layer_training_test.py
@@ -286,3 +286,38 @@ def test_serialization():
 
     new_optimizer = tf.keras.optimizers.deserialize(config)
     assert new_optimizer.get_config() == optimizer.get_config()
+
+
+def test_serialization_after_training(tmpdir):
+    x = np.array(np.ones([100]))
+    y = np.array(np.ones([100]))
+    model = tf.keras.Sequential(
+        [tf.keras.Input(shape=[1]), tf.keras.layers.Dense(1), tf.keras.layers.Dense(1)]
+    )
+
+    opt1 = tf.keras.optimizers.Adam(learning_rate=1e-3)
+    opt2 = tf.keras.optimizers.SGD(learning_rate=0)
+
+    opt_layer_pairs = [(opt1, model.layers[0]), (opt2, model.layers[1])]
+
+    optimizer = MultiOptimizer(opt_layer_pairs)
+
+    # Train the model for a few epochs.
+    model.compile(loss="categorical_crossentropy", optimizer=optimizer)
+    model.fit(x, y)
+
+    # Verift the optimizer can still be serialized (saved).
+    model.save(str(tmpdir))
+    loaded_model = tf.keras.models.load_model(str(tmpdir))
+    old_config = model.optimizer.get_config()
+    new_config = loaded_model.optimizer.get_config()
+    # Verify the loaded model has the same optimizer as before.
+    assert len(old_config["optimizer_specs"]) == len(new_config["optimizer_specs"])
+    for old_optimizer_spec, new_optimizer_spec in zip(
+        old_config["optimizer_specs"], new_config["optimizer_specs"]
+    ):
+        assert old_optimizer_spec["weights"] == new_optimizer_spec["weights"]
+        assert (
+            old_optimizer_spec["optimizer"].get_config()
+            == new_optimizer_spec["optimizer"].get_config()
+        )

--- a/tensorflow_addons/optimizers/tests/discriminative_layer_training_test.py
+++ b/tensorflow_addons/optimizers/tests/discriminative_layer_training_test.py
@@ -306,7 +306,7 @@ def test_serialization_after_training(tmpdir):
     model.compile(loss="categorical_crossentropy", optimizer=optimizer)
     model.fit(x, y)
 
-    # Verift the optimizer can still be serialized (saved).
+    # Verify the optimizer can still be serialized (saved).
     model.save(str(tmpdir))
     loaded_model = tf.keras.models.load_model(str(tmpdir))
     old_config = model.optimizer.get_config()


### PR DESCRIPTION
# Description

The current implementation of `MultiOptimizer` puts grads and vars inside the `optimizer_specs` variable. Since the grads and vars are not serializable, any model that uses `MultiOptimizer` class cannot be saved or checkpointed. This PR will only extract the necessary `optimizer_specs` components that are useful for re-instantiating the `MultiOptimizer` instance inside `get_config()` method, leading to a serializable `MultiOptimizer` implementation.

Fixes # (issue)

## Type of change

- [x] Bug fix
- [ ] New Tutorial
- [ ] Updated or additional documentation
- [ ] Additional Testing
- [ ] New Activation and the changes conform to the [activation contribution guidelines](https://github.com/tensorflow/addons/blob/master/tensorflow_addons/activations/README.md#contribution-guidelines)
- [ ] New Callback and the changes conform to the [callback contribution guidelines](https://github.com/tensorflow/addons/blob/master/tensorflow_addons/callbacks/README.md#contribution-guidelines)
- [ ] New Image addition and the changes conform to the [image op contribution guidelines](https://github.com/tensorflow/addons/blob/master/tensorflow_addons/image/README.md#contribution-guidelines)
- [ ] New Layer and the changes conform to the [layer contribution guidelines](https://github.com/tensorflow/addons/blob/master/tensorflow_addons/layers/README.md#contribution-guidelines)
- [ ] New Loss and the changes conform to the [loss contribution guidelines](https://github.com/tensorflow/addons/blob/master/tensorflow_addons/losses/README.md#contribution-guidelines)
- [ ] New Metric and the changes conform to the [metric contribution guidelines](https://github.com/tensorflow/addons/blob/master/tensorflow_addons/metrics/README.md#contribution-guidelines)
- [ ] New Optimizer and the changes conform to the [optimizer contribution guidelines](https://github.com/tensorflow/addons/blob/master/tensorflow_addons/optimizers/README.md#contribution-guidelines)
- [ ] New RNN Cell and the changes conform to the [rnn contribution guidelines](https://github.com/tensorflow/addons/blob/master/tensorflow_addons/rnn/README.md#contribution-guidelines)
- [ ] New Seq2seq addition and the changes conform to the [seq2seq contribution guidelines](https://github.com/tensorflow/addons/blob/master/tensorflow_addons/seq2seq/README.md#contribution-guidelines)
- [ ] New Text addition and the changes conform to the [text op contribution guidelines](https://github.com/tensorflow/addons/blob/master/tensorflow_addons/text/README.md#contribution-guidelines)

# Checklist:

- [x] I've properly [formatted my code according to the guidelines](https://github.com/tensorflow/addons/blob/master/CONTRIBUTING.md#coding-style)
    - [ ] By running Black + Flake8
    - [x] By running pre-commit hooks
- [ ] This PR addresses an already submitted issue for TensorFlow Addons
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] This PR contains modifications to C++ custom-ops

# How Has This Been Tested?

If you're adding a bugfix or new feature please describe the tests that you ran to verify your changes:
*  
I have tested `model.save()` method after this change. Prior to this change, a trained model (has run training iteration for at least 1 step) with `MultiOptimizer` cannot be saved because of the un-serializable grads and vars. With the fix, I can verify that `model.save()` method works.