### PR TITLE
Mutual information metric

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -135,6 +135,10 @@
 /tensorflow_addons/metrics/tests/geometric_mean_test.py @marload
 /tensorflow_addons/metrics/streaming_correlations.py @sorensenjs @nicolaspi
 /tensorflow_addons/metrics/tests/streaming_correlations_test.py @sorensenjs @nicolaspi
+/tensorflow_addons/metrics/_streaming_buffer.py @nicolaspi
+/tensorflow_addons/metrics/tests/streaming_buffer_test.py @nicolaspi
+/tensorflow_addons/metrics/mutual_information.py @nicolaspi
+/tensorflow_addons/metrics/tests/mutual_information_test.py @nicolaspi
 
 /tensorflow_addons/optimizers/average_wrapper.py @squadrick
 /tensorflow_addons/optimizers/conditional_gradient.py @pkan2 @lokhande-vishnu

--- a/tensorflow_addons/metrics/__init__.py
+++ b/tensorflow_addons/metrics/__init__.py
@@ -21,8 +21,7 @@ from tensorflow_addons.metrics.hamming import (
     hamming_distance,
     hamming_loss_fn,
 )
-from tensorflow_addons.metrics.mutual_information import \
-  MutualInformation
+from tensorflow_addons.metrics.mutual_information import MutualInformation
 from tensorflow_addons.metrics.utils import MeanMetricWrapper
 from tensorflow_addons.metrics.matthews_correlation_coefficient import (
     MatthewsCorrelationCoefficient,

--- a/tensorflow_addons/metrics/__init__.py
+++ b/tensorflow_addons/metrics/__init__.py
@@ -21,6 +21,8 @@ from tensorflow_addons.metrics.hamming import (
     hamming_distance,
     hamming_loss_fn,
 )
+from tensorflow_addons.metrics.mutual_information import \
+  MutualInformation
 from tensorflow_addons.metrics.utils import MeanMetricWrapper
 from tensorflow_addons.metrics.matthews_correlation_coefficient import (
     MatthewsCorrelationCoefficient,

--- a/tensorflow_addons/metrics/_streaming_buffer.py
+++ b/tensorflow_addons/metrics/_streaming_buffer.py
@@ -58,7 +58,9 @@ class StreamingBuffer(Metric):
         self._y_true_buffer = self.add_weight(
             "y_true_buffer", (self.max_buffer_size,), dtype=tf.float32
         )
-        self._buffer_size = self.add_weight("buffer_size", (), dtype=tf.int32)
+        self._buffer_size = self.add_weight(
+            "buffer_size", (), initializer="zeros", dtype=tf.int32
+        )
 
     @property
     def y_pred_buffer(self):
@@ -127,7 +129,9 @@ class StreamingBuffer(Metric):
         pass
 
     def result(self):
-        self._update_state(self.y_true_buffer, self.y_pred_buffer)
+        if self._buffer_size > 0:
+            self._update_state(self.y_true_buffer, self.y_pred_buffer)
+            self._buffer_size.assign(0)
         return self._result()
 
     def get_config(self):

--- a/tensorflow_addons/metrics/_streaming_buffer.py
+++ b/tensorflow_addons/metrics/_streaming_buffer.py
@@ -1,0 +1,123 @@
+# Copyright 2022 The TensorFlow Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ==============================================================================
+
+from abc import abstractmethod
+from typing import Optional
+
+import tensorflow as tf
+from tensorflow.keras.metrics import Metric
+from tensorflow.python.autograph import set_loop_options
+from typeguard import typechecked
+
+from tensorflow_addons.utils.types import AcceptableDTypes
+
+
+class StreamingBuffer(Metric):
+  """`StreamingBuffer` is a base class to be used for metrics that have a too
+  large algorithmic complexity that doesn't allow to compute on the full
+  dataset at once. Instead, the metric computes statistics on chunk of data
+  that can be larger than the batch size. The data is buffered and delivered
+  to the metric for processing once reaching `buffer_size` size.
+
+  Child classes need to implement two abstract methods:
+
+    - `_update_state(self, y_true_buffer, y_pred_buffer)` that updates the
+    state of the metric given a batch of `y_true` and `y_pred` values with
+    size `buffer_size`.
+
+    - `_result(self)` that returns the metric's value.
+  """
+  @typechecked
+  def __init__(self, buffer_size: int = 1024, name: Optional[str] = None,
+               dtype: AcceptableDTypes = None):
+    """Creates a `StreamingBuffer` instance."""
+    super().__init__(name=name, dtype=dtype)
+
+    self.max_buffer_size = buffer_size
+
+    self._y_pred_buffer = self.add_weight("y_pred_buffer",
+                                          (self.max_buffer_size,),
+                                          dtype=tf.float32)
+    self._y_true_buffer = self.add_weight("y_true_buffer",
+                                          (self.max_buffer_size,),
+                                          dtype=tf.float32)
+    self._buffer_size = self.add_weight("buffer_size", (), dtype=tf.int32)
+
+  @property
+  def y_pred_buffer(self):
+    return self._y_pred_buffer[: self._buffer_size]
+
+  @property
+  def y_true_buffer(self):
+    return self._y_true_buffer[: self._buffer_size]
+
+  @abstractmethod
+  def _update_state(self, y_true_buffer, y_pred_buffer):
+    pass
+
+  def update_state(self, y_true, y_pred, sample_weight=None):
+    flat_y_true = tf.cast(tf.reshape(y_true, [-1]), tf.float32)
+    flat_y_pred = tf.cast(tf.reshape(y_pred, [-1]), tf.float32)
+
+    def insert_data_in_buffer(y_true_data, y_pred_data):
+      write_size = tf.minimum(self.max_buffer_size - self._buffer_size, tf.size(y_true_data))
+      indices = tf.range(write_size) + self._buffer_size
+      labels_buffer = tf.tensor_scatter_nd_update(self._y_true_buffer,
+                                                  tf.expand_dims(indices,
+                                                                  axis=-1),
+                                                   y_true_data[:write_size])
+      preds_buffer = tf.tensor_scatter_nd_update(self._y_pred_buffer,
+                                                 tf.expand_dims(indices,
+                                                                 axis=-1),
+                                                  y_pred_data[:write_size])
+      self._y_true_buffer.assign(labels_buffer)
+      self._y_pred_buffer.assign(preds_buffer)
+      self._buffer_size.assign_add(write_size)
+      return y_true_data[write_size:], y_pred_data[write_size:]
+
+    labels_remainder, preds_remainder = insert_data_in_buffer(flat_y_true, flat_y_pred)
+
+    while tf.size(labels_remainder) > 0:
+      set_loop_options(shape_invariants=[(labels_remainder, tf.TensorShape([None])),
+                                         (preds_remainder, tf.TensorShape([None]))])
+      self._update_state(self.y_true_buffer, self.y_pred_buffer)
+      self._buffer_size.assign(0)
+      labels_remainder, preds_remainder = insert_data_in_buffer(
+        labels_remainder, preds_remainder)
+
+  @abstractmethod
+  def _result(self):
+    pass
+
+  def result(self):
+    self._update_state(self.y_true_buffer, self.y_pred_buffer)
+    return self._result()
+
+  def get_config(self):
+    """Returns the serializable config of the metric."""
+
+    config = {"buffer_size": self.max_buffer_size}
+    base_config = super().get_config()
+    return {**base_config, **config}
+
+  def reset_state(self):
+    """Resets all of the metric state variables."""
+    self._buffer_size.assign(0)
+
+  def reset_states(self):
+    # Backwards compatibility alias of `reset_state`. New classes should
+    # only implement `reset_state`.
+    # Required in Tensorflow < 2.5.0
+    return self.reset_state()

--- a/tensorflow_addons/metrics/mutual_information.py
+++ b/tensorflow_addons/metrics/mutual_information.py
@@ -56,7 +56,7 @@ class MutualInformation(StreamingBuffer):
     >>> metric = tfa.metrics.MutualInformation(n_neighbors=1)
     >>> metric.update_state([1, 0, 1, 0, 1], [0, 1, 0, 1, 0])
     >>> metric.result().numpy()
-    1.029490184601355
+    0.8866535773356332
 
     """
 
@@ -72,8 +72,10 @@ class MutualInformation(StreamingBuffer):
         """Creates a `MutualInformation` instance."""
         self.n_neighbors = n_neighbors
         self.compute_batch_size = compute_batch_size
-        self.epsilon = self.add_weight("epsilon", (), dtype=tf.float64)
-        self.count = self.add_weight("count", (), dtype=tf.int64)
+        self.epsilon = self.add_weight(
+            "epsilon", (), initializer="zeros", dtype=tf.float64
+        )
+        self.count = self.add_weight("count", (), initializer="zeros", dtype=tf.int64)
 
     @tf.function
     def _compute_epsilon(self, x, y, n_neighbors):

--- a/tensorflow_addons/metrics/mutual_information.py
+++ b/tensorflow_addons/metrics/mutual_information.py
@@ -56,7 +56,7 @@ class MutualInformation(StreamingBuffer):
     >>> metric = tfa.metrics.MutualInformation(n_neighbors=1)
     >>> metric.update_state([1, 0, 1, 0, 1], [0, 1, 0, 1, 0])
     >>> metric.result().numpy()
-    0.8866535773356332
+    0.88665357733
 
     """
 

--- a/tensorflow_addons/metrics/mutual_information.py
+++ b/tensorflow_addons/metrics/mutual_information.py
@@ -1,0 +1,119 @@
+# Copyright 2022 The TensorFlow Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ==============================================================================
+from typing import Optional
+
+import tensorflow as tf
+
+from tensorflow_addons.metrics._streaming_buffer import StreamingBuffer
+from tensorflow_addons.utils.types import AcceptableDTypes
+
+
+@tf.keras.utils.register_keras_serializable(package="Addons")
+class MutualInformation(StreamingBuffer):
+    """Implementation based on the mutual information estimator described in
+    'Weihao Gao, Sreeram Kannan, Sewoong Oh, and Pramod Viswanath. Estimating
+    mutual information for discrete-continuous mixtures'
+
+    The estimator works on any kind of distribution: discrete,
+    continuous or a mix of both.
+
+    This implementation reduces the memory complexity from O(NxN) to
+    O(`buffer_size`x`compute_batch_size`) and the time complexity from
+    O(NxN) to O(`buffer_size`^2). The trade-off is on the bias that degrades
+    to the one induced from using a dataset of size `buffer_size` instead of N.
+    The variance remains same.
+
+    Args:
+        n_neighbors: The number of nearest neighbors, larger value reduces variance but may introduce a bias.
+        buffer_size: Size of the batches on which the MI will be estimated, larger value reduces the bias, but increases the compute complexity.
+        compute_batch_size: Size of the batches used for computing the distances, larger value increases the memory usage.
+        name: (Optional) String name of the metric instance.
+        dtype: (Optional) Data type of the metric result.
+
+    Returns:
+        mutual information: double.
+
+    Usage:
+
+    >>> metric = tfa.metrics.MutualInformation(n_neighbors=1)
+    >>> metric.update_state([1, 0, 1, 0, 1], [0, 1, 0, 1, 0])
+    >>> metric.result().numpy()
+    1.029490184601355
+
+    """
+    def __init__(self,
+                 n_neighbors: int = 3,
+                 buffer_size: int = 1024,
+                 compute_batch_size: int = 1024,
+                 name: Optional[str] = None,
+                 dtype: AcceptableDTypes = None,
+                 ):
+      super().__init__(
+          buffer_size,
+          name,
+          dtype
+        )
+      """Creates a `MutualInformation` instance."""
+      self.n_neighbors = n_neighbors
+      self.compute_batch_size = compute_batch_size
+      self.epsilon = self.add_weight("epsilon", (), dtype=tf.float64)
+      self.count = self.add_weight("count", (), dtype=tf.int64)
+
+    def _compute_epsilon(self, x, y, n_neighbors):
+      size = tf.shape(x)[0]
+      processed_data = 0
+      sum_epsilon = tf.constant(0.0, tf.float64)
+      fsize = tf.cast(size, tf.float64)
+      while processed_data < size:
+        sub_x = x[processed_data: processed_data + self.compute_batch_size]
+        sub_y = y[processed_data: processed_data + self.compute_batch_size]
+        x_distances = tf.abs(tf.expand_dims(x, 0) - tf.expand_dims(sub_x, -1))
+        y_distances = tf.abs(tf.expand_dims(y, 0) - tf.expand_dims(sub_y, -1))
+        distances = tf.maximum(x_distances, y_distances)
+        sorted_distances = tf.sort(distances, axis=1)
+        radius = sorted_distances[:, n_neighbors]
+        radius = tf.expand_dims(radius, axis=-1)
+        n_x = tf.reduce_sum(tf.cast((x_distances < radius) | ((radius == 0.0) & (x_distances == 0.0)), tf.int32), axis=1)
+        n_y = tf.reduce_sum(tf.cast((y_distances < radius) | ((radius == 0.0) & (y_distances == 0.0)), tf.int32), axis=1)
+        k = tf.reduce_sum(tf.cast(sorted_distances[:, n_neighbors:] == 0.0, tf.int32), axis=1) + n_neighbors
+        eps = tf.math.digamma(tf.cast(k, tf.float64)) - \
+              tf.math.digamma(tf.cast(n_x, tf.float64)) - \
+              tf.math.digamma(tf.cast(n_y, tf.float64))
+        sum_epsilon = sum_epsilon + tf.reduce_sum(eps)
+        processed_data = processed_data + tf.shape(sub_x)[0]
+
+      return sum_epsilon + fsize * tf.math.log(fsize)
+
+    def _update_state(self, y_true_buffer, y_pred_buffer):
+        epsilon = self._compute_epsilon(y_true_buffer, y_pred_buffer, self.n_neighbors)
+        self.epsilon.assign_add(epsilon)
+        self.count.assign_add(tf.shape(y_true_buffer, out_type=tf.int64)[0])
+
+    def _result(self):
+        return self.epsilon / tf.cast(self.count, tf.float64)
+
+    def reset_state(self):
+      """Resets all of the metric state variables."""
+      super().reset_state()
+      self.epsilon.assign(0.0)
+      self.count.assign(0)
+
+    def get_config(self):
+      """Returns the serializable config of the metric."""
+
+      config = {"n_neighbors": self.n_neighbors,
+                "compute_batch_size": self.compute_batch_size}
+      base_config = super().get_config()
+      return {**base_config, **config}

--- a/tensorflow_addons/metrics/mutual_information.py
+++ b/tensorflow_addons/metrics/mutual_information.py
@@ -29,11 +29,11 @@ class MutualInformation(StreamingBuffer):
     The estimator works on any kind of distribution: discrete,
     continuous or a mix of both.
 
-    This implementation reduces the memory complexity from O(NxN) to
-    O(`buffer_size`x`compute_batch_size`) and the time complexity from
-    O(NxN) to O(`buffer_size`^2). The trade-off is on the bias that degrades
-    to the one induced from using a dataset of size `buffer_size` instead of N.
-    The variance remains same.
+    This implementation has a memory complexity of
+    O(`buffer_size`x`compute_batch_size`), a time complexity of
+    O(`buffer_size`^2), and can be adjusted with the corresponding parameters.
+    Smaller value of `buffer_size` increases the bias of the estimator while
+    small value of `compute_batch_size` increases the computation time.
 
     Args:
         n_neighbors: The number of nearest neighbors, larger value reduces
@@ -75,6 +75,7 @@ class MutualInformation(StreamingBuffer):
         self.epsilon = self.add_weight("epsilon", (), dtype=tf.float64)
         self.count = self.add_weight("count", (), dtype=tf.int64)
 
+    @tf.function
     def _compute_epsilon(self, x, y, n_neighbors):
         size = tf.shape(x)[0]
         processed_data = 0
@@ -119,6 +120,7 @@ class MutualInformation(StreamingBuffer):
 
         return sum_epsilon + fsize * tf.math.log(fsize)
 
+    @tf.function
     def _update_state(self, y_true_buffer, y_pred_buffer):
         epsilon = self._compute_epsilon(y_true_buffer, y_pred_buffer, self.n_neighbors)
         self.epsilon.assign_add(epsilon)

--- a/tensorflow_addons/metrics/mutual_information.py
+++ b/tensorflow_addons/metrics/mutual_information.py
@@ -56,7 +56,7 @@ class MutualInformation(StreamingBuffer):
     >>> metric = tfa.metrics.MutualInformation(n_neighbors=1)
     >>> metric.update_state([1, 0, 1, 0, 1], [0, 1, 0, 1, 0])
     >>> metric.result().numpy()
-    0.88665357733
+    0.8866535773356329
 
     """
 

--- a/tensorflow_addons/metrics/mutual_information.py
+++ b/tensorflow_addons/metrics/mutual_information.py
@@ -30,8 +30,8 @@ class MutualInformation(StreamingBuffer):
     continuous or a mix of both.
 
     This implementation has a memory complexity of
-    O(`buffer_size`x`compute_batch_size`), a time complexity of
-    O(`buffer_size`^2), and can be adjusted with the corresponding parameters.
+    O(`buffer_size`x`compute_batch_size`) and a time complexity of
+    O(`buffer_size`^2). They can be adjusted with the corresponding parameters.
     Smaller value of `buffer_size` increases the bias of the estimator while
     small value of `compute_batch_size` increases the computation time.
 

--- a/tensorflow_addons/metrics/mutual_information.py
+++ b/tensorflow_addons/metrics/mutual_information.py
@@ -53,48 +53,65 @@ class MutualInformation(StreamingBuffer):
     1.029490184601355
 
     """
-    def __init__(self,
-                 n_neighbors: int = 3,
-                 buffer_size: int = 1024,
-                 compute_batch_size: int = 1024,
-                 name: Optional[str] = None,
-                 dtype: AcceptableDTypes = None,
-                 ):
-      super().__init__(
-          buffer_size,
-          name,
-          dtype
-        )
-      """Creates a `MutualInformation` instance."""
-      self.n_neighbors = n_neighbors
-      self.compute_batch_size = compute_batch_size
-      self.epsilon = self.add_weight("epsilon", (), dtype=tf.float64)
-      self.count = self.add_weight("count", (), dtype=tf.int64)
+
+    def __init__(
+        self,
+        n_neighbors: int = 3,
+        buffer_size: int = 1024,
+        compute_batch_size: int = 1024,
+        name: Optional[str] = None,
+        dtype: AcceptableDTypes = None,
+    ):
+        super().__init__(buffer_size, name, dtype)
+        """Creates a `MutualInformation` instance."""
+        self.n_neighbors = n_neighbors
+        self.compute_batch_size = compute_batch_size
+        self.epsilon = self.add_weight("epsilon", (), dtype=tf.float64)
+        self.count = self.add_weight("count", (), dtype=tf.int64)
 
     def _compute_epsilon(self, x, y, n_neighbors):
-      size = tf.shape(x)[0]
-      processed_data = 0
-      sum_epsilon = tf.constant(0.0, tf.float64)
-      fsize = tf.cast(size, tf.float64)
-      while processed_data < size:
-        sub_x = x[processed_data: processed_data + self.compute_batch_size]
-        sub_y = y[processed_data: processed_data + self.compute_batch_size]
-        x_distances = tf.abs(tf.expand_dims(x, 0) - tf.expand_dims(sub_x, -1))
-        y_distances = tf.abs(tf.expand_dims(y, 0) - tf.expand_dims(sub_y, -1))
-        distances = tf.maximum(x_distances, y_distances)
-        sorted_distances = tf.sort(distances, axis=1)
-        radius = sorted_distances[:, n_neighbors]
-        radius = tf.expand_dims(radius, axis=-1)
-        n_x = tf.reduce_sum(tf.cast((x_distances < radius) | ((radius == 0.0) & (x_distances == 0.0)), tf.int32), axis=1)
-        n_y = tf.reduce_sum(tf.cast((y_distances < radius) | ((radius == 0.0) & (y_distances == 0.0)), tf.int32), axis=1)
-        k = tf.reduce_sum(tf.cast(sorted_distances[:, n_neighbors:] == 0.0, tf.int32), axis=1) + n_neighbors
-        eps = tf.math.digamma(tf.cast(k, tf.float64)) - \
-              tf.math.digamma(tf.cast(n_x, tf.float64)) - \
-              tf.math.digamma(tf.cast(n_y, tf.float64))
-        sum_epsilon = sum_epsilon + tf.reduce_sum(eps)
-        processed_data = processed_data + tf.shape(sub_x)[0]
+        size = tf.shape(x)[0]
+        processed_data = 0
+        sum_epsilon = tf.constant(0.0, tf.float64)
+        fsize = tf.cast(size, tf.float64)
+        while processed_data < size:
+            sub_x = x[processed_data : processed_data + self.compute_batch_size]
+            sub_y = y[processed_data : processed_data + self.compute_batch_size]
+            x_distances = tf.abs(tf.expand_dims(x, 0) - tf.expand_dims(sub_x, -1))
+            y_distances = tf.abs(tf.expand_dims(y, 0) - tf.expand_dims(sub_y, -1))
+            distances = tf.maximum(x_distances, y_distances)
+            sorted_distances = tf.sort(distances, axis=1)
+            radius = sorted_distances[:, n_neighbors]
+            radius = tf.expand_dims(radius, axis=-1)
+            n_x = tf.reduce_sum(
+                tf.cast(
+                    (x_distances < radius) | ((radius == 0.0) & (x_distances == 0.0)),
+                    tf.int32,
+                ),
+                axis=1,
+            )
+            n_y = tf.reduce_sum(
+                tf.cast(
+                    (y_distances < radius) | ((radius == 0.0) & (y_distances == 0.0)),
+                    tf.int32,
+                ),
+                axis=1,
+            )
+            k = (
+                tf.reduce_sum(
+                    tf.cast(sorted_distances[:, n_neighbors:] == 0.0, tf.int32), axis=1
+                )
+                + n_neighbors
+            )
+            eps = (
+                tf.math.digamma(tf.cast(k, tf.float64))
+                - tf.math.digamma(tf.cast(n_x, tf.float64))
+                - tf.math.digamma(tf.cast(n_y, tf.float64))
+            )
+            sum_epsilon = sum_epsilon + tf.reduce_sum(eps)
+            processed_data = processed_data + tf.shape(sub_x)[0]
 
-      return sum_epsilon + fsize * tf.math.log(fsize)
+        return sum_epsilon + fsize * tf.math.log(fsize)
 
     def _update_state(self, y_true_buffer, y_pred_buffer):
         epsilon = self._compute_epsilon(y_true_buffer, y_pred_buffer, self.n_neighbors)
@@ -105,15 +122,17 @@ class MutualInformation(StreamingBuffer):
         return self.epsilon / tf.cast(self.count, tf.float64)
 
     def reset_state(self):
-      """Resets all of the metric state variables."""
-      super().reset_state()
-      self.epsilon.assign(0.0)
-      self.count.assign(0)
+        """Resets all of the metric state variables."""
+        super().reset_state()
+        self.epsilon.assign(0.0)
+        self.count.assign(0)
 
     def get_config(self):
-      """Returns the serializable config of the metric."""
+        """Returns the serializable config of the metric."""
 
-      config = {"n_neighbors": self.n_neighbors,
-                "compute_batch_size": self.compute_batch_size}
-      base_config = super().get_config()
-      return {**base_config, **config}
+        config = {
+            "n_neighbors": self.n_neighbors,
+            "compute_batch_size": self.compute_batch_size,
+        }
+        base_config = super().get_config()
+        return {**base_config, **config}

--- a/tensorflow_addons/metrics/mutual_information.py
+++ b/tensorflow_addons/metrics/mutual_information.py
@@ -36,9 +36,15 @@ class MutualInformation(StreamingBuffer):
     The variance remains same.
 
     Args:
-        n_neighbors: The number of nearest neighbors, larger value reduces variance but may introduce a bias.
-        buffer_size: Size of the batches on which the MI will be estimated, larger value reduces the bias, but increases the compute complexity.
-        compute_batch_size: Size of the batches used for computing the distances, larger value increases the memory usage.
+        n_neighbors: The number of nearest neighbors, larger value reduces
+        variance but may introduce a bias.
+
+        buffer_size: Size of the batches on which the MI will be estimated,
+        larger value reduces the bias, but increases the compute complexity.
+
+        compute_batch_size: Size of the batches used for computing the
+        distances, larger value increases the memory usage.
+
         name: (Optional) String name of the metric instance.
         dtype: (Optional) Data type of the metric result.
 

--- a/tensorflow_addons/metrics/tests/mutual_information_test.py
+++ b/tensorflow_addons/metrics/tests/mutual_information_test.py
@@ -22,7 +22,7 @@ from tensorflow_addons.testing.serialization import check_metric_serialization
 
 class TestMutualInformation:
     def generate_mixed_data(self, n, correlation=0.9, beta=0.9):
-        """Generate distribution from experiment I
+        """Generate samples from experiment I distribution
         described in https://arxiv.org/pdf/1709.06212v3.pdf
         """
         np.random.seed(0)
@@ -49,7 +49,7 @@ class TestMutualInformation:
         return data, gt
 
     def generate_discrete_continuous_data(self, n=1024, m=5):
-        """Generate distribution from experiment II
+        """Generate samples from experiment II distribution
         described in https://arxiv.org/pdf/1709.06212v3.pdf
         """
         np.random.seed(0)

--- a/tensorflow_addons/metrics/tests/mutual_information_test.py
+++ b/tensorflow_addons/metrics/tests/mutual_information_test.py
@@ -1,0 +1,103 @@
+# Copyright 2022 The TensorFlow Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ==============================================================================
+"""Tests for `MutualInformation` metric."""
+import pytest
+import numpy as np
+
+from tensorflow_addons.metrics import MutualInformation
+from tensorflow_addons.testing.serialization import check_metric_serialization
+
+
+class TestMutualInformation:
+    def generate_mixed_data(self, n, correlation=0.9, beta=0.9):
+      """ Generate distribution from experiment I
+      described in https://arxiv.org/pdf/1709.06212v3.pdf
+      """
+      np.random.seed(0)
+      # https://github.com/wgao9/mixed_KSG/blob/master/demo.py
+      cov = [[1, correlation], [correlation, 1]]
+      p_con, p_dis = 0.5, 0.5
+      gt = -p_con * 0.5 * np.log(np.linalg.det(cov)) + p_dis * (np.log(2) + beta * np.log(beta) + (1 - beta) * np.log(1 - beta)) - p_con * np.log(p_con) - p_dis * np.log(p_dis)
+
+      x_con, y_con = np.random.multivariate_normal([0, 0], cov, int(n * p_con)).T
+      x_dis = np.random.binomial(1, 0.5, int(n * p_dis))
+      y_dis = (x_dis + np.random.binomial(1, 1 - beta, int(n * p_dis))) % 2
+      x_dis, y_dis = 2 * x_dis - np.ones(int(n * p_dis)), 2 * y_dis - np.ones(int(n * p_dis))
+      x = np.concatenate((x_con, x_dis))
+      y = np.concatenate((y_con, y_dis))
+      data = np.stack([x, y], axis=-1)
+      np.random.shuffle(data)
+      return data, gt
+
+    def generate_discrete_continuous_data(self, n=1024, m=5):
+      """ Generate distribution from experiment II
+      described in https://arxiv.org/pdf/1709.06212v3.pdf
+      """
+      np.random.seed(0)
+      x = np.random.randint(m, size=n)
+      y = np.random.random(size=n)
+      y = y * 2 + x
+      data = np.stack([x, y], axis=-1)
+      true_mi = np.log(m) - (m - 1) * np.log(2)/m
+      return data, true_mi
+
+    def test_uniform(self):
+        np.random.seed(0)
+        data = np.random.random(size=(4096, 2))
+        x, y = data[:, 0], data[:, 1]
+        metric = MutualInformation(buffer_size=512, compute_batch_size=512, n_neighbors=3)
+        metric.update_state(x, y)
+        np.testing.assert_allclose(metric.result(), 0.0, atol=5e-3)
+
+    @pytest.mark.parametrize("correlation", [0.0, 0.1, 0.5, 0.9])
+    def test_gaussian(self, correlation):
+        np.random.seed(0)
+        cov = np.array([[1.0, correlation],
+                        [correlation, 1.0]])
+        data = np.random.multivariate_normal([0.0, 0.0], cov=cov, size=4096)
+        x, y = data[:, 0], data[:, 1]
+        metric = MutualInformation(buffer_size=512, compute_batch_size=512, n_neighbors=3)
+        metric.update_state(x, y)
+
+        true_mi = - 0.5 * np.log(1 - correlation**2)
+        np.testing.assert_allclose(metric.result(), true_mi, atol=5e-2)
+
+    @pytest.mark.parametrize("correlation, beta",
+                             [(0.9, 0.9),
+                              (0.5, 0.5)])
+    def test_mixed(self, correlation, beta):
+      data, true_mi = self.generate_mixed_data(n=4096, correlation=correlation, beta=beta)
+      x, y = data[:, 0], data[:, 1]
+      metric = MutualInformation(buffer_size=4096,
+                                 compute_batch_size=512, n_neighbors=1)
+      metric.update_state(x, y)
+      np.testing.assert_allclose(metric.result(), true_mi, atol=6e-2)
+
+    def test_discrete_x_continuous_y(self):
+      data, true_mi = self.generate_discrete_continuous_data(n=4096, m=5)
+      x, y = data[:, 0], data[:, 1]
+      metric = MutualInformation(buffer_size=4096,
+                                 compute_batch_size=512, n_neighbors=1)
+      metric.update_state(x, y)
+      np.testing.assert_allclose(metric.result(), true_mi, atol=5e-3)
+
+    def test_serialization(self):
+        labels = np.array([4, 4, 3, 3, 2, 2, 1, 1], dtype=np.int32)
+        preds = np.array([1, 2, 4, 1, 3, 3, 4, 4], dtype=np.int32)
+
+        obj = MutualInformation(buffer_size=512,
+                                compute_batch_size=512,
+                                n_neighbors=3)
+        check_metric_serialization(obj, labels, preds)

--- a/tensorflow_addons/metrics/tests/mutual_information_test.py
+++ b/tensorflow_addons/metrics/tests/mutual_information_test.py
@@ -22,82 +22,92 @@ from tensorflow_addons.testing.serialization import check_metric_serialization
 
 class TestMutualInformation:
     def generate_mixed_data(self, n, correlation=0.9, beta=0.9):
-      """ Generate distribution from experiment I
-      described in https://arxiv.org/pdf/1709.06212v3.pdf
-      """
-      np.random.seed(0)
-      # https://github.com/wgao9/mixed_KSG/blob/master/demo.py
-      cov = [[1, correlation], [correlation, 1]]
-      p_con, p_dis = 0.5, 0.5
-      gt = -p_con * 0.5 * np.log(np.linalg.det(cov)) + p_dis * (np.log(2) + beta * np.log(beta) + (1 - beta) * np.log(1 - beta)) - p_con * np.log(p_con) - p_dis * np.log(p_dis)
+        """Generate distribution from experiment I
+        described in https://arxiv.org/pdf/1709.06212v3.pdf
+        """
+        np.random.seed(0)
+        # https://github.com/wgao9/mixed_KSG/blob/master/demo.py
+        cov = [[1, correlation], [correlation, 1]]
+        p_con, p_dis = 0.5, 0.5
+        gt = (
+            -p_con * 0.5 * np.log(np.linalg.det(cov))
+            + p_dis * (np.log(2) + beta * np.log(beta) + (1 - beta) * np.log(1 - beta))
+            - p_con * np.log(p_con)
+            - p_dis * np.log(p_dis)
+        )
 
-      x_con, y_con = np.random.multivariate_normal([0, 0], cov, int(n * p_con)).T
-      x_dis = np.random.binomial(1, 0.5, int(n * p_dis))
-      y_dis = (x_dis + np.random.binomial(1, 1 - beta, int(n * p_dis))) % 2
-      x_dis, y_dis = 2 * x_dis - np.ones(int(n * p_dis)), 2 * y_dis - np.ones(int(n * p_dis))
-      x = np.concatenate((x_con, x_dis))
-      y = np.concatenate((y_con, y_dis))
-      data = np.stack([x, y], axis=-1)
-      np.random.shuffle(data)
-      return data, gt
+        x_con, y_con = np.random.multivariate_normal([0, 0], cov, int(n * p_con)).T
+        x_dis = np.random.binomial(1, 0.5, int(n * p_dis))
+        y_dis = (x_dis + np.random.binomial(1, 1 - beta, int(n * p_dis))) % 2
+        x_dis, y_dis = 2 * x_dis - np.ones(int(n * p_dis)), 2 * y_dis - np.ones(
+            int(n * p_dis)
+        )
+        x = np.concatenate((x_con, x_dis))
+        y = np.concatenate((y_con, y_dis))
+        data = np.stack([x, y], axis=-1)
+        np.random.shuffle(data)
+        return data, gt
 
     def generate_discrete_continuous_data(self, n=1024, m=5):
-      """ Generate distribution from experiment II
-      described in https://arxiv.org/pdf/1709.06212v3.pdf
-      """
-      np.random.seed(0)
-      x = np.random.randint(m, size=n)
-      y = np.random.random(size=n)
-      y = y * 2 + x
-      data = np.stack([x, y], axis=-1)
-      true_mi = np.log(m) - (m - 1) * np.log(2)/m
-      return data, true_mi
+        """Generate distribution from experiment II
+        described in https://arxiv.org/pdf/1709.06212v3.pdf
+        """
+        np.random.seed(0)
+        x = np.random.randint(m, size=n)
+        y = np.random.random(size=n)
+        y = y * 2 + x
+        data = np.stack([x, y], axis=-1)
+        true_mi = np.log(m) - (m - 1) * np.log(2) / m
+        return data, true_mi
 
     def test_uniform(self):
         np.random.seed(0)
         data = np.random.random(size=(4096, 2))
         x, y = data[:, 0], data[:, 1]
-        metric = MutualInformation(buffer_size=512, compute_batch_size=512, n_neighbors=3)
+        metric = MutualInformation(
+            buffer_size=512, compute_batch_size=512, n_neighbors=3
+        )
         metric.update_state(x, y)
         np.testing.assert_allclose(metric.result(), 0.0, atol=5e-3)
 
     @pytest.mark.parametrize("correlation", [0.0, 0.1, 0.5, 0.9])
     def test_gaussian(self, correlation):
         np.random.seed(0)
-        cov = np.array([[1.0, correlation],
-                        [correlation, 1.0]])
+        cov = np.array([[1.0, correlation], [correlation, 1.0]])
         data = np.random.multivariate_normal([0.0, 0.0], cov=cov, size=4096)
         x, y = data[:, 0], data[:, 1]
-        metric = MutualInformation(buffer_size=512, compute_batch_size=512, n_neighbors=3)
+        metric = MutualInformation(
+            buffer_size=512, compute_batch_size=512, n_neighbors=3
+        )
         metric.update_state(x, y)
 
-        true_mi = - 0.5 * np.log(1 - correlation**2)
+        true_mi = -0.5 * np.log(1 - correlation**2)
         np.testing.assert_allclose(metric.result(), true_mi, atol=5e-2)
 
-    @pytest.mark.parametrize("correlation, beta",
-                             [(0.9, 0.9),
-                              (0.5, 0.5)])
+    @pytest.mark.parametrize("correlation, beta", [(0.9, 0.9), (0.5, 0.5)])
     def test_mixed(self, correlation, beta):
-      data, true_mi = self.generate_mixed_data(n=4096, correlation=correlation, beta=beta)
-      x, y = data[:, 0], data[:, 1]
-      metric = MutualInformation(buffer_size=4096,
-                                 compute_batch_size=512, n_neighbors=1)
-      metric.update_state(x, y)
-      np.testing.assert_allclose(metric.result(), true_mi, atol=6e-2)
+        data, true_mi = self.generate_mixed_data(
+            n=4096, correlation=correlation, beta=beta
+        )
+        x, y = data[:, 0], data[:, 1]
+        metric = MutualInformation(
+            buffer_size=4096, compute_batch_size=512, n_neighbors=1
+        )
+        metric.update_state(x, y)
+        np.testing.assert_allclose(metric.result(), true_mi, atol=6e-2)
 
     def test_discrete_x_continuous_y(self):
-      data, true_mi = self.generate_discrete_continuous_data(n=4096, m=5)
-      x, y = data[:, 0], data[:, 1]
-      metric = MutualInformation(buffer_size=4096,
-                                 compute_batch_size=512, n_neighbors=1)
-      metric.update_state(x, y)
-      np.testing.assert_allclose(metric.result(), true_mi, atol=5e-3)
+        data, true_mi = self.generate_discrete_continuous_data(n=4096, m=5)
+        x, y = data[:, 0], data[:, 1]
+        metric = MutualInformation(
+            buffer_size=4096, compute_batch_size=512, n_neighbors=1
+        )
+        metric.update_state(x, y)
+        np.testing.assert_allclose(metric.result(), true_mi, atol=5e-3)
 
     def test_serialization(self):
         labels = np.array([4, 4, 3, 3, 2, 2, 1, 1], dtype=np.int32)
         preds = np.array([1, 2, 4, 1, 3, 3, 4, 4], dtype=np.int32)
 
-        obj = MutualInformation(buffer_size=512,
-                                compute_batch_size=512,
-                                n_neighbors=3)
+        obj = MutualInformation(buffer_size=512, compute_batch_size=512, n_neighbors=3)
         check_metric_serialization(obj, labels, preds)

--- a/tensorflow_addons/metrics/tests/streaming_buffer_test.py
+++ b/tensorflow_addons/metrics/tests/streaming_buffer_test.py
@@ -64,10 +64,12 @@ def test_buffer(buffer_size, dataset_size, batch_size):
     for batch in dataset:
         metric.update_state(batch["x"], batch["y"])
 
-    result = metric.result()
-    assert result[0] == result[1]
-    assert result[0] == dataset_size
-    assert result[2] == np.ceil(dataset_size / buffer_size)
+    for _ in range(2):
+        # multiple calls to `results` must be idempotent
+        result = metric.result()
+        assert result[0] == result[1]
+        assert result[0] == dataset_size
+        assert result[2] == np.ceil(dataset_size / buffer_size)
 
 
 def test_serialization():

--- a/tensorflow_addons/metrics/tests/streaming_buffer_test.py
+++ b/tensorflow_addons/metrics/tests/streaming_buffer_test.py
@@ -1,0 +1,74 @@
+# Copyright 2020 The TensorFlow Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ==============================================================================
+"""Tests for StreamingBuffer."""
+
+import numpy as np
+import pytest
+import tensorflow as tf
+
+from tensorflow_addons.metrics._streaming_buffer import StreamingBuffer
+from tensorflow_addons.testing.serialization import check_metric_serialization
+
+
+class Counter(StreamingBuffer):
+  def __init__(self, buffer_size: int = 1024, name=None, dtype=None):
+    super().__init__(buffer_size, name, dtype)
+    self.pred_count = self.add_weight('pred_count', (), dtype=tf.int32)
+    self.true_count = self.add_weight('true_count', (), dtype=tf.int32)
+    self.update_count = self.add_weight('update_count', (), dtype=tf.int32)
+
+  def _update_state(self, y_true_buffer, y_pred_buffer):
+    self.true_count.assign_add(tf.reduce_sum(tf.cast(y_true_buffer, tf.int32)))
+    self.pred_count.assign_add(tf.reduce_sum(tf.cast(y_pred_buffer, tf.int32)))
+    self.update_count.assign_add(1)
+
+  def _result(self):
+    return tf.concat([self.true_count, self.pred_count, self.update_count], axis=0)
+
+  def reset_state(self):
+    self.true_count.assign(0)
+    self.pred_count.assign(0)
+    self.update_count.assign(0)
+
+@pytest.mark.parametrize(
+    "buffer_size, dataset_size, batch_size",
+    [
+        (8, 16, 4),
+        (16, 16, 4),
+        (16, 16, 16),
+        (16, 15, 4),
+        (15, 16, 4),
+        (15, 16, 3),
+    ],
+)
+def test_buffer(buffer_size, dataset_size, batch_size):
+    metric = Counter(buffer_size=buffer_size)
+    data = np.ones((dataset_size, 2))
+    x, y = data[:, 0], data[:, 1]
+    dataset = tf.data.Dataset.from_tensor_slices({'x': x, 'y': y}).batch(batch_size, drop_remainder=False)
+    for batch in dataset:
+      metric.update_state(batch['x'], batch['y'])
+
+    result = metric.result()
+    assert result[0] == result[1]
+    assert result[0] == dataset_size
+    assert result[2] == np.ceil(dataset_size / buffer_size)
+
+def test_serialization():
+    labels = np.array([4, 4, 3, 3, 2, 2, 1, 1], dtype=np.int32)
+    preds = np.array([1, 2, 4, 1, 3, 3, 4, 4], dtype=np.int32)
+
+    kt = Counter(buffer_size=4)
+    check_metric_serialization(kt, labels, preds)

--- a/tools/testing/source_code_test.py
+++ b/tools/testing/source_code_test.py
@@ -98,6 +98,7 @@ def test_no_private_tf_api():
         "tensorflow_addons/utils/test_utils.py",
         "tensorflow_addons/seq2seq/decoder.py",
         "tensorflow_addons/utils/types.py",
+        "tensorflow_addons/metrics/_streaming_buffer.py",
     ]
 
     for file_path, line_idx, line in get_lines_of_source_code(allowlist):


### PR DESCRIPTION
# Description

Adds the `MutualInformation` metric.

Implementation based on the mutual information estimator described in
_Weihao Gao, Sreeram Kannan, Sewoong Oh, and Pramod Viswanath. Estimating
mutual information for discrete-continuous mixtures._
https://arxiv.org/pdf/1709.06212v3.pdf

The estimator works on any kind of distribution: discrete, continuous or a mix of both.

This implementation has a memory complexity of O(`buffer_size`x`compute_batch_size`) and a time complexity of O(`buffer_size`^2). They can be adjusted with the corresponding parameters. Smaller value of `buffer_size` increases the bias of the estimator while small value of `compute_batch_size` increases the computation time.

The effect of the parameter `buffer_size` is depicted in the following figures. They show the performance of the estimator when _X_ and _Y_ are drawn from a multivariate gaussian for different correlation coefficients. We can see that lower values increase the bias, but preserves the variance.

![image](https://user-images.githubusercontent.com/3748978/188132180-ccb58730-9f82-41de-9169-906e743372dd.png)

![image](https://user-images.githubusercontent.com/3748978/188132560-0edd6b19-64d7-4a12-8c01-1ff12da1f25a.png)

## Type of change

- [X] New Metric and the changes conform to the [metric contribution guidelines](https://github.com/tensorflow/addons/blob/master/tensorflow_addons/metrics/README.md#contribution-guidelines)

# Checklist:

- [X] I've properly [formatted my code according to the guidelines](https://github.com/tensorflow/addons/blob/master/CONTRIBUTING.md#coding-style)
    - [X] By running pre-commit hooks
- [X] I have made corresponding changes to the documentation
- [X] I have added tests that prove my fix is effective or that my feature works

