### PR TITLE
Update embedding_bag.py for save_model in 'tf' mode

### DIFF
--- a/tensorflow_addons/layers/embedding_bag.py
+++ b/tensorflow_addons/layers/embedding_bag.py
@@ -147,7 +147,6 @@ class EmbeddingBag(tf.keras.layers.Layer):
                 self.embeddings_constraint
             ),
             "mask_zero": self.mask_zero,
-            "input_length": self.input_length,
             "combiner": self.combiner,
         }
         base_config = super(EmbeddingBag, self).get_config()


### PR DESCRIPTION
`self.input_length` is not defined, which affects the pickling / unpickling of this layer in `tf` model mode.

# Description

Brief Description of the PR:

Of the two options of adding `input_length` or removing it entirely, it seems more elegant to remove it. The attribute `input_length` was likely ported from [TF Embedding Layer](https://www.tensorflow.org/api_docs/python/tf/keras/layers/Embedding), where it might be necessary; however, in EmbeddingBag there does not appear to be such requirements. 

The alternative way to solve the issue is to take `input_length` as an `int` argument set to `None` but this seems likely to be more confusing and would additionally require a modification to the documentation

Fixes # (issue)
`2803`

## Type of change

- [x ] Bug fix
- [ ] New Tutorial
- [ ] Updated or additional documentation
- [ ] Additional Testing
- [ ] New Activation and the changes conform to the [activation contribution guidelines](https://github.com/tensorflow/addons/blob/master/tensorflow_addons/activations/README.md#contribution-guidelines)
- [ ] New Callback and the changes conform to the [callback contribution guidelines](https://github.com/tensorflow/addons/blob/master/tensorflow_addons/callbacks/README.md#contribution-guidelines)
- [ ] New Image addition and the changes conform to the [image op contribution guidelines](https://github.com/tensorflow/addons/blob/master/tensorflow_addons/image/README.md#contribution-guidelines)
- [ ] New Layer and the changes conform to the [layer contribution guidelines](https://github.com/tensorflow/addons/blob/master/tensorflow_addons/layers/README.md#contribution-guidelines)
- [ ] New Loss and the changes conform to the [loss contribution guidelines](https://github.com/tensorflow/addons/blob/master/tensorflow_addons/losses/README.md#contribution-guidelines)
- [ ] New Metric and the changes conform to the [metric contribution guidelines](https://github.com/tensorflow/addons/blob/master/tensorflow_addons/metrics/README.md#contribution-guidelines)
- [ ] New Optimizer and the changes conform to the [optimizer contribution guidelines](https://github.com/tensorflow/addons/blob/master/tensorflow_addons/optimizers/README.md#contribution-guidelines)
- [ ] New RNN Cell and the changes conform to the [rnn contribution guidelines](https://github.com/tensorflow/addons/blob/master/tensorflow_addons/rnn/README.md#contribution-guidelines)
- [ ] New Seq2seq addition and the changes conform to the [seq2seq contribution guidelines](https://github.com/tensorflow/addons/blob/master/tensorflow_addons/seq2seq/README.md#contribution-guidelines)
- [ ] New Text addition and the changes conform to the [text op contribution guidelines](https://github.com/tensorflow/addons/blob/master/tensorflow_addons/text/README.md#contribution-guidelines)

# Checklist:

- [x ] I've properly [formatted my code according to the guidelines](https://github.com/tensorflow/addons/blob/master/CONTRIBUTING.md#coding-style)
    - [ ] By running Black + Flake8
    - [ ] By running pre-commit hooks
- [x ] This PR addresses an already submitted issue for TensorFlow Addons
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] This PR contains modifications to C++ custom-ops

# How Has This Been Tested?

If you're adding a bugfix or new feature please describe the tests that you ran to verify your changes:
*  This is a simple modification of the removal of a line which is unused. If you look in VS Code you would see that the original is undefined. This layer now works as intended in `save_model` and `load_model`.
