### PR TITLE
Update tensorflow 2.11.0 checksum

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -21,7 +21,7 @@ cuda_configure(name = "local_config_cuda")
 
 http_archive(
     name = "org_tensorflow",
-    sha256 = "99c732b92b1b37fc243a559e02f9aef5671771e272758aa4aec7f34dc92dac48",
+    sha256 = "80685bf2fd46edc5c6f47b61ec9d747f2b17dec6a8c304eeeb196f8d4bda68a5",
     strip_prefix = "tensorflow-2.11.0",
     urls = [
         "https://github.com/tensorflow/tensorflow/archive/refs/tags/v2.11.0.tar.gz",


### PR DESCRIPTION
This PR should solve the issue with bazel build
```


WARNING: Download from https://github.com/tensorflow/tensorflow/archive/refs/tags/v2.11.0.tar.gz failed: class com.google.devtools.build.lib.bazel.repository.downloader.UnrecoverableHttpException Checksum was 80685bf2fd46edc5c6f47b61ec9d747f2b17dec6a8c304eeeb196f8d4bda68a5 but wanted 99c732b92b1b37fc243a559e02f9aef5671771e272758aa4aec7f34dc92dac48
--
976 | ERROR: An error occurred during the fetch of repository 'org_tensorflow':
977 | Traceback (most recent call last):
978 | File "/root/.cache/bazel/_bazel_root/e051f2f195071208ea7f081f88730f4f/external/bazel_tools/tools/build_defs/repo/http.bzl", line 100, column 45, in _http_archive_impl
979 | download_info = ctx.download_and_extract(
980 | Error in download_and_extract: java.io.IOException: Error downloading [https://github.com/tensorflow/tensorflow/archive/refs/tags/v2.11.0.tar.gz] to /root/.cache/bazel/_bazel_root/e051f2f195071208ea7f081f88730f4f/external/org_tensorflow/temp14443264024284195505/v2.11.0.tar.gz: Checksum was 80685bf2fd46edc5c6f47b61ec9d747f2b17dec6a8c304eeeb196f8d4bda68a5 but wanted 99c732b92b1b37fc243a559e02f9aef5671771e272758aa4aec7f34dc92dac48
981 | ERROR: /addons/WORKSPACE:25:13: fetching http_archive rule //external:org_tensorflow: Traceback (most recent call last):
982 | File "/root/.cache/bazel/_bazel_root/e051f2f195071208ea7f081f88730f4f/external/bazel_tools/tools/build_defs/repo/http.bzl", line 100, column 45, in _http_archive_impl
983 | download_info = ctx.download_and_extract(
984 | Error in download_and_extract: java.io.IOException: Error downloading [https://github.com/tensorflow/tensorflow/archive/refs/tags/v2.11.0.tar.gz] to /root/.cache/bazel/_bazel_root/e051f2f195071208ea7f081f88730f4f/external/org_tensorflow/temp14443264024284195505/v2.11.0.tar.gz: Checksum was 80685bf2fd46edc5c6f47b61ec9d747f2b17dec6a8c304eeeb196f8d4bda68a5 but wanted 99c732b92b1b37fc243a559e02f9aef5671771e272758aa4aec7f34dc92dac48
985 | ERROR: no such package '@org_tensorflow//tensorflow': java.io.IOException: Error downloading [https://github.com/tensorflow/tensorflow/archive/refs/tags/v2.11.0.tar.gz] to /root/.cache/bazel/_bazel_root/e051f2f195071208ea7f081f88730f4f/external/org_tensorflow/temp14443264024284195505/v2.11.0.tar.gz: Checksum was 80685bf2fd46edc5c6f47b61ec9d747f2b17dec6a8c304eeeb196f8d4bda68a5 but wanted 99c732b92b1b37fc243a559e02f9aef5671771e272758aa4aec7f34dc92dac48


```

yes, sha256 was changed
```
$ wget https://github.com/tensorflow/tensorflow/archive/refs/tags/v2.11.0.tar.gz
$ sha256sum v2.11.0.tar.gz
80685bf2fd46edc5c6f47b61ec9d747f2b17dec6a8c304eeeb196f8d4bda68a5  v2.11.0.tar.gz
```