### PR TITLE
Fix wheel building for macos

### DIFF
--- a/.github/workflows/make_wheel_macOS_arm64.sh
+++ b/.github/workflows/make_wheel_macOS_arm64.sh
@@ -3,9 +3,11 @@ set -e -x
 export TF_NEED_CUDA=0
 
 python --version
-python -m pip install --default-timeout=1000 delocate==0.9.1 wheel setuptools tensorflow==$TF_VERSION
+python -m pip install --default-timeout=1000 delocate==0.10.2 wheel setuptools tensorflow==$TF_VERSION
 
 python configure.py
+# Setting DYLD_LIBRARY_PATH to help delocate finding tensorflow after the rpath invalidation
+export DYLD_LIBRARY_PATH=$DYLD_LIBRARY_PATH:$(python -c 'import configure; print(configure.get_tf_shared_lib_dir())')
 
 # For dynamic linking, we want the ARM version of TensorFlow.
 # Since we cannot run it on x86 so we need to force pip to install it regardless
@@ -27,5 +29,5 @@ bazel build \
   build_pip_pkg
 
 bazel-bin/build_pip_pkg artifacts "--plat-name macosx_11_0_arm64 $NIGHTLY_FLAG"
-delocate-wheel -w wheelhouse artifacts/*.whl
+delocate-wheel -w wheelhouse -v artifacts/*.whl
 

--- a/.github/workflows/make_wheel_macOS_x86.sh
+++ b/.github/workflows/make_wheel_macOS_x86.sh
@@ -4,7 +4,7 @@ export TF_NEED_CUDA=0
 
 # Install Deps
 python --version
-python -m pip install --default-timeout=1000 delocate==0.9.1 wheel setuptools tensorflow==$TF_VERSION
+python -m pip install --default-timeout=1000 delocate==0.10.2 wheel setuptools tensorflow==$TF_VERSION
 
 # Test
 bash ./tools/testing/build_and_run_tests.sh
@@ -25,5 +25,8 @@ bazel build \
   build_pip_pkg
 
 bazel-bin/build_pip_pkg artifacts $NIGHTLY_FLAG
-delocate-wheel -w wheelhouse artifacts/*.whl
+
+# Setting DYLD_LIBRARY_PATH to help delocate finding tensorflow after the rpath invalidation
+export DYLD_LIBRARY_PATH=$DYLD_LIBRARY_PATH:$(python -c 'import configure; print(configure.get_tf_shared_lib_dir())')
+delocate-wheel -w wheelhouse -v artifacts/*.whl
 


### PR DESCRIPTION
The rpaths in the `custom_ops` libraries are invalidated once packaged into the wheel, this prevents delocate from retrieving the tensorflow dependency. This PR solves the issue by setting the env variable `DYLD_LIBRARY_PATH`.

`delocate==0.9.1` was failing silently with older version of `setuptools` (the packaged libraries were not processed). Upgrading to the lastest version solves the issue.

This fixes the current CI issue.

