### PR TITLE
Add a test verifying independence of group normalization results from batch size

### DIFF
--- a/tensorflow_addons/layers/tests/normalizations_test.py
+++ b/tensorflow_addons/layers/tests/normalizations_test.py
@@ -106,7 +106,11 @@ def test_picture_input(center, scale):
 
 def _test_random_shape_on_all_axis_except_batch(shape, groups, center, scale):
     inputs = tf.random.normal(shape)
+    # Test positive axis indices
     for axis in range(1, len(shape)):
+        _test_specific_layer(inputs, axis, groups, center, scale)
+    # Test negative axis indices
+    for axis in range(-len(shape) + 1, 0):
         _test_specific_layer(inputs, axis, groups, center, scale)
 
 
@@ -140,9 +144,9 @@ def _test_specific_layer(inputs, axis, groups, center, scale):
 
     group_reduction_axes = list(range(1, len(reshaped_dims)))
     if not is_instance_norm:
-        axis = -2 if axis == -1 else axis - 1
+        axis = axis - 1 if axis < 0 else axis - 1
     else:
-        axis = -1 if axis == -1 else axis - 1
+        axis = axis     if axis < 0 else axis - 1
     group_reduction_axes.pop(axis)
 
     # Calculate mean and variance

--- a/tensorflow_addons/layers/tests/normalizations_test.py
+++ b/tensorflow_addons/layers/tests/normalizations_test.py
@@ -163,7 +163,7 @@ def _test_specific_layer(inputs, axis, groups, center, scale):
 
     # compare outputs
     output_test = tf.reshape(output_test, input_shape)
-    np.testing.assert_almost_equal(tf.reduce_mean(output_test - outputs), 0, decimal=7)
+    np.testing.assert_almost_equal(output_test, outputs, decimal=6)
 
 
 def _create_and_fit_sequential_model(layer, shape):

--- a/tensorflow_addons/layers/tests/normalizations_test.py
+++ b/tensorflow_addons/layers/tests/normalizations_test.py
@@ -306,18 +306,33 @@ def test_groupnorm_2d_different_groups():
         )
 
 
-def test_groupnorm_batch_size_independence():
+@pytest.mark.parametrize(["axis", "groups"],
+                         [
+                             (1, 1),
+                             (1, 3),
+                             (1, 24),
+                             (2, 1),
+                             (2, 3),
+                             (2, 24),
+                             (3, 1),
+                             (3, 3),
+                             (3, 24)
+                         ])
+def test_groupnorm_batch_size_independence(axis, groups):
     # Dimensions
     b = 4
     h = 60
     w = 40
-    g = 3
-    c = g * 8
+    c = 24
 
-    input = tf.random.stateless_uniform([b, h, w, c], seed=[1, 2])
+    shape = [b, h, w]
+    shape.insert(axis, c)
+    input = tf.random.stateless_uniform(shape, seed=[1, 2])
 
-    gn = GroupNormalization(groups=g, axis=-1)
-    gn.build([None, None, None, c])
+    gn = GroupNormalization(groups=groups, axis=axis)
+    shape_spec = [None, None, None]
+    shape_spec.insert(axis, c)
+    gn.build(shape_spec)
 
     # Apply group normalization to the whole batch (4 slices) at once
     output_b4 = gn.call(input)

--- a/tensorflow_addons/layers/tests/normalizations_test.py
+++ b/tensorflow_addons/layers/tests/normalizations_test.py
@@ -114,9 +114,10 @@ def _test_random_shape_on_all_axis_except_batch(shape, groups, center, scale):
 def _test_specific_layer(inputs, axis, groups, center, scale):
 
     input_shape = inputs.shape
+    epsilon = 1e-5
 
     # Get Output from Keras model
-    layer = GroupNormalization(axis=axis, groups=groups, center=center, scale=scale)
+    layer = GroupNormalization(axis=axis, groups=groups, center=center, scale=scale, epsilon=epsilon)
     model = tf.keras.models.Sequential()
     model.add(layer)
     outputs = model.predict(inputs, steps=1)
@@ -157,7 +158,7 @@ def _test_specific_layer(inputs, axis, groups, center, scale):
 
     # Get ouput from Numpy
     zeroed = reshaped_inputs - mean
-    rsqrt = 1 / np.sqrt(variance + 1e-5)
+    rsqrt = 1 / np.sqrt(variance + epsilon)
     output_test = gamma * zeroed * rsqrt + beta
 
     # compare outputs

--- a/tensorflow_addons/layers/tests/normalizations_test.py
+++ b/tensorflow_addons/layers/tests/normalizations_test.py
@@ -301,7 +301,6 @@ def test_groupnorm_2d_different_groups():
         )
 
 
-@pytest.mark.xfail
 def test_groupnorm_batch_size_independence():
     # Dimensions
     b = 4


### PR DESCRIPTION
# Description

This PR adds a test diagnosing the issue reported in https://github.com/tensorflow/addons/issues/2745. This test is currently expected to fail.

## Type of change

- [ ] Bug fix
- [ ] New Tutorial
- [ ] Updated or additional documentation
- [x] Additional Testing
- [ ] New Activation and the changes conform to the [activation contribution guidelines](https://github.com/tensorflow/addons/blob/master/tensorflow_addons/activations/README.md#contribution-guidelines)
- [ ] New Callback and the changes conform to the [callback contribution guidelines](https://github.com/tensorflow/addons/blob/master/tensorflow_addons/callbacks/README.md#contribution-guidelines)
- [ ] New Image addition and the changes conform to the [image op contribution guidelines](https://github.com/tensorflow/addons/blob/master/tensorflow_addons/image/README.md#contribution-guidelines)
- [ ] New Layer and the changes conform to the [layer contribution guidelines](https://github.com/tensorflow/addons/blob/master/tensorflow_addons/layers/README.md#contribution-guidelines)
- [ ] New Loss and the changes conform to the [loss contribution guidelines](https://github.com/tensorflow/addons/blob/master/tensorflow_addons/losses/README.md#contribution-guidelines)
- [ ] New Metric and the changes conform to the [metric contribution guidelines](https://github.com/tensorflow/addons/blob/master/tensorflow_addons/metrics/README.md#contribution-guidelines)
- [ ] New Optimizer and the changes conform to the [optimizer contribution guidelines](https://github.com/tensorflow/addons/blob/master/tensorflow_addons/optimizers/README.md#contribution-guidelines)
- [ ] New RNN Cell and the changes conform to the [rnn contribution guidelines](https://github.com/tensorflow/addons/blob/master/tensorflow_addons/rnn/README.md#contribution-guidelines)
- [ ] New Seq2seq addition and the changes conform to the [seq2seq contribution guidelines](https://github.com/tensorflow/addons/blob/master/tensorflow_addons/seq2seq/README.md#contribution-guidelines)
- [ ] New Text addition and the changes conform to the [text op contribution guidelines](https://github.com/tensorflow/addons/blob/master/tensorflow_addons/text/README.md#contribution-guidelines)

# Checklist:

- [x] I've properly [formatted my code according to the guidelines](https://github.com/tensorflow/addons/blob/master/CONTRIBUTING.md#coding-style)
    - [x] By running Black + Flake8
    - [ ] By running pre-commit hooks
- [ ] This PR addresses an already submitted issue for TensorFlow Addons
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] This PR contains modifications to C++ custom-ops

# How Has This Been Tested?

This PR adds a new test without modifying any existing functionality.