### PR TITLE
tensorflow_docs requires python3.9

### DIFF
--- a/tools/docker/sanity_check.Dockerfile
+++ b/tools/docker/sanity_check.Dockerfile
@@ -79,7 +79,7 @@ RUN touch /ok.txt
 
 # -------------------------------
 # docs tests
-FROM python:3.7 as docs_tests
+FROM python:3.9 as docs_tests
 
 COPY tools/install_deps/tensorflow-cpu.txt ./
 RUN pip install --default-timeout=1000 -r tensorflow-cpu.txt


### PR DESCRIPTION
# Description

Brief Description of the PR:

The CI is failing with the error  (e.g. https://github.com/tensorflow/addons/pull/2739): 
```
#20 2.103   File "/usr/local/lib/python3.7/site-packages/tensorflow_docs/api_generator/reference_resolver.py", line 88, in ReferenceResolver
#20 2.103     physical_path: Optional[dict[str, str]] = None,
#20 2.103 TypeError: 'type' object is not subscriptable
```
because `tensorflow_docs` is using a feature introduced in python3.9. This fix bumps the python version for the `docs_tests` target in `tools/docker/sanity_check.Dockerfile`.

## Type of change

- [X] Bug fix

# How Has This Been Tested?

Locally the command `bash tools/run_build.sh` run successfully after the change. 
