### PR TITLE
Fixed TypeError in CyclicalLearningRate

### DIFF
--- a/tensorflow_addons/optimizers/cyclical_learning_rate.py
+++ b/tensorflow_addons/optimizers/cyclical_learning_rate.py
@@ -95,7 +95,7 @@ class CyclicalLearningRate(tf.keras.optimizers.schedules.LearningRateSchedule):
             cycle = tf.floor(1 + step_as_dtype / (2 * step_size))
             x = tf.abs(step_as_dtype / step_size - 2 * cycle + 1)
 
-            mode_step = cycle if self.scale_mode == "cycle" else step
+            mode_step = cycle if self.scale_mode == "cycle" else step_as_dtype
 
             return initial_learning_rate + (
                 maximal_learning_rate - initial_learning_rate


### PR DESCRIPTION
# Description

Fixed bug which appears at the end of the first training epoch. With TF2.5 or higher, the optimizer returns the step variable as int64 but the scale_fn function needs it to be of type float for Triangular2CyclicalLearningRate and ExponentialCyclicalLearningRate.

## Type of change

- [x] Bug fix
- [ ] New Tutorial
- [ ] Updated or additional documentation
- [ ] Additional Testing
- [ ] New Activation and the changes conform to the [activation contribution guidelines](https://github.com/tensorflow/addons/blob/master/tensorflow_addons/activations/README.md#contribution-guidelines)
- [ ] New Callback and the changes conform to the [callback contribution guidelines](https://github.com/tensorflow/addons/blob/master/tensorflow_addons/callbacks/README.md#contribution-guidelines)
- [ ] New Image addition and the changes conform to the [image op contribution guidelines](https://github.com/tensorflow/addons/blob/master/tensorflow_addons/image/README.md#contribution-guidelines)
- [ ] New Layer and the changes conform to the [layer contribution guidelines](https://github.com/tensorflow/addons/blob/master/tensorflow_addons/layers/README.md#contribution-guidelines)
- [ ] New Loss and the changes conform to the [loss contribution guidelines](https://github.com/tensorflow/addons/blob/master/tensorflow_addons/losses/README.md#contribution-guidelines)
- [ ] New Metric and the changes conform to the [metric contribution guidelines](https://github.com/tensorflow/addons/blob/master/tensorflow_addons/metrics/README.md#contribution-guidelines)
- [ ] New Optimizer and the changes conform to the [optimizer contribution guidelines](https://github.com/tensorflow/addons/blob/master/tensorflow_addons/optimizers/README.md#contribution-guidelines)
- [ ] New RNN Cell and the changes conform to the [rnn contribution guidelines](https://github.com/tensorflow/addons/blob/master/tensorflow_addons/rnn/README.md#contribution-guidelines)
- [ ] New Seq2seq addition and the changes conform to the [seq2seq contribution guidelines](https://github.com/tensorflow/addons/blob/master/tensorflow_addons/seq2seq/README.md#contribution-guidelines)
- [ ] New Text addition and the changes conform to the [text op contribution guidelines](https://github.com/tensorflow/addons/blob/master/tensorflow_addons/text/README.md#contribution-guidelines)

# Checklist:

- [ ] I've properly [formatted my code according to the guidelines](https://github.com/tensorflow/addons/blob/master/CONTRIBUTING.md#coding-style)
    - [ ] By running Black + Flake8
    - [ ] By running pre-commit hooks
- [ ] This PR addresses an already submitted issue for TensorFlow Addons
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] This PR contains modifications to C++ custom-ops

# How Has This Been Tested?
  
