### PR TITLE
native Keras dependency removed

### DIFF
--- a/tensorflow_addons/optimizers/discriminative_layer_training.py
+++ b/tensorflow_addons/optimizers/discriminative_layer_training.py
@@ -21,8 +21,8 @@ import tensorflow as tf
 from tensorflow_addons.optimizers import KerasLegacyOptimizer
 from typeguard import typechecked
 
-from keras import backend
-from keras.utils import tf_utils
+from tensorflow.keras import backend
+from tensorflow.python.keras.utils import tf_utils
 
 
 @tf.keras.utils.register_keras_serializable(package="Addons")


### PR DESCRIPTION
# Description

Fixes one Keras dependency in tensorflow.addons.optimizers, uses tensorflow.keras instead.

## Type of change

- Bug fix

# Checklist:

- I've properly formatted my code according to the guidelines

# How Has This Been Tested?

The imports running fine without keras module installed.
