### PR TITLE
Fix the Kendalls Tau metric when used in graph mode

### DIFF
--- a/tensorflow_addons/metrics/kendalls_tau.py
+++ b/tensorflow_addons/metrics/kendalls_tau.py
@@ -15,7 +15,7 @@
 """Approximate Kendall's Tau-b Metric."""
 
 import tensorflow as tf
-from keras.metrics import Metric
+from tensorflow.keras.metrics import Metric
 from tensorflow_addons.utils.types import AcceptableDTypes
 
 from typeguard import typechecked

--- a/tensorflow_addons/metrics/kendalls_tau.py
+++ b/tensorflow_addons/metrics/kendalls_tau.py
@@ -151,15 +151,9 @@ class KendallsTau(Metric):
 
     def result(self):
         m = tf.cast(self.m, tf.float32)
-        n_cap = tf.cumsum(
-            tf.cumsum(
-                tf.slice(tf.pad(m, [[1, 0], [1, 0]]), [0, 0], self.m.shape),
-                axis=0,
-            ),
-            axis=1,
-        )
+        n_cap = tf.cumsum(tf.cumsum(m, axis=0), axis=1)
         # Number of concordant pairs.
-        p = tf.math.reduce_sum(tf.multiply(n_cap, m))
+        p = tf.math.reduce_sum(tf.multiply(n_cap[:-1, :-1], m[1:, 1:]))
         sum_m_squard = tf.math.reduce_sum(tf.math.square(m))
         # Ties in x.
         t = (

--- a/tensorflow_addons/metrics/tests/kendalls_tau_test.py
+++ b/tensorflow_addons/metrics/tests/kendalls_tau_test.py
@@ -90,7 +90,8 @@ def test_keras_binary_classification_model():
     x = np.random.rand(1000, 10).astype(np.float32)
     y = np.random.rand(1000, 1).astype(np.float32)
 
-    model.fit(x, y, epochs=1, verbose=0, batch_size=32)
+    history = model.fit(x, y, epochs=1, verbose=0, batch_size=32)
+    assert not any(np.isnan(history.history["kendalls_tau"]))
 
 
 def test_kendalls_tau_serialization():


### PR DESCRIPTION
# Description
~Blocked by https://github.com/tensorflow/addons/pull/2740~

Brief Description of the PR:

The metric was only working in eager mode. This fix makes it work in graph mode too.

## Type of change

- [X] Bug fix

# Checklist:

- [X] I've properly [formatted my code according to the guidelines](https://github.com/tensorflow/addons/blob/master/CONTRIBUTING.md#coding-style)
    - [ ] By running Black + Flake8
    - [X] By running pre-commit hooks
- [ ] This PR addresses an already submitted issue for TensorFlow Addons
- [ ] I have made corresponding changes to the documentation
- [X] I have added tests that prove my fix is effective or that my feature works
- [ ] This PR contains modifications to C++ custom-ops

# How Has This Been Tested?

The metric was giving NaNs when running in graph mode. I modified the test to check against the NaN values.
