### PR TITLE
Replace tensorflow::Status::OK() with tensorflow::OkStatus().

### DIFF
--- a/tensorflow_addons/custom_ops/image/cc/ops/resampler_ops.cc
+++ b/tensorflow_addons/custom_ops/image/cc/ops/resampler_ops.cc
@@ -42,7 +42,7 @@ REGISTER_OP("Addons>Resampler")
           c->Concatenate(output, c->Vector(c->Dim(data, -1)), &output));
 
       c->set_output(0, output);
-      return Status::OK();
+      return Status();
     })
     .Doc(R"doc(Resampler op.)doc");
 
@@ -57,7 +57,7 @@ REGISTER_OP("Addons>ResamplerGrad")
     .SetShapeFn([](InferenceContext* c) {
       c->set_output(0, c->input(0));
       c->set_output(1, c->input(1));
-      return Status::OK();
+      return Status();
     })
     .Doc(R"doc(Resampler Grad op.)doc");
 

--- a/tensorflow_addons/custom_ops/layers/cc/kernels/correlation_cost_op.cc
+++ b/tensorflow_addons/custom_ops/layers/cc/kernels/correlation_cost_op.cc
@@ -114,7 +114,7 @@ struct CorrelationCostFunctor<CPUDevice, Dtype> {
     auto thread_pool =
         context->device()->tensorflow_cpu_worker_threads()->workers;
     thread_pool->ParallelFor(oN * oH * oW, cost_per_pixel, work);
-    return Status::OK();
+    return Status();
   }
 };
 
@@ -211,7 +211,7 @@ struct CorrelationCostGradFunctor<CPUDevice, Dtype> {
         context->device()->tensorflow_cpu_worker_threads()->workers;
     thread_pool->ParallelFor(iN * oH * oW, cost_per_pixel, work);
 
-    return Status::OK();
+    return Status();
   }
 };
 

--- a/tensorflow_addons/custom_ops/layers/cc/kernels/correlation_cost_op_gpu.cu.cc
+++ b/tensorflow_addons/custom_ops/layers/cc/kernels/correlation_cost_op_gpu.cu.cc
@@ -366,7 +366,7 @@ struct CorrelationCostFunctor<GPUDevice, Dtype> {
             padded_b_t.flat<Dtype>().data(), pad, kernel_size, max_displacement,
             stride_1, stride_2);
 
-    return Status::OK();
+    return Status();
   }
 };
 
@@ -452,7 +452,7 @@ struct CorrelationCostGradFunctor<GPUDevice, Dtype> {
               max_displacement, stride_1, stride_2, is_NCHW);
     }
 
-    return Status::OK();
+    return Status();
   }
 };
 

--- a/tensorflow_addons/custom_ops/layers/cc/ops/correlation_cost_op.cc
+++ b/tensorflow_addons/custom_ops/layers/cc/ops/correlation_cost_op.cc
@@ -85,7 +85,7 @@ REGISTER_OP("Addons>CorrelationCost")
 
       // Note, the output is always NCHW (even when input is NHWC)
       c->set_output(0, c->MakeShape({B, Cout, Hout, Wout}));
-      return Status::OK();
+      return Status();
     })
     .Doc(R"Doc(
 Compute Correlation costs.
@@ -127,7 +127,7 @@ REGISTER_OP("Addons>CorrelationCostGrad")
       TF_RETURN_IF_ERROR(c->Merge(c->input(0), c->input(1), &shp_hnd));
       c->set_output(0, shp_hnd);
       c->set_output(1, shp_hnd);
-      return Status::OK();
+      return Status();
     })
     .Doc(R"doc(CorrelationCostGrad op.)doc");
 

--- a/tensorflow_addons/custom_ops/layers/cc/ops/embedding_bag_ops.cc
+++ b/tensorflow_addons/custom_ops/layers/cc/ops/embedding_bag_ops.cc
@@ -41,7 +41,7 @@ REGISTER_OP("Addons>EmbeddingBag")
           c->ReplaceDim(indices, c->Rank(indices) - 1, output_dim, &output));
       TF_RETURN_IF_ERROR(c->Merge(indices, weights, &unused));
       c->set_output(0, output);
-      return Status::OK();
+      return Status();
     });
 
 REGISTER_OP("Addons>EmbeddingBagGrad")
@@ -63,7 +63,7 @@ REGISTER_OP("Addons>EmbeddingBagGrad")
       TF_RETURN_IF_ERROR(c->Merge(indices, weights, &unused));
       c->set_output(0, c->input(1));
       c->set_output(1, c->input(2));
-      return Status::OK();
+      return Status();
     });
 
 }  // namespace addons

--- a/tensorflow_addons/custom_ops/seq2seq/cc/ops/beam_search_ops.cc
+++ b/tensorflow_addons/custom_ops/seq2seq/cc/ops/beam_search_ops.cc
@@ -49,7 +49,7 @@ REGISTER_OP("Addons>GatherTree")
                                         &step_ids_prefix));
 
       c->set_output(0, step_ids);
-      return tensorflow::Status::OK();
+      return tensorflow::Status();
     })
     .Doc(R"doc(
 Calculates the full beams from the per-step ids and parent beam ids.

--- a/tensorflow_addons/custom_ops/text/cc/ops/skip_gram_ops.cc
+++ b/tensorflow_addons/custom_ops/text/cc/ops/skip_gram_ops.cc
@@ -46,7 +46,7 @@ REGISTER_OP("Addons>SkipGramGenerateCandidates")
       // outputs will be of rank-1, but not their sizes.
       c->set_output(0, c->Vector(c->UnknownDim()));
       c->set_output(1, c->Vector(c->UnknownDim()));
-      return Status::OK();
+      return Status();
     })
     .Doc(R"doc(
 Generates skip-gram token and label paired Tensors from the input tensor.


### PR DESCRIPTION
# Description

The OkStatus() symbols was added on May 2022, between the 2.9 and 2.10 releases of Tensorflow. The Tensorflow v2.10 release happened on September 6, 2022.

https://github.com/tensorflow/tensorflow/blob/master/tensorflow/tsl/platform/status.h#L102

## Type of change

Code cleanup.

# Checklist:

- [ x] I've properly [formatted my code according to the guidelines](https://github.com/tensorflow/addons/blob/master/CONTRIBUTING.md#coding-style)
    - [x] By running Black + Flake8
    - [x] By running pre-commit hooks
- [] This PR addresses an already submitted issue for TensorFlow Addons
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] This PR contains modifications to C++ custom-ops

# How Has This Been Tested?

python3 -m pytest tensorflow_addons.
Failures are the same.
